### PR TITLE
Add OpenRouter as a model provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # ── Provider ────────────────────────────────────────────────────────────────
 # Pick ONE provider and paste its key below. That's the whole setup.
-#   anthropic (default) · openai · gemini · deepseek · kimi · glm
+#   anthropic (default) · openai · gemini · deepseek · kimi · glm · openrouter
 WAKU_PROVIDER=anthropic
 
 # Keys — only the one for your chosen provider is needed.
@@ -17,15 +17,21 @@ DEEPSEEK_API_KEY=
 MOONSHOT_API_KEY=
 # glm → https://z.ai
 ZHIPU_API_KEY=
+# openrouter (one key, hundreds of hosted models) → https://openrouter.ai/keys
+OPENROUTER_API_KEY=
 
 # ── Models (optional) ───────────────────────────────────────────────────────
 # Each provider has sensible defaults (see waku/loop/models.py PROVIDERS):
-#   anthropic: claude-sonnet-5        + claude-haiku-4-5 (gate/summarizer)
-#   openai:    gpt-5.6                + gpt-5.6-luna
-#   gemini:    gemini-3.5-flash       + gemini-3.1-flash-lite
-#   deepseek:  deepseek-v4-pro         + deepseek-v4-pro
-#   kimi:      kimi-k2.7              + kimi-k2.7
-#   glm:       glm-5.2                + glm-5-turbo
+#   anthropic:  claude-sonnet-5              + claude-haiku-4-5 (gate/summarizer)
+#   openai:     gpt-5.6                      + gpt-5.6-luna
+#   gemini:     gemini-3.5-flash             + gemini-3.1-flash-lite
+#   deepseek:   deepseek-v4-pro              + deepseek-v4-pro
+#   kimi:       kimi-k2.7                    + kimi-k2.7
+#   glm:        glm-5.2                      + glm-5-turbo
+#   openrouter: anthropic/claude-sonnet-5    + anthropic/claude-haiku-4.5
+# openrouter's whole point is picking a different model, so WAKU_MODEL takes
+# any "<vendor>/<model>" slug from https://openrouter.ai/models — e.g.
+# WAKU_MODEL=meta-llama/llama-3.1-70b-instruct
 # Override here if you want something else — they're just strings:
 # WAKU_MODEL=
 # WAKU_SMALL_MODEL=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,8 +40,8 @@ for its own sake is not.
   full assistant. New capabilities (providers, tools, gateways, integrations) are welcome
   when they're self-contained, tested, and keep the core legible. Reject only complexity
   that muddies how the system works or bloats the default path — prefer opt-in extras.
-- Providers are framed neutrally in docs (Anthropic, OpenAI, Gemini, Kimi, GLM) —
-  no ranking, no "open-source vs closed" framing.
+- Providers are framed neutrally in docs (Anthropic, OpenAI, Gemini, DeepSeek, Kimi, GLM,
+  OpenRouter) — no ranking, no "open-source vs closed" framing.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ laptop. Set `TELEGRAM_BOT_TOKEN` and it starts your bot too. (`make dashboard` w
 *"Book a catch-up with Alex on Friday."* → it remembers, and books 9am. Your memory is one
 file: `.waku/state.db`.
 
-**Use the model you already pay for.** Anthropic (default), OpenAI, Gemini, DeepSeek, Kimi, or GLM —
-set `WAKU_PROVIDER=`, paste the key, done. One dialect in the loop; a
-[~60-line adapter](waku/loop/models.py) handles the rest.
+**Use the model you already pay for.** Anthropic (default), OpenAI, Gemini, DeepSeek, Kimi,
+GLM, or OpenRouter (one key, hundreds of hosted models) — set `WAKU_PROVIDER=`, paste the key,
+done. One dialect in the loop; a [~60-line adapter](waku/loop/models.py) handles the rest.
 
 ## Watch the harness run — the dashboard
 

--- a/waku/loop/models.py
+++ b/waku/loop/models.py
@@ -4,11 +4,14 @@ The loop speaks one dialect: Anthropic's Messages shape (system/messages/tools
 in, content blocks out). Providers plug in two ways:
 
   anthropic wire format (native)     → Anthropic, Kimi/Moonshot, GLM/Z.ai
