### PR TITLE
feat: add DeepSeek provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # ── Provider ────────────────────────────────────────────────────────────────
 # Pick ONE provider and paste its key below. That's the whole setup.
-#   anthropic (default) · openai · gemini · kimi · glm
+#   anthropic (default) · openai · gemini · deepseek · kimi · glm
 WAKU_PROVIDER=anthropic
 
 # Keys — only the one for your chosen provider is needed.
@@ -11,6 +11,8 @@ ANTHROPIC_API_KEY=
 OPENAI_API_KEY=
 # gemini → https://aistudio.google.com
 GEMINI_API_KEY=
+# deepseek → https://platform.deepseek.com
+DEEPSEEK_API_KEY=
 # kimi → https://platform.moonshot.ai
 MOONSHOT_API_KEY=
 # glm → https://z.ai
@@ -21,6 +23,7 @@ ZHIPU_API_KEY=
 #   anthropic: claude-sonnet-5        + claude-haiku-4-5 (gate/summarizer)
 #   openai:    gpt-5.6                + gpt-5.6-luna
 #   gemini:    gemini-3.5-flash       + gemini-3.1-flash-lite
+#   deepseek:  deepseek-v4-pro         + deepseek-v4-pro
 #   kimi:      kimi-k2.7              + kimi-k2.7
 #   glm:       glm-5.2                + glm-5-turbo
 # Override here if you want something else — they're just strings:

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ laptop. Set `TELEGRAM_BOT_TOKEN` and it starts your bot too. (`make dashboard` w
 *"Book a catch-up with Alex on Friday."* → it remembers, and books 9am. Your memory is one
 file: `.waku/state.db`.
 
-**Use the model you already pay for.** Anthropic (default), OpenAI, Gemini, Kimi, or GLM —
+**Use the model you already pay for.** Anthropic (default), OpenAI, Gemini, DeepSeek, Kimi, or GLM —
 set `WAKU_PROVIDER=`, paste the key, done. One dialect in the loop; a
 [~60-line adapter](waku/loop/models.py) handles the rest.
 

--- a/evals/deterministic/test_models.py
+++ b/evals/deterministic/test_models.py
@@ -1,0 +1,29 @@
+from waku.config import Settings
+from waku.loop import models
+
+
+def test_deepseek_provider_uses_expected_key_endpoint_and_models(monkeypatch, tmp_path):
+    captured = {}
+
+    class StubOpenAICompatClient:
+        def __init__(self, *, api_key, base_url, timeout):
+            captured.update(api_key=api_key, base_url=base_url, timeout=timeout)
+
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-deepseek-key")
+    monkeypatch.setattr(models, "OpenAICompatClient", StubOpenAICompatClient)
+    settings = Settings(
+        provider="deepseek",
+        api_key="",
+        base_url=None,
+        model="",
+        small_model="",
+        home=tmp_path,
+    )
+
+    client = models.get_client(settings)
+
+    assert isinstance(client, StubOpenAICompatClient)
+    assert captured["api_key"] == "test-deepseek-key"
+    assert captured["base_url"] == "https://api.deepseek.com"
+    assert settings.model == "deepseek-v4-pro"
+    assert settings.small_model == "deepseek-v4-pro"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [{ name = "Sean Chen (ShenSeanChen)" }]
 requires-python = ">=3.11"
 dependencies = [
     "anthropic>=0.40",   # anthropic wire format: Anthropic, Kimi, GLM
-    "openai>=1.50",      # openai wire format: OpenAI, Gemini (and embeddings)
+    "openai>=1.50",      # openai wire format: OpenAI, Gemini, DeepSeek (and embeddings)
     "python-dotenv>=1.0",
     "rich>=13.0",
 ]

--- a/waku/loop/models.py
+++ b/waku/loop/models.py
@@ -1,12 +1,12 @@
-"""Model access — five providers, one loop, zero framework.
+"""Model access — six providers, one loop, zero framework.
 
 The loop speaks one dialect: Anthropic's Messages shape (system/messages/tools
 in, content blocks out). Providers plug in two ways:
 
   anthropic wire format (native)     → Anthropic, Kimi/Moonshot, GLM/Z.ai
-  openai wire format (thin adapter)  → OpenAI, Google Gemini
+  openai wire format (thin adapter)  → OpenAI, Google Gemini, DeepSeek
 
-Pick with WAKU_PROVIDER=anthropic|openai|gemini|kimi|glm and set that
+Pick with WAKU_PROVIDER=anthropic|openai|gemini|deepseek|kimi|glm and set that
 provider's API key in .env. Override the model ids with WAKU_MODEL /
 WAKU_SMALL_MODEL if the defaults below age out — they're just strings.
 """
@@ -38,6 +38,8 @@ PROVIDERS: dict[str, Provider] = {
     "gemini":    Provider("openai", "GEMINI_API_KEY",
                           "https://generativelanguage.googleapis.com/v1beta/openai/",
                           "gemini-3.5-flash", "gemini-3.1-flash-lite"),
+    "deepseek":  Provider("openai", "DEEPSEEK_API_KEY", "https://api.deepseek.com",
+                          "deepseek-v4-pro", "deepseek-v4-pro"),
     "kimi":      Provider("anthropic", "MOONSHOT_API_KEY", "https://api.moonshot.ai/anthropic",
                           "kimi-k2.7", "kimi-k2.7"),
     "glm":       Provider("anthropic", "ZHIPU_API_KEY", "https://api.z.ai/api/anthropic",

--- a/waku/ops/dashboard.py
+++ b/waku/ops/dashboard.py
@@ -118,7 +118,7 @@ def chat_stream(message: str, emit) -> None:
 # actually feel. Keyed by provider; deliberately approximate and labelled "est".
 PRICING = {
     "anthropic": (3.0, 15.0), "openai": (2.5, 15.0), "gemini": (0.3, 2.5),
-    "kimi": (0.6, 2.5), "glm": (0.6, 2.2),
+    "deepseek": (0.435, 0.87), "kimi": (0.6, 2.5), "glm": (0.6, 2.2),
 }
 
 


### PR DESCRIPTION
## Summary

- Add DeepSeek as a first-class provider using the existing OpenAI-compatible adapter
- Add `DEEPSEEK_API_KEY` configuration
- Use `deepseek-v4-pro` as the default main and small model
- Expose DeepSeek in Dashboard settings and cost estimates
- Add deterministic coverage for provider configuration

## Test plan

- [x] DeepSeek provider regression test passes
- [x] Deterministic test suite passes: 33 passed, 5 skipped
- [x] Ruff lint passes
- [x] No real API key is included