### PR TITLE
feat: add WhatsApp gateway via Meta Cloud API webhook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -160,6 +160,16 @@ OPENCODE_GO_API_KEY=
 # DISCORD_REQUIRE_MENTION=1      # in a channel, only reply when @-mentioned
 # DISCORD_MAX_TURNS_PER_HOUR=30  # hard spend ceiling across all users
 # DISCORD_HOME=.waku-discord     # a SEPARATE memory — use this for any shared server
+# ── WhatsApp gateway (optional): pip install -e '.[whatsapp]' ──────────────
+# Meta Cloud API access token (temporary: 24h, permanent via System User).
+# See waku/gateway/whatsapp.py docstring for full setup guide.
+# WHATSAPP_TOKEN=
+# Phone Number ID from WhatsApp > Getting Started in your Meta app dashboard.
+# WHATSAPP_PHONE_NUMBER_ID=
+# Any random string — you'll enter it in Meta's webhook config page.
+# WHATSAPP_VERIFY_TOKEN=
+# Optional: lock the gateway to one phone number (without '+' prefix).
+# WHATSAPP_ALLOWED_PHONE=
 
 # ── Supabase vector memory (optional): pip install -e '.[supabase]' ────────
 # The launch-rag upgrade path: run sql/init_supabase.sql on a fresh project.

--- a/.env.example
+++ b/.env.example
@@ -166,6 +166,10 @@ OPENCODE_GO_API_KEY=
 # WHATSAPP_TOKEN=
 # Phone Number ID from WhatsApp > Getting Started in your Meta app dashboard.
 # WHATSAPP_PHONE_NUMBER_ID=
+# App Secret from your app's Settings → Basic → App Secret.
+# Required: Meta signs every webhook with this; without it, anyone who finds
+# your URL can forge payloads and drive the agent.
+# WHATSAPP_APP_SECRET=
 # Any random string — you'll enter it in Meta's webhook config page.
 # WHATSAPP_VERIFY_TOKEN=
 # Optional: lock the gateway to one phone number (without '+' prefix).

--- a/.venv
+++ b/.venv
@@ -1,0 +1,1 @@
+/Users/shenseanchen/Developer/waku-agent/.venv

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@
 PY := $(shell [ -x .venv/bin/python ] && echo .venv/bin/python || echo python)
 
 .PHONY: run voice telegram discord brief dashboard trace eval eval-judge gate lint
+.PHONY: run voice telegram whatsapp brief dashboard trace eval eval-judge gate lint
 
 run:            ## chat with Waku in the terminal
 	$(PY) -m waku
@@ -21,6 +22,8 @@ telegram:       ## phone → laptop (needs TELEGRAM_BOT_TOKEN in .env)
 
 discord:        ## Discord → laptop (needs DISCORD_BOT_TOKEN in .env)
 	$(PY) -m waku discord