-  openai wire format (thin adapter)  → OpenAI, Google Gemini, DeepSeek
+  openai wire format (thin adapter)  → OpenAI, Google Gemini, DeepSeek, OpenRouter
 
-Pick with WAKU_PROVIDER=anthropic|openai|gemini|deepseek|kimi|glm and set that
-provider's API key in .env. Override the model ids with WAKU_MODEL /
-WAKU_SMALL_MODEL if the defaults below age out — they're just strings.
+Pick with WAKU_PROVIDER=anthropic|openai|gemini|deepseek|kimi|glm|openrouter and
+set that provider's API key in .env. Override the model ids with WAKU_MODEL /
+WAKU_SMALL_MODEL if the defaults below age out — they're just strings. This
+matters most for openrouter: it's a single key in front of hundreds of
+models, so WAKU_MODEL=<vendor>/<model> (e.g. "google/gemini-3.5-flash") picks
+whichever one you want.
 """
 
 from __future__ import annotations
@@ -44,6 +47,8 @@ PROVIDERS: dict[str, Provider] = {
                           "kimi-k2.7", "kimi-k2.7"),
     "glm":       Provider("anthropic", "ZHIPU_API_KEY", "https://api.z.ai/api/anthropic",
                           "glm-5.2", "glm-5-turbo"),
+    "openrouter": Provider("openai", "OPENROUTER_API_KEY", "https://openrouter.ai/api/v1",
+                           "anthropic/claude-sonnet-5", "anthropic/claude-haiku-4.5"),
 }
 
 

--- a/waku/ops/dashboard.py
+++ b/waku/ops/dashboard.py
@@ -116,9 +116,12 @@ def chat_stream(message: str, emit) -> None:
 
 # Rough $/million tokens (in, out) for a dollar ESTIMATE — the number humans
 # actually feel. Keyed by provider; deliberately approximate and labelled "est".
+# openrouter fans out to many underlying models at very different prices; this
+# row assumes the default model (see PROVIDERS) — real cost varies with WAKU_MODEL.
 PRICING = {
     "anthropic": (3.0, 15.0), "openai": (2.5, 15.0), "gemini": (0.3, 2.5),
     "deepseek": (0.435, 0.87), "kimi": (0.6, 2.5), "glm": (0.6, 2.2),
+    "openrouter": (3.0, 15.0),
 }
 
 


### PR DESCRIPTION
## Summary
- Adds `openrouter` to `PROVIDERS` in `waku/loop/models.py`. OpenRouter exposes an OpenAI-compatible `chat.completions` endpoint, so it reuses the existing `OpenAICompatClient` adapter path (same pattern as `gemini`) — no new dependency, no new code path.
- Default models are `anthropic/claude-sonnet-5` / `anthropic/claude-haiku-4.5`, but OpenRouter's whole value is picking a different hosted model, so `WAKU_MODEL`/`WAKU_SMALL_MODEL` take any `<vendor>/<model>` slug from openrouter.ai/models.
- Documents `openrouter` everywhere the other providers are listed: `.env.example` (key + model defaults table), `README.md`, `CLAUDE.md`'s "framed neutrally" provider list.
- Adds an approximate `PRICING` row for the dashboard's cost estimate, with a comment noting real cost varies by the underlying model chosen.
- The dashboard's Settings tab provider dropdown, key inputs, and `/api/settings` writer are all already driven dynamically off `PROVIDERS` — no frontend changes needed.

## Test plan
- [x] `python -m ruff check waku/loop/models.py waku/ops/dashboard.py` — passes
- [x] Manually instantiated `get_client(Settings(provider="openrouter"))` with a dummy key — builds an `OpenAICompatClient` pointed at `https://openrouter.ai/api/v1/` and resolves default model ids correctly (no network call)
- [ ] Could not run `evals/deterministic` — this environment's Python is 3.10 and the project requires `>=3.11`, so `pip install -e .` fails locally. The change is additive-only (one new dict entry + docs) and doesn't touch any code path the deterministic evals exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)