### PR TITLE
feat: add trace pretty-printer

### DIFF
--- a/evals/deterministic/test_show_trace.py
+++ b/evals/deterministic/test_show_trace.py
@@ -1,0 +1,61 @@
+import json
+
+from waku.ops.show_trace import format_events, read_events
+
+
+def test_format_events_renders_indented_timeline():
+    events = [
+        {"type": "turn_start", "ts": "2026-07-17T13:00:00Z", "user_message": "Book swim"},
+        {
+            "type": "gate",
+            "ts": "2026-07-17T13:00:01Z",
+            "decision": "retrieve",
+            "reason": "calendar context",
+        },
+        {
+            "type": "llm",
+            "ts": "2026-07-17T13:00:02Z",
+            "iteration": 1,
+            "stop_reason": "tool_use",
+            "usage": {"in": 12, "out": 5},
+        },
+        {
+            "type": "tool",
+            "ts": "2026-07-17T13:00:03Z",
+            "tool": "create_event",
+            "args": {"title": "Swim", "start": "2026-07-18T17:00"},
+            "output": "Created Swim.",
+        },
+        {"type": "turn_end", "ts": "2026-07-17T13:00:04Z", "reply": "Done.", "iterations": 1},
+    ]
+
+    lines = format_events(events)
+
+    assert lines == [
+        "2026-07-17T13:00:00Z turn",
+        "  user: Book swim",
+        "2026-07-17T13:00:01Z gate: retrieve - calendar context",
+        "2026-07-17T13:00:02Z llm: iteration 1, stop tool_use, tokens 12 in / 5 out",
+        "2026-07-17T13:00:03Z tool: create_event",
+        '  args: {"start": "2026-07-18T17:00", "title": "Swim"}',
+        "  output: Created Swim.",
+        "2026-07-17T13:00:04Z reply: Done. (1 iterations)",
+    ]
+
+
+def test_read_events_ignores_blank_lines(tmp_path):
+    trace_file = tmp_path / "trace.jsonl"
+    trace_file.write_text(
+        "\n".join(
+            [
+                json.dumps({"type": "turn_start", "user_message": "hello"}),
+                "",
+                json.dumps({"type": "turn_end", "reply": "hi", "iterations": 1}),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    events = read_events(trace_file)
+
+    assert [event["type"] for event in events] == ["turn_start", "turn_end"]

--- a/waku/ops/show_trace.py
+++ b/waku/ops/show_trace.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from json import JSONDecodeError
+from pathlib import Path
+from typing import Final
+
+JsonValue = None | bool | int | float | str | list["JsonValue"] | dict[str, "JsonValue"]
+TraceEvent = dict[str, JsonValue]
+
+INDENT: Final = "  "
+
+
+@dataclass(frozen=True, slots=True)
+class TraceParseError(Exception):
+    path: Path
+    line_number: int
+    detail: str
+
+    def __str__(self) -> str:
+        return f"{self.path}:{self.line_number}: {self.detail}"
+
+
+def read_events(path: Path) -> list[TraceEvent]:
+    events: list[TraceEvent] = []
+    with path.open(encoding="utf-8") as trace:
+        for line_number, line in enumerate(trace, start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                record = json.loads(stripped)
+            except JSONDecodeError as exc:
+                raise TraceParseError(path, line_number, exc.msg) from exc
+            if not isinstance(record, dict):
+                raise TraceParseError(path, line_number, "trace line must be a JSON object")
+            events.append(record)
+    return events
+
+
+def format_events(events: list[TraceEvent]) -> list[str]:
+    lines: list[str] = []
+    for event in events:
+        lines.extend(_format_event(event))
+    return lines
+
+
+def _format_event(event: TraceEvent) -> list[str]:
+    timestamp = _text(event.get("ts"))
+    prefix = f"{timestamp} " if timestamp else ""
+    event_type = _text(event.get("type"))
+    match event_type:
+        case "turn_start":
+            return [f"{prefix}turn", f"{INDENT}user: {_text(event.get('user_message'))}"]
+        case "gate":
+            return [f"{prefix}gate: {_text(event.get('decision'))} - {_text(event.get('reason'))}"]
+        case "llm":
+            return [f"{prefix}llm: {_llm_summary(event)}"]
+        case "tool":
+            return [
+                f"{prefix}tool: {_text(event.get('tool'))}",
+                f"{INDENT}args: {_json_summary(event.get('args'))}",
+                f"{INDENT}output: {_text(event.get('output'))}",
+            ]
+        case "turn_end":
+            return [
+                f"{prefix}reply: {_text(event.get('reply'))} "
+                f"({_text(event.get('iterations'))} iterations)"
+            ]
+        case "consolidation":
+            return [f"{prefix}consolidation: {_text(event.get('status'))}"]
+        case "wake_scan":
+            return [f"{prefix}wake_scan: heard {_text(event.get('heard'))}"]
+        case _:
+            return [f"{prefix}{event_type or 'event'}: {_json_summary(event)}"]
+
+
+def _llm_summary(event: TraceEvent) -> str:
+    usage = event.get("usage")
+    tokens = "0 in / 0 out"
+    if isinstance(usage, dict):
+        tokens = f"{_text(usage.get('in', 0))} in / {_text(usage.get('out', 0))} out"
+    return (
+        f"iteration {_text(event.get('iteration'))}, "
+        f"stop {_text(event.get('stop_reason'))}, tokens {tokens}"
+    )
+
+
+def _text(value: JsonValue | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return str(value)
+
+
+def _json_summary(value: JsonValue | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, ensure_ascii=False, sort_keys=True)
+
+
+def _default_trace_path() -> Path:
+    traces = Path.home() / ".waku" / "traces"
+    trace_files = sorted(traces.glob("*.jsonl"))
+    if trace_files:
+        return trace_files[-1]
+    return traces / "missing.jsonl"
+
+
+def main(argv: list[str] | None = None) -> int:
+    from rich.console import Console
+
+    parser = argparse.ArgumentParser(description="Render a Waku JSONL trace as a timeline.")
+    parser.add_argument("trace", nargs="?", type=Path, default=_default_trace_path())
+    args = parser.parse_args(argv)
+    console = Console()
+    try:
+        events = read_events(args.trace)
+    except FileNotFoundError:
+        console.print(f"trace file not found: {args.trace}", style="red")
+        return 1
+    except TraceParseError as exc:
+        console.print(str(exc), style="red")
+        return 1
+    for line in format_events(events):
+        console.print(line)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
Adds `python -m waku.ops.show_trace [file]` to render Waku JSONL traces as a readable indented terminal timeline.

## Root cause
Waku already writes useful chronological trace events, but there was no terminal-friendly way to inspect those JSONL files without reading raw records.

## Changes
- Add `waku.ops.show_trace` with JSONL parsing, event-specific formatting, and a small CLI wrapper using the existing `rich` dependency.
- Add deterministic eval coverage for the formatter and JSONL reader.

## Testing
- `.venv/bin/python -m pytest -q evals/deterministic/test_show_trace.py`
- `make eval`
- `make lint`
- `.venv/bin/python -m waku.ops.show_trace /tmp/waku-show-trace-smoke.jsonl`

Fixes #12
