### PR TITLE
feat: add MiniMax provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # ── Provider ────────────────────────────────────────────────────────────────
 # Pick ONE provider and paste its key below. That's the whole setup.
-#   anthropic (default) · openai · gemini · deepseek · kimi · glm · openrouter
+#   anthropic (default) · openai · gemini · deepseek · minimax · kimi · glm · openrouter
 WAKU_PROVIDER=anthropic
 
 # Keys — only the one for your chosen provider is needed.
@@ -13,6 +13,8 @@ OPENAI_API_KEY=
 GEMINI_API_KEY=
 # deepseek → https://platform.deepseek.com
 DEEPSEEK_API_KEY=
+# minimaxi → https://platform.minimaxi.com
+MINIMAX_API_KEY=
 # kimi → https://platform.moonshot.ai
 MOONSHOT_API_KEY=
 # glm → https://z.ai
@@ -26,6 +28,7 @@ OPENROUTER_API_KEY=
 #   openai:     gpt-5.6                      + gpt-5.6-luna
 #   gemini:     gemini-3.5-flash             + gemini-3.1-flash-lite
 #   deepseek:   deepseek-v4-pro              + deepseek-v4-pro
+#   minimax:    MiniMax-M3                   + MiniMax-M2
 #   kimi:       kimi-k2.7                    + kimi-k2.7
 #   glm:        glm-5.2                      + glm-5-turbo
 #   openrouter: anthropic/claude-sonnet-5    + anthropic/claude-haiku-4.5

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ laptop. Set `TELEGRAM_BOT_TOKEN` and it starts your bot too. (`make dashboard` w
 *"Book a catch-up with Alex on Friday."* → it remembers, and books 9am. Your memory is one
 file: `.waku/state.db`.
 
-**Use the model you already pay for.** Anthropic (default), OpenAI, Gemini, DeepSeek, Kimi,
-GLM, or OpenRouter (one key, hundreds of hosted models) — set `WAKU_PROVIDER=`, paste the key,
+**Use the model you already pay for.** Anthropic (default), OpenAI, Gemini, DeepSeek, MiniMax,
+Kimi, GLM, or OpenRouter (one key, hundreds of hosted models) — set `WAKU_PROVIDER=`, paste the key,
 done. One dialect in the loop; a [~60-line adapter](waku/loop/models.py) handles the rest.
 
 ## Watch the harness run — the dashboard

--- a/evals/deterministic/test_models.py
+++ b/evals/deterministic/test_models.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 from waku.config import Settings
 from waku.loop import models
 
@@ -27,3 +29,36 @@ def test_deepseek_provider_uses_expected_key_endpoint_and_models(monkeypatch, tm
     assert captured["base_url"] == "https://api.deepseek.com"
     assert settings.model == "deepseek-v4-pro"
     assert settings.small_model == "deepseek-v4-pro"
+
+
+def test_minimax_provider_uses_expected_key_endpoint_and_models(monkeypatch, tmp_path):
+    captured = {}
+
+    class StubAnthropicClient:
+        def __init__(self, *, api_key, base_url, timeout):
+            captured.update(api_key=api_key, base_url=base_url, timeout=timeout)
+            self.messages = None
+
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-minimax-key")
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "anthropic",
+        SimpleNamespace(Anthropic=StubAnthropicClient),
+    )
+    settings = Settings(
+        provider="minimax",
+        api_key="",
+        base_url=None,
+        model="",
+        small_model="",
+        home=tmp_path,
+    )
+
+    client = models.get_client(settings)
+
+    assert isinstance(client, StubAnthropicClient)
+    assert captured["api_key"] == "test-minimax-key"
+    assert captured["base_url"] == "https://api.minimaxi.com/anthropic"
+    assert captured["timeout"] == 120.0
+    assert settings.model == "MiniMax-M3"
+    assert settings.small_model == "MiniMax-M2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = { text = "MIT" }
 authors = [{ name = "Sean Chen (ShenSeanChen)" }]
 requires-python = ">=3.11"
 dependencies = [
-    "anthropic>=0.40",   # anthropic wire format: Anthropic, Kimi, GLM
+    "anthropic>=0.40",   # anthropic wire format: Anthropic, Kimi, GLM, MiniMax
     "openai>=1.50",      # openai wire format: OpenAI, Gemini, DeepSeek (and embeddings)
     "python-dotenv>=1.0",
     "rich>=13.0",

--- a/waku/loop/models.py
+++ b/waku/loop/models.py
@@ -1,12 +1,12 @@
-"""Model access — six providers, one loop, zero framework.
+"""Model access — eight providers, one loop, zero framework.
 
 The loop speaks one dialect: Anthropic's Messages shape (system/messages/tools
 in, content blocks out). Providers plug in two ways:
 
-  anthropic wire format (native)     → Anthropic, Kimi/Moonshot, GLM/Z.ai
+  anthropic wire format (native)     → Anthropic, Kimi/Moonshot, GLM/Z.ai, MiniMax
   openai wire format (thin adapter)  → OpenAI, Google Gemini, DeepSeek, OpenRouter
 
-Pick with WAKU_PROVIDER=anthropic|openai|gemini|deepseek|kimi|glm|openrouter and
+Pick with WAKU_PROVIDER=anthropic|openai|gemini|deepseek|kimi|glm|openrouter|minimax and
 set that provider's API key in .env. Override the model ids with WAKU_MODEL /
 WAKU_SMALL_MODEL if the defaults below age out — they're just strings. This
 matters most for openrouter: it's a single key in front of hundreds of
@@ -43,6 +43,8 @@ PROVIDERS: dict[str, Provider] = {
                           "gemini-3.5-flash", "gemini-3.1-flash-lite"),
     "deepseek":  Provider("openai", "DEEPSEEK_API_KEY", "https://api.deepseek.com",
                           "deepseek-v4-pro", "deepseek-v4-pro"),
+    "minimax":   Provider("anthropic", "MINIMAX_API_KEY", "https://api.minimaxi.com/anthropic",
+                          "MiniMax-M3", "MiniMax-M2"),
     "kimi":      Provider("anthropic", "MOONSHOT_API_KEY", "https://api.moonshot.ai/anthropic",
                           "kimi-k2.7", "kimi-k2.7"),
     "glm":       Provider("anthropic", "ZHIPU_API_KEY", "https://api.z.ai/api/anthropic",

--- a/waku/ops/dashboard.py
+++ b/waku/ops/dashboard.py
@@ -120,7 +120,7 @@ def chat_stream(message: str, emit) -> None:
 # row assumes the default model (see PROVIDERS) — real cost varies with WAKU_MODEL.
 PRICING = {
     "anthropic": (3.0, 15.0), "openai": (2.5, 15.0), "gemini": (0.3, 2.5),
-    "deepseek": (0.435, 0.87), "kimi": (0.6, 2.5), "glm": (0.6, 2.2),
+    "deepseek": (0.435, 0.87), "minimax": (0.30, 1.20), "kimi": (0.6, 2.5), "glm": (0.6, 2.2),
     "openrouter": (3.0, 15.0),
 }
 


### PR DESCRIPTION
## Summary

Add MiniMax as a new LLM provider using its [Anthropic-compatible API](https://platform.minimaxi.com/docs/api-reference/text-anthropic-api). This follows the same pattern as the existing DeepSeek provider PR (#2).

Changes:
- Register `minimax` in `waku/loop/models.py` (`anthropic` wire format, `https://api.minimaxi.com/anthropic`, default models `MiniMax-M3` / `MiniMax-M2`).
- Document `MINIMAX_API_KEY` and provider defaults in `.env.example`.
- List MiniMax as a supported provider in `README.md`.
- Update the `anthropic` dependency comment in `pyproject.toml`.
- Add MiniMax pricing (`$0.30 / $1.20` per million tokens) to `waku/ops/dashboard.py`.
- Add a deterministic test in `evals/deterministic/test_models.py`.

## Test Plan

- `ruff check waku/loop/models.py waku/ops/dashboard.py evals/deterministic/test_models.py` passes.
- `pytest evals/deterministic/` passes: 35 passed, 5 skipped.