### PR TITLE
fix: write JSONL traces as UTF-8

### DIFF
--- a/evals/deterministic/test_trace_encoding.py
+++ b/evals/deterministic/test_trace_encoding.py
@@ -1,0 +1,113 @@
+"""DETERMINISTIC EVAL — JSONL traces have one portable UTF-8 encoding."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from waku.config import Settings
+from waku.ops.dashboard import collect, events_since
+from waku.ops.tracing import TraceEncodingError, Tracer
+
+
+MESSAGE = "处理中文日程 " + chr(0x1F680)
+
+
+def _today_trace(home: Path) -> Path:
+    return home / "traces" / f"{datetime.now().strftime('%Y-%m-%d')}.jsonl"
+
+
+def test_tracer_writes_utf8_when_platform_default_cannot(tmp_path, monkeypatch):
+    """Simulate Windows GBK: an implicit append must fail on every CI OS."""
+    settings = Settings(home=tmp_path)
+    settings.ensure_home()
+    original_open = Path.open
+
+    def reject_implicit_jsonl(path, mode="r", *args, encoding=None, **kwargs):
+        if path.suffix == ".jsonl" and "a" in mode and encoding is None:
+            raise UnicodeEncodeError("gbk", MESSAGE, len(MESSAGE) - 1, len(MESSAGE), "illegal")
+        return original_open(path, mode, *args, encoding=encoding, **kwargs)
+
+    monkeypatch.setattr(Path, "open", reject_implicit_jsonl)
+
+    with Tracer(settings).turn(MESSAGE):
+        pass
+
+    raw = _today_trace(tmp_path).read_bytes()
+    record = json.loads(raw.decode("utf-8"))
+    assert record["user_message"] == MESSAGE
+
+
+def test_dashboard_reads_utf8_without_platform_default(tmp_path, monkeypatch):
+    """The live Dashboard endpoint must explicitly decode a UTF-8 trace."""
+    home = tmp_path / "home"
+    trace = _today_trace(home)
+    trace.parent.mkdir(parents=True)
+    trace.write_text(
+        json.dumps({"type": "turn_start", "user_message": MESSAGE}, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("WAKU_HOME", str(home))
+    original_open = Path.open
+
+    def reject_implicit_jsonl(path, mode="r", *args, encoding=None, **kwargs):
+        if path.suffix == ".jsonl" and "r" in mode and encoding is None:
+            raise UnicodeDecodeError("gbk", b"\x94", 0, 1, "illegal multibyte sequence")
+        return original_open(path, mode, *args, encoding=encoding, **kwargs)
+
+    monkeypatch.setattr(Path, "open", reject_implicit_jsonl)
+
+    result = events_since(0)
+
+    assert result["events"][0]["user_message"] == MESSAGE
+    assert "error" not in result
+
+
+def test_dashboard_reports_legacy_non_utf8_trace_without_modifying_it(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    trace = _today_trace(home)
+    trace.parent.mkdir(parents=True)
+    original = (
+        json.dumps({"type": "turn_start", "user_message": "中文"}, ensure_ascii=False) + "\n"
+    ).encode("gbk")
+    trace.write_bytes(original)
+    monkeypatch.setenv("WAKU_HOME", str(home))
+
+    data = collect()
+    live = events_since(0)
+
+    assert data["trace_errors"] == [
+        {"file": trace.name, "error": live["error"]}
+    ]
+    assert "not valid UTF-8" in live["error"]
+    assert "was not modified" in live["error"]
+    assert live["events"] == []
+    assert trace.read_bytes() == original
+
+
+def test_tracer_refuses_to_append_to_legacy_non_utf8_trace(tmp_path):
+    settings = Settings(home=tmp_path)
+    settings.ensure_home()
+    trace = _today_trace(tmp_path)
+    original = (
+        json.dumps({"type": "turn_start", "user_message": "中文"}, ensure_ascii=False) + "\n"
+    ).encode("gbk")
+    trace.write_bytes(original)
+
+    with pytest.raises(TraceEncodingError, match="not valid UTF-8"):
+        with Tracer(settings).turn("next turn"):
+            pass
+
+    assert trace.read_bytes() == original
+
+
+def test_dashboard_ops_view_surfaces_trace_encoding_errors():
+    views = (
+        Path(__file__).resolve().parents[2] / "waku" / "ops" / "static" / "js" / "views.js"
+    ).read_text(encoding="utf-8")
+
+    assert "trace_errors" in views
+    assert "trace encoding error" in views

--- a/waku/ops/dashboard.py
+++ b/waku/ops/dashboard.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from waku.config import load_settings
 from waku.db import connect
 from waku.ops import compare_history, judge as judge_mod, scoring
+from waku.ops.tracing import TraceEncodingError, iter_trace_lines
 
 PORT = 7777
 # The frontend lives in its own files (static/index.html + style.css + app.js),
@@ -589,9 +590,15 @@ def collect() -> dict:
 
     # --- traces → turns (group events between turn_start and turn_end)
     events = []
+    trace_errors = []
     trace_files = sorted((home / "traces").glob("*.jsonl"))
     for path in trace_files:
-        for line in path.read_text().splitlines():
+        try:
+            lines = list(iter_trace_lines(path))
+        except TraceEncodingError as exc:
+            trace_errors.append({"file": path.name, "error": str(exc)})
+            continue
+        for line in lines:
             try:
                 events.append(json.loads(line))
             except json.JSONDecodeError:
@@ -722,6 +729,7 @@ def collect() -> dict:
                                    or e.get("reply") or "")}
                        for e in events[-18:]][::-1],
         "trace_file": (trace_files[-1].name if trace_files else None),
+        "trace_errors": trace_errors,
         "facts": rows("SELECT id, subject, content, source, created_at FROM facts ORDER BY id DESC"),
         "episodes": episodes_data["items"],
         "episodes_source": episodes_data["source"],
@@ -1406,7 +1414,10 @@ def events_since(cursor):
     path = settings.home / "traces" / (datetime.now().strftime("%Y-%m-%d") + ".jsonl")
     if not path.exists():
         return {"events": [], "cursor": 0}
-    lines = path.read_text().splitlines()
+    try:
+        lines = list(iter_trace_lines(path))
+    except TraceEncodingError as exc:
+        return {"events": [], "cursor": 0, "error": str(exc)}
     if cursor is None or cursor < 0 or cursor > len(lines):
         return {"events": [], "cursor": len(lines)}
     out = []

--- a/waku/ops/static/js/views.js
+++ b/waku/ops/static/js/views.js
@@ -451,6 +451,10 @@ const VIEWS = {
       `<tr><td>${esc((t.user_message||"").slice(0,48))}</td><td class="meta">${secs(t.latency_ms)}</td><td class="meta">${money(t.cost||0)}</td><td class="meta">${(t.tools||[]).map(x=>x.tool).join(", ")||"—"}</td></tr>`));
 
     h += `<h2>Tracing <span class="meta" style="font-weight:400">· every turn as JSONL, always on</span></h2>`;
+    if ((d.trace_errors||[]).length){
+      h += d.trace_errors.map(e => `<div class="card"><span class="pill fail">trace encoding error</span>
+        <div class="meta" style="margin-top:8px"><code>${esc(e.file)}</code> — ${esc(e.error)}</div></div>`).join("");
+    }
     h += `<div class="card"><span class="r">${s.trace_files} trace file(s) in <code>traces/</code>${
       d.trace_file?` (newest: <code>${esc(d.trace_file)}</code>)`:""}. ${reveal("traces","open the traces folder")}.
       A trace is just "what happened, in order" — here are the most recent lines:</span></div>`;

--- a/waku/ops/tracing.py
+++ b/waku/ops/tracing.py
@@ -20,14 +20,38 @@ Two outputs from the same events:
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import datetime, timezone
+from pathlib import Path
 
 from waku.config import Settings
 
 
 def _now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="milliseconds")
+
+
+class TraceEncodingError(UnicodeError):
+    """A legacy trace cannot be safely read or appended as UTF-8."""
+
+    def __init__(self, path: Path):
+        self.path = path
+        super().__init__(
+            f"Trace file is not valid UTF-8: {path}. It may have been written by an older "
+            "Waku version using the Windows system encoding. Move it out of the traces directory "
+            "and keep it as a backup, then restart Waku if it is today's trace. The file "
+            "was not modified."
+        )
+
+
+def iter_trace_lines(path: Path) -> Iterator[str]:
+    """Yield one UTF-8 trace line at a time with a useful legacy-file error."""
+    try:
+        with path.open("r", encoding="utf-8") as trace:
+            yield from trace
+    except UnicodeDecodeError as exc:
+        raise TraceEncodingError(path) from exc
 
 
 class Tracer:
@@ -39,6 +63,7 @@ class Tracer:
         self.path = settings.home / "traces" / f"{datetime.now().strftime('%Y-%m-%d')}.jsonl"
         self._otel_tracer = self._init_otel(settings)
         self._span_ctx = None
+        self._trace_encoding_checked = False
 
     def _init_otel(self, settings: Settings):
         if not settings.otel_endpoint:
@@ -63,8 +88,16 @@ class Tracer:
             return None
 
     def _write(self, record: dict) -> None:
+        # An older Windows release may have created this daily file in GBK.
+        # Refuse to make a mixed-encoding JSONL file: validate once, explain how
+        # to preserve the old file, and never guess or rewrite user data.
+        if not self._trace_encoding_checked:
+            if self.path.exists():
+                for _ in iter_trace_lines(self.path):
+                    pass
+            self._trace_encoding_checked = True
         record["ts"] = _now()
-        with self.path.open("a") as f:
+        with self.path.open("a", encoding="utf-8") as f:
             f.write(json.dumps(record, ensure_ascii=False, default=str) + "\n")
 
     def _record_usage(self, event: dict) -> None:


### PR DESCRIPTION
Prevent Windows system encodings from breaking traces containing Chinese or emoji. Dashboard trace readers now use UTF-8, and legacy non-UTF-8 traces are reported without being modified. Verified with 117 deterministic tests, Ruff, the release gate, and a live CP936 round trip.