### PR TITLE
fix: cache the Notion episodic client across dashboard refreshes

### DIFF
--- a/evals/deterministic/test_episodic_store_switch.py
+++ b/evals/deterministic/test_episodic_store_switch.py
@@ -19,8 +19,12 @@ class _FakeNotionClient:
     same rows as one created in the test body."""
 
     _pages: list[dict] = []
+    _init_count = 0     # Client constructions — the dashboard must build ONE
+    _query_count = 0    # data-source queries — the result cache throttles these
+    _query_fails = False   # simulate a Notion outage after a successful fetch
 
     def __init__(self, auth: str | None = None) -> None:
+        type(self)._init_count += 1
         self.auth = auth
         self.databases = types.SimpleNamespace(retrieve=self._retrieve)
         self.data_sources = types.SimpleNamespace(query=self._query)
@@ -49,18 +53,31 @@ class _FakeNotionClient:
         return {}
 
     def _query(self, *, data_source_id: str, start_cursor: str | None = None) -> dict:
+        if type(self)._query_fails:
+            raise RuntimeError("notion is down")
+        type(self)._query_count += 1
         assert data_source_id == "test-ds-id"
-        return {"results": list(type(self)._pages), "has_more": False}
+        # the real API excludes archived pages from query results
+        return {"results": [p for p in type(self)._pages if not p.get("archived")],
+                "has_more": False}
 
 
 @pytest.fixture
 def fake_notion(monkeypatch):
     _FakeNotionClient._pages = []
+    _FakeNotionClient._init_count = 0
+    _FakeNotionClient._query_count = 0
+    _FakeNotionClient._query_fails = False
     fake_module = types.ModuleType("notion_client")
     fake_module.Client = _FakeNotionClient
     monkeypatch.setitem(sys.modules, "notion_client", fake_module)
     monkeypatch.setenv("NOTION_TOKEN", "test-token")
     monkeypatch.setenv("NOTION_EPISODES_DATABASE_ID", "test-db-id")
+    # the dashboard caches the store + result module-wide — reset between tests
+    from waku.ops import dashboard
+
+    monkeypatch.setattr(dashboard, "_notion_store", None)
+    monkeypatch.setattr(dashboard, "_notion_episodes", None)
     return _FakeNotionClient
 
 
@@ -190,3 +207,92 @@ def test_manage_memory_delete_episode_sqlite_accepts_string_id(tmp_path):
     tool = make_manage_memory_tool(memory)
     assert tool.fn("delete", kind="episode", id="1") == "Deleted episode #1."
     assert store.recent(top_k=1) == []
+
+
+def test_collect_builds_notion_client_once_across_refreshes(monkeypatch, fake_notion, tmp_path):
+    """Issue #20: repeated collect() calls (dashboard auto-refresh) must reuse
+    ONE Notion client and serve the cached result within the TTL — not rebuild
+    the client and re-query Notion on every poll."""
+    _isolated_home(monkeypatch, tmp_path)
+    monkeypatch.setenv("WAKU_EPISODIC_STORE", "notion")
+
+    from waku.memory.episodic.notion_store import NotionEpisodeStore
+
+    NotionEpisodeStore().add("episode from notion", "2026-07-18")
+
+    from waku.ops import dashboard
+
+    fake_notion._init_count = 0   # ignore the setup construction above
+    fake_notion._query_count = 0
+
+    payloads = [dashboard.collect() for _ in range(3)]
+
+    assert all(p["episodes_source"] == "notion" and p["episodes_error"] == "" for p in payloads)
+    assert [p["episodes"] for p in payloads] == [payloads[0]["episodes"]] * 3
+    assert fake_notion._init_count == 1   # client built once, then cached
+    assert fake_notion._query_count == 1  # result cached for the TTL, no re-query
+
+
+def test_collect_refetches_after_ttl_but_reuses_client(monkeypatch, fake_notion, tmp_path):
+    _isolated_home(monkeypatch, tmp_path)
+    monkeypatch.setenv("WAKU_EPISODIC_STORE", "notion")
+
+    from waku.memory.episodic.notion_store import NotionEpisodeStore
+
+    NotionEpisodeStore().add("ep", "2026-07-18")
+
+    from waku.ops import dashboard
+
+    monkeypatch.setattr(dashboard, "_NOTION_EPISODES_TTL", 0)   # every poll is stale
+    fake_notion._init_count = 0
+    fake_notion._query_count = 0
+
+    dashboard.collect()
+    dashboard.collect()
+
+    assert fake_notion._query_count == 2   # TTL expired → refetch each time
+    assert fake_notion._init_count == 1    # …but the client is still built once
+
+
+def test_collect_serves_stale_episodes_during_notion_outage(monkeypatch, fake_notion, tmp_path):
+    """House rule: a Notion outage must degrade gracefully — and with a cache
+    on hand the tab keeps its last good data instead of going blank."""
+    _isolated_home(monkeypatch, tmp_path)
+    monkeypatch.setenv("WAKU_EPISODIC_STORE", "notion")
+
+    from waku.memory.episodic.notion_store import NotionEpisodeStore
+
+    NotionEpisodeStore().add("cached episode", "2026-07-18")
+
+    from waku.ops import dashboard
+
+    assert dashboard.collect()["episodes_error"] == ""
+
+    monkeypatch.setattr(dashboard, "_NOTION_EPISODES_TTL", 0)
+    fake_notion._query_fails = True
+    data = dashboard.collect()
+    assert data["episodes_source"] == "notion"
+    assert "notion is down" in data["episodes_error"]
+    assert [e["summary"] for e in data["episodes"]] == ["cached episode"]
+    assert "facts" in data   # the rest of the payload still rendered
+
+
+def test_delete_episode_busts_the_episodes_cache(monkeypatch, fake_notion, tmp_path):
+    _isolated_home(monkeypatch, tmp_path)
+    monkeypatch.setenv("WAKU_EPISODIC_STORE", "notion")
+
+    from waku.memory.episodic.notion_store import NotionEpisodeStore
+
+    store = NotionEpisodeStore()
+    store.add("first", "2026-07-18")
+    store.add("second", "2026-07-19")
+
+    from waku.ops import dashboard
+
+    assert len(dashboard.collect()["episodes"]) == 2   # populates the cache
+
+    page_id = _FakeNotionClient._pages[0]["id"]
+    assert dashboard.memory_action({"action": "delete_episode", "id": page_id}) == {"ok": True}
+
+    after = dashboard.collect()   # cache busted → refetch, not the stale pair
+    assert [e["summary"] for e in after["episodes"]] == ["second"]

--- a/waku/memory/__init__.py
+++ b/waku/memory/__init__.py
@@ -26,12 +26,16 @@ REPO_SKILLS = Path(__file__).resolve().parents[2] / "skills"
 
 
 class Memory:
-    def __init__(self, conn: sqlite3.Connection, settings: Settings, client: anthropic.Anthropic):
+    def __init__(self, conn: sqlite3.Connection, settings: Settings, client: anthropic.Anthropic,
+                 episode_store=None):
+        # episode_store: inject an already-built store (the dashboard caches ONE
+        # NotionEpisodeStore process-wide — its constructor hits the network,
+        # so building one per Memory would re-query Notion on every poll).
         self.conn = conn
         self.settings = settings
         self.client = client
         self.facts = self._make_fact_store(conn, settings)
-        self.episodes = self._make_episode_store(conn, settings)
+        self.episodes = episode_store if episode_store is not None else self._make_episode_store(conn, settings)
         self.skills = SkillLoader([REPO_SKILLS, settings.home / "skills"])
 
     @staticmethod

--- a/waku/ops/dashboard.py
+++ b/waku/ops/dashboard.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import json
 import os
 import threading
+import time
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -557,6 +558,28 @@ def _tool_status(output: str) -> str:
     return "ok"
 
 
+# Notion-backed episodes live across the network, so the client AND the result
+# are cached with a short TTL — collect() runs on every dashboard auto-refresh
+# and must not round-trip to Notion every few seconds (rate limits + latency).
+# The sqlite path is a local query and doesn't need this.
+_NOTION_EPISODES_TTL = 30.0   # seconds; the page polls ~every 5s
+_notion_lock = threading.Lock()
+_notion_store = None                       # built once (its constructor calls Notion)
+_notion_episodes: tuple[float, list] | None = None   # (fetched_at, items)
+
+
+def _get_notion_store():
+    """The ONE NotionEpisodeStore for the whole dashboard process. Its
+    constructor round-trips to Notion (data-source resolution), so it's built
+    lazily and cached. Callers must hold _notion_lock."""
+    global _notion_store
+    if _notion_store is None:
+        from waku.memory.episodic.notion_store import NotionEpisodeStore
+
+        _notion_store = NotionEpisodeStore()
+    return _notion_store
+
+
 def collect() -> dict:
     """Everything the page shows, in one JSON blob."""
     settings = load_settings()
@@ -579,11 +602,19 @@ def collect() -> dict:
                 ),
             }
         try:
-            from waku.memory.episodic.notion_store import NotionEpisodeStore
-
-            return {"source": "notion", "error": "", "items": NotionEpisodeStore().list()}
+            global _notion_episodes
+            with _notion_lock:
+                store = _get_notion_store()
+                if _notion_episodes and time.time() - _notion_episodes[0] < _NOTION_EPISODES_TTL:
+                    return {"source": "notion", "error": "", "items": _notion_episodes[1]}
+                items = store.list()
+                _notion_episodes = (time.time(), items)
+                return {"source": "notion", "error": "", "items": items}
         except Exception as exc:
-            return {"source": "notion", "error": str(exc), "items": []}
+            # Degrade gracefully: never take the payload down, and serve the
+            # last good fetch if we have one (an outage shouldn't blank the tab).
+            stale = _notion_episodes[1] if _notion_episodes else []
+            return {"source": "notion", "error": str(exc), "items": stale}
 
     episodes_data = episodes_payload()
 
@@ -834,7 +865,13 @@ def tools_info() -> dict:
 
         conn = connect(settings.home)
         try:
-            mem = Memory(conn, settings, None)
+            # Notion mode: reuse the dashboard's one cached client instead of
+            # letting Memory() build a fresh one per poll (issue #20).
+            episode_store = None
+            if settings.episodic_store == "notion":
+                with _notion_lock:
+                    episode_store = _get_notion_store()
+            mem = Memory(conn, settings, None, episode_store=episode_store)
         except Exception:
             # A misconfigured optional backend (notion/supabase) must not take
             # the dashboard down — drop the memory-admin tools from the
@@ -1058,9 +1095,13 @@ def memory_action(payload: dict) -> dict:
     conn = connect(settings.home)
     facts, episodes = SqliteFactStore(conn), SqliteEpisodeStore(conn)
     if action == "delete_episode" and settings.episodic_store == "notion":
-        from waku.memory.episodic.notion_store import NotionEpisodeStore
-
-        return {"ok": NotionEpisodeStore().delete(str(payload.get("id", "")))}
+        global _notion_episodes
+        with _notion_lock:
+            ok = _get_notion_store().delete(str(payload.get("id", "")))
+            # bust the TTL cache so the next collect() refetches — otherwise a
+            # deleted episode would linger on the page for up to 30s
+            _notion_episodes = None
+        return {"ok": ok}
     try:
         rid = int(payload.get("id", 0))
     except (TypeError, ValueError):


### PR DESCRIPTION
Closes #20

## Background

This is a follow-up to #10 and the corresponding PR #18, which introduced a configurable Notion episodic memory backend.

After #18 was merged, [this review comment](https://github.com/ShenSeanChen/waku-agent/issues/20) pointed out that with **WAKU_EPISODIC_STORE=notion**, **collect()** constructs a fresh **NotionEpisodeStore** on every dashboard auto-refresh. Because the dashboard polls roughly every 5 seconds, merely leaving the tab open creates a new Notion client plus a network round-trip several times a second. This is both slow and a quick way to hit Notion rate limits.

## What changed

- **Process-wide client cache** (waku/ops/dashboard.py)
  - Added **_get_notion_store()** so the **NotionEpisodeStore** instance is built once per process. Its constructor itself calls Notion (data-source resolution), so repeated construction was the main cost.

- **30-second TTL for episode query results** (waku/ops/dashboard.py)
  - Added **_notion_episodes** with a short TTL. The dashboard polls ~every 5s; caching the list for 30s cuts Notion queries by roughly 6× while keeping the data fresh enough for display.

- **Reuse the cached store in tools_info()** (waku/memory/__init__.py)
  - Added an optional **episode_store** parameter to **Memory**. **tools_info()** now passes in the dashboard's cached store instead of letting **Memory()** build a second fresh client per poll.

- **Cache invalidation on delete** (waku/ops/dashboard.py)
  - **memory_action(delete_episode)** clears **_notion_episodes** so deletions appear immediately instead of lingering for up to 30s.

- **Graceful degradation during a Notion outage**
  - If the TTL has expired and Notion is unreachable, **collect()** returns the last cached episode list with an error field set, rather than blanking the tab.

## Tests

Added four deterministic evals in evals/deterministic/test_episodic_store_switch.py:

1. **test_collect_builds_notion_client_once_across_refreshes** — confirms one client construction and one query across three **collect()** calls.
2. **test_collect_refetches_after_ttl_but_reuses_client** — confirms TTL expiry triggers a refetch while still reusing the cached client.
3. **test_collect_serves_stale_episodes_during_notion_outage** — confirms cached data is served when Notion is down.
4. **test_delete_episode_busts_the_episodes_cache** — confirms deletion invalidates the cache.

All tests use a mocked Notion client, so they run without network access.

## Verification

- [x] Dashboard auto-refresh with **WAKU_EPISODIC_STORE=notion** no longer shows repeated Notion client constructions.
- [x] Episode list updates within 30s and reflects deletions immediately.
- [x] Tab remains populated during a simulated Notion outage.
