### PR TITLE
fix: read procedural skills as UTF-8

### DIFF
--- a/evals/deterministic/test_skill_encoding.py
+++ b/evals/deterministic/test_skill_encoding.py
@@ -1,0 +1,28 @@
+"""DETERMINISTIC EVAL — procedural skills use a portable text encoding."""
+
+from pathlib import Path
+
+from waku.memory.procedural.loader import SkillLoader
+
+
+def test_skill_loader_reads_utf8_when_platform_default_cannot(tmp_path, monkeypatch):
+    skill_path = tmp_path / "demo" / "SKILL.md"
+    skill_path.parent.mkdir()
+    skill_path.write_text(
+        "---\nname: demo\ndescription: portable skill\n---\nUse an em dash \u2014 safely.\n",
+        encoding="utf-8",
+    )
+
+    original_read_text = Path.read_text
+
+    def reject_implicit_encoding(path, encoding=None, *args, **kwargs):
+        if encoding is None:
+            raise UnicodeDecodeError("gbk", b"\x94", 0, 1, "illegal multibyte sequence")
+        return original_read_text(path, encoding=encoding, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", reject_implicit_encoding)
+
+    loader = SkillLoader([tmp_path])
+
+    assert [skill.name for skill in loader.skills] == ["demo"]
+    assert "em dash \u2014 safely" in loader.skills[0].body

--- a/waku/memory/procedural/loader.py
+++ b/waku/memory/procedural/loader.py
@@ -41,7 +41,7 @@ def _parse_text(text: str, path: Path) -> Skill | None:
 
 
 def _parse(path: Path) -> Skill | None:
-    return _parse_text(path.read_text(), path)
+    return _parse_text(path.read_text(encoding="utf-8"), path)
 
 
 class SkillLoader:


### PR DESCRIPTION
Specify the Agent Skills text encoding so Windows installations with a GBK system locale can load the bundled UTF-8 SKILL.md files. Add a deterministic regression test that simulates a platform default unable to decode the file. Verified with the release gate: 33 passed, 5 skipped.