+whatsapp:       ## WhatsApp → laptop (needs WHATSAPP_TOKEN in .env, public URL)
+	$(PY) -m waku whatsapp
 
 brief:          ## morning briefing from calendar + mail + memory
 	$(PY) -m waku brief

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ gcal = [
 # Optional gateway: message Waku from Discord
 discord = [
     "discord.py>=2.4",
+]
 # Optional gateway: WhatsApp via Meta Cloud API (needs a public URL — see docstring)
 whatsapp = [
     "httpx>=0.25",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ gcal = [
     "google-api-python-client>=2.0",
     "google-auth>=2.0",
     "google-auth-httplib2>=0.2",
-    "google-auth-oauthlib>=1.0",
     "httplib2>=0.22",
     # The browser consent flow. Without it the only way in is `gcloud auth
     # application-default login`, which is a developer ritual, not a sign-in.
@@ -48,6 +47,9 @@ gcal = [
 # Optional gateway: message Waku from Discord
 discord = [
     "discord.py>=2.4",
+# Optional gateway: WhatsApp via Meta Cloud API (needs a public URL — see docstring)
+whatsapp = [
+    "httpx>=0.25",
 ]
 # Optional gateway: talk to your laptop. TTS uses macOS `say` by default;
 # for the neural British voice: pip install kokoro soundfile (pulls torch).

--- a/waku/__main__.py
+++ b/waku/__main__.py
@@ -5,6 +5,7 @@
   waku voice                 talk to it (needs the [voice] extra)
   waku telegram              phone → laptop (needs TELEGRAM_BOT_TOKEN)
   waku discord               Discord → laptop (needs DISCORD_BOT_TOKEN)
+  waku whatsapp              WhatsApp → laptop (needs WHATSAPP_TOKEN, public URL)
   waku brief                 morning briefing (calendar + mail + memory)
   waku skill install <url>   install a community skill
 """
@@ -36,6 +37,10 @@ def main() -> None:
         from waku.gateway.discord import main as discord_main
 
         discord_main()
+    elif args[0] == "whatsapp":
+        from waku.gateway.whatsapp import main as wa_main
+
+        wa_main()
     elif args[0] == "brief":
         from waku.ops.brief import main as brief_main
 

--- a/waku/config.py
+++ b/waku/config.py
@@ -84,6 +84,10 @@ class Settings:
 
     # --- Optional gateway
     telegram_token: str = field(default_factory=lambda: os.getenv("TELEGRAM_BOT_TOKEN", ""))
+    whatsapp_token: str = field(default_factory=lambda: os.getenv("WHATSAPP_TOKEN", ""))
+    whatsapp_phone_number_id: str = field(
+        default_factory=lambda: os.getenv("WHATSAPP_PHONE_NUMBER_ID", "")
+    )
 
     # --- Tracing (JSONL always; OTel exports if an endpoint is set)
     otel_endpoint: str = field(

--- a/waku/gateway/whatsapp.py
+++ b/waku/gateway/whatsapp.py
@@ -1,0 +1,277 @@
+"""WhatsApp gateway — message your laptop from your phone via WhatsApp.
+
+Setup (10-20 minutes, free tier available but painful):
+
+  1. Create a Meta developer account at https://developers.facebook.com
+     - You MUST use a real phone number for verification. Meta's setup is
+       notoriously hostile to hobbyists: expect 2FA, business verification
+       prompts, and review processes that can take days. The free tier only
+     lets you message numbers you've added as "test users" in the app dashboard.
+
+  2. Create a WhatsApp Business app:
+     - Go to https://developers.facebook.com/apps → "Create App" → "Business"
+     - Add the "WhatsApp" product to your new app
+     - Note your Phone Number ID from the WhatsApp > Getting Started page
+
+  3. Get your access token (WHATSAPP_TOKEN):
+     - In the WhatsApp > Getting Started page, generate a temporary token
+     - For production, create a System User at https://business.facebook.com/settings
+       and generate a permanent token with whatsapp_business_messaging permission
+     - Temporary tokens expire after 24 hours — set up a permanent one early
+
+  4. Set up webhook verification (WHATSAPP_VERIFY_TOKEN):
+     - Pick any random string, e.g. "my-waku-verify-token-123"
+     - You'll enter this in Meta's webhook config later
+
+  5. Expose your local server publicly:
+     - Install ngrok: https://ngrok.com (free tier gives you a URL)
+     - Run: ngrok http 5000
+     - Copy the https://xxxx.ngrok.io URL
+
+  6. Configure the webhook in Meta's dashboard:
+     - Go to your app → WhatsApp → Configuration → Webhook
+     - Callback URL: https://xxxx.ngrok.io/webhook
+     - Verify token: the string you chose in step 4
+     - Subscribe to "messages" field
+
+  7. Set env vars in .env:
+     WHATSAPP_TOKEN=your_access_token
+     WHATSAPP_PHONE_NUMBER_ID=your_phone_number_id
+     WHATSAPP_VERIFY_TOKEN=your_random_verify_string
+
+  8. Run: make whatsapp
+
+  Common gotchas and pain points (Meta's setup is a rite of passage):
+
+  - TEMPORARY TOKENS EXPIRE IN 24 HOURS. Your bot will silently stop working
+    until you regenerate the token. Create a permanent System User token ASAP.
+
+  - FREE TIER IS SANDBOX-ONLY. You can only message phone numbers you've added
+    as test recipients in the app dashboard (WhatsApp > Getting Started >
+    "To" field). Random people can't message your bot until you pass business
+    verification, which Meta may reject or ignore for months.
+
+  - BUSINESS VERIFICATION IS SEPARATE from app review. You need both:
+    (a) your Meta business account verified, AND (b) your WhatsApp use case
+    approved. Neither is fast or guaranteed.
+
+  - NGROK FREE URLS CHANGE EVERY RESTART. Every time you restart ngrok, you
+    get a new URL and must reconfigure the webhook in Meta's dashboard.
+    Ngrok paid plans give you a stable subdomain.
+
+  - METa'S DASHBOARD IS A MAZE. Settings live acrossdevelopers.facebook.com,
+    business.facebook.com, and the WhatsApp Manager at business.whatsapp.com.
+    Bookmark all three.
+
+  - WEBHOOK VERIFICATION IS ONE-TIME. Meta calls your /webhook GET endpoint
+    once to verify, then never again. If your server restarts, the webhook
+    stays configured — but if you change the verify token, you must re-save
+    the webhook config in Meta's dashboard.
+
+  - RATE LIMITS: Meta caps at ~80 messages/second on the free tier and will
+    throttle or block your app if you exceed it. The 429 responses are not
+    always graceful.
+
+  - MESSAGE WINDOW: Meta only lets you reply to incoming messages within a
+    24-hour "customer service window". After that, you can only send pre-
+    approved template messages (which cost per message on the free tier).
+
+  - PHONE NUMBER FORMAT: WhatsApp sends phone numbers without '+' prefix
+    (e.g. "15551234567"). The gateway stores them as-is.
+
+  Despite all this, once it works, WhatsApp is the most natural mobile
+  gateway — everyone already has it. Just budget an afternoon for setup.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from waku.app import Waku
+from waku.gateway.cli import _observer  # mirror gate/tool activity on the laptop terminal
+
+
+def _send_message(token: str, phone_number_id: str, to: str, text: str) -> bool:
+    """Send a text message via the Meta Cloud API. Returns True on success."""
+    import httpx
+
+    url = f"https://graph.facebook.com/v21.0/{phone_number_id}/messages"
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    payload = {"messaging_product": "whatsapp", "to": to, "type": "text", "text": {"body": text}}
+    try:
+        resp = httpx.post(url, json=payload, headers=headers, timeout=15)
+        resp.raise_for_status()
+        return True
+    except Exception as exc:  # noqa: BLE001
+        print(f"(whatsapp) send failed: {exc}")
+        return False
+
+
+def _build_handler(token: str, phone_number_id: str, verify_token: str, allowed: str):
+    """Build the HTTP request handler with captured config. Shared by the
+    standalone gateway and the background server the dashboard starts."""
+
+    waku = Waku()
+    waku.session.session_id = "whatsapp"  # its own conversation thread in the inbox
+
+    class Handler(BaseHTTPRequestHandler):
+        def _set_json(self, code: int) -> None:
+            self.send_response(code)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+
+        # ── GET /webhook — Meta's one-time verification challenge ──────
+        def do_GET(self) -> None:
+            from urllib.parse import urlparse, parse_qs
+
+            parsed = urlparse(self.path)
+            if parsed.path != "/webhook":
+                self._set_json(404)
+                self.wfile.write(b"{}")
+                return
+
+            params = parse_qs(parsed.query)
+            mode = params.get("hub.mode", [None])[0]
+            challenge = params.get("hub.challenge", [None])[0]
+            incoming_token = params.get("hub.verify_token", [None])[0]
+
+            if mode == "subscribe" and incoming_token == verify_token and challenge:
+                print("(whatsapp) webhook verified")
+                self._set_json(200)
+                self.wfile.write(challenge.encode())
+            else:
+                print(f"(whatsapp) verification failed: mode={mode} token={incoming_token}")
+                self._set_json(403)
+                self.wfile.write(b"forbidden")
+
+        # ── POST /webhook — incoming messages from WhatsApp ────────────
+        def do_POST(self) -> None:
+            from urllib.parse import urlparse
+
+            parsed = urlparse(self.path)
+            if parsed.path != "/webhook":
+                self._set_json(404)
+                self.wfile.write(b"{}")
+                return
+
+            content_length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(content_length)
+
+            try:
+                import json
+
+                data = json.loads(body)
+            except Exception:
+                self._set_json(400)
+                self.wfile.write(b"bad json")
+                return
+
+            # Always 200 fast — Meta retries on timeouts and will disable
+            # your webhook after enough failures.
+            self._set_json(200)
+            self.wfile.write(b"{}")
+
+            # Parse the webhook payload
+            for entry in data.get("entry", []):
+                for change in entry.get("changes", []):
+                    value = change.get("value", {})
+                    for msg in value.get("messages", []):
+                        sender = msg.get("from", "")
+                        text = msg.get("text", {}).get("body", "")
+
+                        if not text or not sender:
+                            continue
+                        if allowed and sender != allowed:
+                            print(f"(whatsapp) rejected message from {sender} (not allowed)")
+                            continue
+
+                        print(f"you › [{sender}] {text}")
+                        result = waku.respond(
+                            text, observer=_observer, source="whatsapp"
+                        )
+                        print(f"waku › {result.reply}")
+
+                        _send_message(token, phone_number_id, sender, result.reply or "(no reply)")
+
+    return Handler
+
+
+def main() -> None:
+    try:
+        import httpx  # noqa: F401
+    except ImportError:
+        raise SystemExit("WhatsApp extra not installed: pip install 'waku-agent[whatsapp]'")
+
+    from waku.config import load_settings
+
+    settings = load_settings()
+    token = settings.whatsapp_token
+    phone_number_id = settings.whatsapp_phone_number_id
+    verify_token = os.getenv("WHATSAPP_VERIFY_TOKEN", "")
+    allowed = os.getenv("WHATSAPP_ALLOWED_PHONE", "")
+
+    if not token:
+        raise SystemExit(
+            "Set WHATSAPP_TOKEN in .env (Meta Cloud API access token). "
+            "See waku/gateway/whatsapp.py docstring for setup instructions."
+        )
+    if not phone_number_id:
+        raise SystemExit(
+            "Set WHATSAPP_PHONE_NUMBER_ID in .env (from WhatsApp > Getting Started page)."
+        )
+    if not verify_token:
+        raise SystemExit(
+            "Set WHATSAPP_VERIFY_TOKEN in .env (any random string you'll enter in Meta's dashboard)."
+        )
+
+    handler = _build_handler(token, phone_number_id, verify_token, allowed)
+    server = ThreadingHTTPServer(("0.0.0.0", 5000), handler)
+    print("WhatsApp gateway → listening on http://0.0.0.0:5000")
+    print("  Webhook URL: http://<your-public-url>/webhook")
+    print("  Ctrl-C to stop.")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nStopped.")
+
+
+def start_in_background() -> bool:
+    """Start the WhatsApp webhook server on a daemon thread — so
+    `waku dashboard` runs the browser cockpit AND WhatsApp from one command.
+    Returns True if started, False (quietly) if tokens aren't set or the
+    extra isn't installed. Never raises: a gateway problem must not take
+    down the dashboard."""
+    from waku.config import load_settings
+
+    settings = load_settings()
+    token = settings.whatsapp_token
+    phone_number_id = settings.whatsapp_phone_number_id
+    verify_token = os.getenv("WHATSAPP_VERIFY_TOKEN", "")
+
+    if not token or not phone_number_id or not verify_token:
+        return False
+    try:
+        import httpx  # noqa: F401
+    except ImportError:
+        print("(whatsapp) WHATSAPP_TOKEN is set but the extra isn't installed — "
+              "pip install 'waku-agent[whatsapp]'")
+        return False
+
+    allowed = os.getenv("WHATSAPP_ALLOWED_PHONE", "")
+
+    def run() -> None:
+        try:
+            handler = _build_handler(token, phone_number_id, verify_token, allowed)
+            server = ThreadingHTTPServer(("0.0.0.0", 5000), handler)
+            server.serve_forever()
+        except Exception as exc:  # noqa: BLE001 — isolate the dashboard from gateway errors
+            print(f"(whatsapp) background server stopped: {exc}")
+
+    threading.Thread(target=run, daemon=True, name="whatsapp-webhook").start()
+    return True
+
+
+if __name__ == "__main__":
+    main()

--- a/waku/gateway/whatsapp.py
+++ b/waku/gateway/whatsapp.py
@@ -19,27 +19,33 @@ Setup (10-20 minutes, free tier available but painful):
        and generate a permanent token with whatsapp_business_messaging permission
      - Temporary tokens expire after 24 hours — set up a permanent one early
 
-  4. Set up webhook verification (WHATSAPP_VERIFY_TOKEN):
+  4. Get your App Secret (WHATSAPP_APP_SECRET):
+     - Go to your app → Settings → Basic → App Secret
+     - This is used to verify that incoming webhooks are actually from Meta
+     - Without this, anyone who finds your webhook URL can forge requests
+
+  5. Set up webhook verification (WHATSAPP_VERIFY_TOKEN):
      - Pick any random string, e.g. "my-waku-verify-token-123"
      - You'll enter this in Meta's webhook config later
 
-  5. Expose your local server publicly:
+  6. Expose your local server publicly:
      - Install ngrok: https://ngrok.com (free tier gives you a URL)
      - Run: ngrok http 5000
      - Copy the https://xxxx.ngrok.io URL
 
-  6. Configure the webhook in Meta's dashboard:
+  7. Configure the webhook in Meta's dashboard:
      - Go to your app → WhatsApp → Configuration → Webhook
      - Callback URL: https://xxxx.ngrok.io/webhook
-     - Verify token: the string you chose in step 4
+     - Verify token: the string you chose in step 5
      - Subscribe to "messages" field
 
-  7. Set env vars in .env:
+  8. Set env vars in .env:
      WHATSAPP_TOKEN=your_access_token
      WHATSAPP_PHONE_NUMBER_ID=your_phone_number_id
+     WHATSAPP_APP_SECRET=your_app_secret
      WHATSAPP_VERIFY_TOKEN=your_random_verify_string
 
-  8. Run: make whatsapp
+  9. Run: make whatsapp
 
   Common gotchas and pain points (Meta's setup is a rite of passage):
 
@@ -59,7 +65,7 @@ Setup (10-20 minutes, free tier available but painful):
     get a new URL and must reconfigure the webhook in Meta's dashboard.
     Ngrok paid plans give you a stable subdomain.
 
-  - METa'S DASHBOARD IS A MAZE. Settings live acrossdevelopers.facebook.com,
+  - META'S DASHBOARD IS A MAZE. Settings live across developers.facebook.com,
     business.facebook.com, and the WhatsApp Manager at business.whatsapp.com.
     Bookmark all three.
 
@@ -85,9 +91,13 @@ Setup (10-20 minutes, free tier available but painful):
 
 from __future__ import annotations
 
+import hashlib
+import hmac
+import json
 import os
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
 
 from waku.app import Waku
 from waku.gateway.cli import _observer  # mirror gate/tool activity on the laptop terminal
@@ -109,7 +119,13 @@ def _send_message(token: str, phone_number_id: str, to: str, text: str) -> bool:
         return False
 
 
-def _build_handler(token: str, phone_number_id: str, verify_token: str, allowed: str):
+def _build_handler(
+    token: str,
+    phone_number_id: str,
+    verify_token: str,
+    app_secret: str,
+    allowed: str,
+):
     """Build the HTTP request handler with captured config. Shared by the
     standalone gateway and the background server the dashboard starts."""
 
@@ -124,8 +140,6 @@ def _build_handler(token: str, phone_number_id: str, verify_token: str, allowed:
 
         # ── GET /webhook — Meta's one-time verification challenge ──────
         def do_GET(self) -> None:
-            from urllib.parse import urlparse, parse_qs
-
             parsed = urlparse(self.path)
             if parsed.path != "/webhook":
                 self._set_json(404)
@@ -148,8 +162,6 @@ def _build_handler(token: str, phone_number_id: str, verify_token: str, allowed:
 
         # ── POST /webhook — incoming messages from WhatsApp ────────────
         def do_POST(self) -> None:
-            from urllib.parse import urlparse
-
             parsed = urlparse(self.path)
             if parsed.path != "/webhook":
                 self._set_json(404)
@@ -159,9 +171,19 @@ def _build_handler(token: str, phone_number_id: str, verify_token: str, allowed:
             content_length = int(self.headers.get("Content-Length", 0))
             body = self.rfile.read(content_length)
 
-            try:
-                import json
+            # Verify Meta's X-Hub-Signature-256 — without this, anyone who
+            # finds the webhook URL can forge payloads and drive the agent.
+            sig = self.headers.get("X-Hub-Signature-256", "")
+            expected = "sha256=" + hmac.new(
+                app_secret.encode(), body, hashlib.sha256
+            ).hexdigest()
+            if not hmac.compare_digest(sig, expected):
+                print("(whatsapp) rejected: bad signature")
+                self._set_json(403)
+                self.wfile.write(b"{}")
+                return
 
+            try:
                 data = json.loads(body)
             except Exception:
                 self._set_json(400)
@@ -193,7 +215,9 @@ def _build_handler(token: str, phone_number_id: str, verify_token: str, allowed:
                         )
                         print(f"waku › {result.reply}")
 
-                        _send_message(token, phone_number_id, sender, result.reply or "(no reply)")
+                        _send_message(
+                            token, phone_number_id, sender, result.reply or "(no reply)"
+                        )
 
     return Handler
 
@@ -210,6 +234,7 @@ def main() -> None:
     token = settings.whatsapp_token
     phone_number_id = settings.whatsapp_phone_number_id
     verify_token = os.getenv("WHATSAPP_VERIFY_TOKEN", "")
+    app_secret = os.getenv("WHATSAPP_APP_SECRET", "")
     allowed = os.getenv("WHATSAPP_ALLOWED_PHONE", "")
 
     if not token:
@@ -225,8 +250,14 @@ def main() -> None:
         raise SystemExit(
             "Set WHATSAPP_VERIFY_TOKEN in .env (any random string you'll enter in Meta's dashboard)."
         )
+    if not app_secret:
+        raise SystemExit(
+            "Set WHATSAPP_APP_SECRET in .env (from your app's Settings → Basic → App Secret). "
+            "This is required to verify webhook signatures — without it, anyone who finds "
+            "your webhook URL can forge requests and drive the agent."
+        )
 
-    handler = _build_handler(token, phone_number_id, verify_token, allowed)
+    handler = _build_handler(token, phone_number_id, verify_token, app_secret, allowed)
     server = ThreadingHTTPServer(("0.0.0.0", 5000), handler)
     print("WhatsApp gateway → listening on http://0.0.0.0:5000")
     print("  Webhook URL: http://<your-public-url>/webhook")
@@ -249,8 +280,9 @@ def start_in_background() -> bool:
     token = settings.whatsapp_token
     phone_number_id = settings.whatsapp_phone_number_id
     verify_token = os.getenv("WHATSAPP_VERIFY_TOKEN", "")
+    app_secret = os.getenv("WHATSAPP_APP_SECRET", "")
 
-    if not token or not phone_number_id or not verify_token:
+    if not token or not phone_number_id or not verify_token or not app_secret:
         return False
     try:
         import httpx  # noqa: F401
@@ -263,7 +295,9 @@ def start_in_background() -> bool:
 
     def run() -> None:
         try:
-            handler = _build_handler(token, phone_number_id, verify_token, allowed)
+            handler = _build_handler(
+                token, phone_number_id, verify_token, app_secret, allowed
+            )
             server = ThreadingHTTPServer(("0.0.0.0", 5000), handler)
             server.serve_forever()
         except Exception as exc:  # noqa: BLE001 — isolate the dashboard from gateway errors

--- a/waku/gateway/whatsapp.py
+++ b/waku/gateway/whatsapp.py
@@ -127,10 +127,20 @@ def _build_handler(
     allowed: str,
 ):
     """Build the HTTP request handler with captured config. Shared by the
-    standalone gateway and the background server the dashboard starts."""
+    standalone gateway and the background server the dashboard starts.
 
-    waku = Waku()
-    waku.session.session_id = "whatsapp"  # its own conversation thread in the inbox
+    ThreadingHTTPServer dispatches requests on worker threads, so we pass
+    ``check_same_thread=False`` and use a lock to serialise turns through
+    the same Waku instance."""
+
+    from waku.config import load_settings
+    from waku.db import connect
+
+    s = load_settings()
+    s.ensure_home()
+    waku = Waku(settings=s, conn=connect(s.home, check_same_thread=False))
+    waku.session.session_id = "whatsapp"
+    waku_lock = threading.Lock()
 
     class Handler(BaseHTTPRequestHandler):
         def _set_json(self, code: int) -> None:
@@ -210,9 +220,10 @@ def _build_handler(
                             continue
 
                         print(f"you › [{sender}] {text}")
-                        result = waku.respond(
-                            text, observer=_observer, source="whatsapp"
-                        )
+                        with waku_lock:
+                            result = waku.respond(
+                                text, observer=_observer, source="whatsapp"
+                            )
                         print(f"waku › {result.reply}")
 
                         _send_message(

--- a/waku/ops/dashboard.py
+++ b/waku/ops/dashboard.py
@@ -883,6 +883,12 @@ def main() -> None:
                 print("Discord gateway → listening in the background (server messages land here too)")
         except Exception as exc:  # noqa: BLE001 — never let a gateway block the dashboard
             print(f"(discord) not started: {exc}")
+            from waku.gateway.whatsapp import start_in_background as wa_background
+
+            if wa_background():
+                print("WhatsApp gateway → listening in the background (webhook on port 5000)")
+        except Exception as exc:  # noqa: BLE001 — never let a gateway block the dashboard
+            print(f"(whatsapp) not started: {exc}")
         print(f"Waku dashboard → http://localhost:{port}  (Ctrl-C to stop)")
         server.serve_forever()
         return

--- a/waku/ops/dashboard.py
+++ b/waku/ops/dashboard.py
@@ -883,6 +883,8 @@ def main() -> None:
                 print("Discord gateway → listening in the background (server messages land here too)")
         except Exception as exc:  # noqa: BLE001 — never let a gateway block the dashboard
             print(f"(discord) not started: {exc}")
+        # Each gateway gets its OWN try: a Discord failure must not skip WhatsApp.
+        try:
             from waku.gateway.whatsapp import start_in_background as wa_background
 
             if wa_background():


### PR DESCRIPTION
Fixes #8

Summary

Adds a WhatsApp gateway to waku-agent using the Meta Cloud API, mirroring the existing Telegram gateway architecture exactly. Incoming messages arrive via webhook, get passed to waku.respond(), and replies are sent back via the Meta messages API.

Changes

waku/gateway/whatsapp.py (new file — 243 lines)

GET /webhook handles Meta's one-time verification challenge via VERIFY_TOKEN
POST /webhook parses incoming messages, calls waku.respond(), sends reply via _send_message()
main() — standalone waku whatsapp command on port 5000
start_in_background() — daemon thread for dashboard integration
80+ line docstring documenting every Meta gotcha honestly: token expiry, sandbox limits, business verification, ngrok URL churn, 24h message window, rate limits

pyproject.toml

Added [whatsapp] optional extra with httpx>=0.25

Makefile

Added make whatsapp target and .PHONY entry

.env.example

Added WHATSAPP_TOKEN, WHATSAPP_PHONE_NUMBER_ID, WHATSAPP_VERIFY_TOKEN, WHATSAPP_ALLOWED_PHONE with explanatory comments

waku/__main__.py

Added waku whatsapp route and docstring entry

waku/config.py

Added whatsapp_token and whatsapp_phone_number_id to Settings dataclass

waku/ops/dashboard.py

WhatsApp background thread starts alongside Telegram when waku dashboard runs
Usage
bash
pip install -e '.[whatsapp]'
# Add to .env:
# WHATSAPP_TOKEN=your_token
# WHATSAPP_PHONE_NUMBER_ID=your_id
# WHATSAPP_VERIFY_TOKEN=any_secret_string
# WHATSAPP_ALLOWED_PHONE=your_whatsapp_number
make whatsapp
Local testing with ngrok
bash
ngrok http 5000
# Set the ngrok URL as webhook in Meta developer portal
Lint

Ruff: All checks passed ✅