### PR TITLE
fix: write procedural skills as UTF-8

### DIFF
--- a/evals/deterministic/test_skill_encoding.py
+++ b/evals/deterministic/test_skill_encoding.py
@@ -1,8 +1,37 @@
 """DETERMINISTIC EVAL — procedural skills use a portable text encoding."""
 
+from io import BytesIO
 from pathlib import Path
+from types import SimpleNamespace
 
+import pytest
+
+from waku.memory.procedural import installer
 from waku.memory.procedural.loader import SkillLoader
+from waku.ops.dashboard import memory_action
+from waku.tools.memory_admin import make_create_skill_tool
+
+DESCRIPTION = "\u5904\u7406\u4e2d\u6587\u5468\u62a5"
+BODY = "\u7b2c\u4e00\u6b65\uff1a\u603b\u7ed3\u672c\u5468\u3002 \U0001f680"
+
+
+@pytest.fixture
+def require_explicit_text_encoding(monkeypatch):
+    """Make implicit writes fail on every OS, as they can on Windows."""
+    original_write_text = Path.write_text
+
+    def reject_implicit_encoding(path, data, encoding=None, *args, **kwargs):
+        if encoding is None:
+            raise UnicodeEncodeError("gbk", "\U0001f680", 0, 1, "illegal multibyte sequence")
+        return original_write_text(path, data, *args, encoding=encoding, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", reject_implicit_encoding)
+
+
+def assert_utf8_skill(path: Path, name: str) -> None:
+    text = path.read_bytes().decode("utf-8")
+    assert DESCRIPTION in text and BODY in text
+    assert [skill.name for skill in SkillLoader([path.parents[1]]).skills] == [name]
 
 
 def test_skill_loader_reads_utf8_when_platform_default_cannot(tmp_path, monkeypatch):
@@ -26,3 +55,45 @@ def test_skill_loader_reads_utf8_when_platform_default_cannot(tmp_path, monkeypa
 
     assert [skill.name for skill in loader.skills] == ["demo"]
     assert "em dash \u2014 safely" in loader.skills[0].body
+
+
+def test_agent_created_skill_is_written_as_utf8(tmp_path, require_explicit_text_encoding):
+    home = tmp_path / "home"
+    memory = SimpleNamespace(skills=SkillLoader([home / "skills"]))
+    settings = SimpleNamespace(home=home)
+    tool = make_create_skill_tool(settings, memory)
+
+    result = tool.fn(name="chinese-report", description=DESCRIPTION, body=BODY)
+
+    assert result.startswith("Created skill 'chinese-report'")
+    assert_utf8_skill(home / "skills" / "chinese-report" / "SKILL.md", "chinese-report")
+
+
+def test_installed_skill_is_written_as_utf8(
+    tmp_path, monkeypatch, require_explicit_text_encoding
+):
+    home = tmp_path / "home"
+    source = (
+        f"---\nname: installed-report\ndescription: {DESCRIPTION}\n---\n\n{BODY}\n"
+    ).encode("utf-8")
+    monkeypatch.setenv("WAKU_HOME", str(home))
+    monkeypatch.setattr(installer.urllib.request, "urlopen", lambda *args, **kwargs: BytesIO(source))
+
+    installer.install("https://example.com/SKILL.md")
+
+    assert_utf8_skill(home / "skills" / "installed-report" / "SKILL.md", "installed-report")
+
+
+def test_dashboard_edited_skill_is_written_as_utf8(
+    tmp_path, monkeypatch, require_explicit_text_encoding
+):
+    home = tmp_path / "home"
+    path = home / "skills" / "dashboard-report" / "SKILL.md"
+    path.parent.mkdir(parents=True)
+    content = f"---\nname: dashboard-report\ndescription: {DESCRIPTION}\n---\n\n{BODY}\n"
+    monkeypatch.setenv("WAKU_HOME", str(home))
+
+    result = memory_action({"action": "save_skill", "path": str(path), "content": content})
+
+    assert result == {"ok": True}
+    assert_utf8_skill(path, "dashboard-report")

--- a/waku/memory/procedural/installer.py
+++ b/waku/memory/procedural/installer.py
@@ -35,7 +35,7 @@ def install(url: str) -> None:
     settings.ensure_home()
     tmp = settings.home / "skills" / "_incoming" / "SKILL.md"
     tmp.parent.mkdir(parents=True, exist_ok=True)
-    tmp.write_text(text)
+    tmp.write_text(text, encoding="utf-8")
 
     skill = _parse(tmp)
     if skill is None:

--- a/waku/ops/dashboard.py
+++ b/waku/ops/dashboard.py
@@ -630,7 +630,7 @@ def memory_action(payload: dict) -> dict:
             return {"error": "can only edit SKILL.md files inside the skills folders"}
         if _parse_text(text, dest) is None:
             return {"error": "invalid SKILL.md — needs a name and description in the frontmatter"}
-        dest.write_text(text.rstrip() + "\n")
+        dest.write_text(text.rstrip() + "\n", encoding="utf-8")
         return {"ok": True}
 
     conn = connect(settings.home)

--- a/waku/tools/memory_admin.py
+++ b/waku/tools/memory_admin.py
@@ -117,7 +117,7 @@ def make_create_skill_tool(settings, memory) -> Tool:
         if _parse_text(text, dest) is None:
             return "That didn't validate — description must be present and non-trivial."
         dest.parent.mkdir(parents=True, exist_ok=True)
-        dest.write_text(text)
+        dest.write_text(text, encoding="utf-8")
         memory.skills.refresh()  # live this session
         return f"Created skill '{name}'. It will trigger on: {description.strip()}"
 


### PR DESCRIPTION
## Summary
- Write agent-created skills explicitly as UTF-8 before refreshing the skill loader.
- Preserve UTF-8 when installing community skills and saving dashboard edits.
- Add deterministic regression coverage for all three official `SKILL.md` write paths, independent of the host OS default encoding.

## Why

The loader now reads every `SKILL.md` as UTF-8, but the three official write paths still relied on the platform default encoding. On Windows with CP936/GBK, creating or saving a skill containing Chinese text or emoji could write a non-UTF-8 file and then fail when Waku immediately reloaded it.

## Test Coverage

- Agent `create_skill`: writes Chinese text and emoji, then refreshes and reloads the skill.
- `waku skill install`: mocks a UTF-8 download and verifies the installed file remains UTF-8.
- Dashboard `save_skill`: saves non-ASCII content and verifies the loader can read it.
- Tests force implicit `Path.write_text()` calls to fail, so Linux CI catches the Windows regression too.

## Pre-Landing Review

No issues found. No new dependencies, configuration, prompt behavior, or frontend behavior.

## Test plan

- [x] Confirmed all three new tests fail against the old implicit writes.
- [x] `python -m pytest -q evals/deterministic` — 37 passed, 5 skipped.
- [x] `python -m waku.ops.release_gate` — gate open; judge suite skipped without `ANTHROPIC_API_KEY`.
- [x] `python -m ruff check waku evals` — passed.
- [x] `python scripts/validate_skills.py` — passed.
- [x] Live CP936 reproduction: Chinese + emoji skill writes as UTF-8 and reloads successfully.