### PR TITLE
feat: disclose each model's knowledge cutoff in the Compare arena

### DIFF
--- a/evals/deterministic/test_providers.py
+++ b/evals/deterministic/test_providers.py
@@ -153,3 +153,27 @@ def test_price_for_layers_model_over_provider():
     fable_in, fable_out = price_for("anthropic", "claude-fable-5")
     opus_in, opus_out = price_for("anthropic", "claude-opus-4-8")
     assert fable_in > opus_in and fable_out > opus_out   # fable is never cheaper
+
+
+def test_every_priced_model_has_a_knowledge_cutoff():
+    """Arena honesty: the Compare arena discloses each model's knowledge cutoff
+    so stale world knowledge isn't misread as low capability (gemini-3.1-pro
+    confidently denies 2026 models exist — its cutoff is 2025-01). Every model
+    in MODEL_PRICING must have a MODEL_CUTOFF entry. None is a valid value
+    (vendor hasn't published a cutoff; the UI shows a dash) — a MISSING key
+    means someone added a model without deciding, which is what this catches."""
+    import re
+
+    from waku.ops.dashboard import MODEL_CUTOFF, MODEL_PRICING, cutoff_for
+
+    missing = set(MODEL_PRICING) - set(MODEL_CUTOFF)
+    assert not missing, f"models priced but missing a MODEL_CUTOFF entry: {sorted(missing)}"
+
+    for model, cutoff in MODEL_CUTOFF.items():
+        if cutoff is not None:
+            assert re.fullmatch(r"20\d\d-(0[1-9]|1[0-2])", cutoff), \
+                f"{model}: cutoff {cutoff!r} is not YYYY-MM"
+
+    # The motivating case, plus the unknown-model path (no guessing).
+    assert cutoff_for("gemini-3.1-pro-preview") == "2025-01"
+    assert cutoff_for("some-future-model") is None

--- a/waku/ops/dashboard.py
+++ b/waku/ops/dashboard.py
@@ -226,7 +226,8 @@ def _compare_one(message: str, spec: str) -> dict:
                 "gate": (gate or None), "iterations": result.iterations, "latency_ms": ms,
                 "tools": [{"tool": c["tool"]} for c in result.tool_calls],
                 "tokens_in": tin, "tokens_out": tout,
-                "cost_usd": round(tin / 1e6 * pin + tout / 1e6 * pout, 4)}
+                "cost_usd": round(tin / 1e6 * pin + tout / 1e6 * pout, 4),
+                "cutoff": cutoff_for(settings.model)}
     except (Exception, SystemExit) as exc:   # a broken contestant (incl. a missing
         # key, which get_client raises as SystemExit) fails alone, not the whole race
         return {"spec": spec, "provider": provider, "model": model, "error": str(exc)[:200]}
@@ -283,7 +284,8 @@ def compare_stream(message: str, specs: list, emit, judge: bool = False,
 
     def run(spec):
         provider, _, model = spec.partition(":")
-        send("start", {"spec": spec, "provider": provider, "model": model})
+        send("start", {"spec": spec, "provider": provider, "model": model,
+                       "cutoff": cutoff_for(model)})
         home = Path(tempfile.mkdtemp(prefix=f"compare-{provider}-"))
         gate: dict = {}
 
@@ -338,6 +340,7 @@ def compare_stream(message: str, specs: list, emit, judge: bool = False,
                             "iterations": result.iterations, "latency_ms": ms,
                             "tools": [{"tool": c["tool"]} for c in result.tool_calls],
                             "tokens_in": tin, "tokens_out": tout, "cost_usd": cost,
+                            "cutoff": cutoff_for(settings.model),
                             "completion": completion, "quality": None})
         except (Exception, SystemExit) as exc:
             # SystemExit (not an Exception subclass) is what get_client raises for
@@ -386,10 +389,13 @@ def compare_clear(payload: dict) -> dict:
 
 def _compare_history_response(runs: list[dict]) -> dict:
     """Reprice each stored result from its tokens with the CURRENT price table (so
-    a pricing fix corrects past races), aggregate, and tag each row with the rate.
-    The shared shape returned by /api/compare/history and the re-grade endpoint."""
+    a pricing fix corrects past races), aggregate, and tag each row with the rate
+    and knowledge cutoff (also from the current table, so a cutoff fix corrects
+    past races too). The shared shape returned by /api/compare/history and the
+    re-grade endpoint."""
     for run in runs:
         for r in run.get("results", []):
+            r["cutoff"] = cutoff_for(r.get("model", ""))
             if r.get("error"):
                 continue
             pin, pout = price_for(r.get("provider", ""), r.get("model", ""))
@@ -398,6 +404,7 @@ def _compare_history_response(runs: list[dict]) -> dict:
     agg = compare_history.aggregate(runs)
     for row in agg:
         row["rate_in"], row["rate_out"] = price_for(row["provider"], row["model"])
+        row["cutoff"] = cutoff_for(row["model"])
     return {"runs": runs[-20:][::-1], "aggregate": agg}
 
 
@@ -484,6 +491,42 @@ MODEL_PRICING = {
     "grok-4.5": (2.0, 6.0),
     "grok-4.3": (1.25, 2.5),
 }
+
+
+# Knowledge cutoff (YYYY-MM) per model — the arena discloses when each brain's
+# world knowledge ends, so stale knowledge isn't misread as low capability
+# (gemini-3.1-pro will confidently deny that 2026 models exist: its cutoff is
+# 2025-01, a year before them). Values are each vendor's published knowledge
+# cutoff (for Anthropic, the "reliable knowledge cutoff"; training data runs
+# later). None = the vendor hasn't published one. Fact-checked Jul 2026 against
+# vendor model cards/docs. Every MODEL_PRICING id must have an entry here —
+# enforced by evals/deterministic/test_providers.py.
+MODEL_CUTOFF = {
+    # Anthropic — support.claude.com "How up-to-date is Claude's training data?"
+    "claude-opus-4-8": "2026-01",
+    "claude-fable-5": "2026-01",
+    "claude-sonnet-5": "2026-01",
+    "claude-haiku-4-5-20251001": "2025-02",   # trained on data through 2025-07
+    # OpenAI — developers.openai.com model pages
+    "gpt-5.6-sol": "2026-02",
+    "gpt-5.3-chat-latest": "2025-08",
+    # Google Gemini — deepmind.google model cards / ai.google.dev
+    "gemini-3.1-pro-preview": "2025-01",
+    "gemini-3.5-flash": "2025-01",
+    # Moonshot Kimi — K3 reported "early 2026"; K2.7 cutoffs unpublished
+    "kimi-k3": "2026-01",
+    "kimi-k2.7-code-highspeed": None,
+    "kimi-k2.7": None,
+    # xAI Grok — docs.x.ai model list
+    "grok-4.5": "2026-02",
+    "grok-4.3": "2025-12",
+}
+
+
+def cutoff_for(model: str) -> str | None:
+    """Knowledge-cutoff date ('YYYY-MM') for a model id, or None when the
+    vendor hasn't published one (the UI shows a dash rather than a guess)."""
+    return MODEL_CUTOFF.get(model)
 
 
 def price_for(provider: str, model: str) -> tuple[float, float]:

--- a/waku/ops/static/js/compare.js
+++ b/waku/ops/static/js/compare.js
@@ -239,10 +239,18 @@ function compareErrorReason(err){
   if (e.includes("not found") || e.includes("no longer available")) return "model id not available";
   return null;
 }
+// "knows to 2026-01" next to the model name — each brain's knowledge cutoff,
+// so a confidently-wrong answer about recent events reads as stale knowledge,
+// not low capability (a model can't know about releases after its cutoff).
+// Server-supplied (MODEL_CUTOFF in dashboard.py); absent = vendor unpublished.
+function cutoffTag(cutoff){
+  return cutoff ? ` <span class="meta" style="font-size:11px;white-space:nowrap"
+    title="knowledge cutoff — this model's world knowledge ends here; it cannot know releases after this date">knows to ${esc(cutoff)}</span>` : "";
+}
 function compareCol(res){
   if (res.error){
     const why = compareErrorReason(res.error);
-    return `<div class="cmp-col err"><div class="cmp-h"><span class="mm-prov">${esc(res.provider)}</span> <code>${esc(res.model)}</code>
+    return `<div class="cmp-col err"><div class="cmp-h"><span class="mm-prov">${esc(res.provider)}</span> <code>${esc(res.model)}</code>${cutoffTag(res.cutoff)}
       <span class="srcpill apple">error</span></div>
       ${why?`<div class="meta" style="color:var(--bad)"><b>${esc(why)}</b></div>`:""}
       <div class="meta" style="opacity:.7">${esc(res.error)}</div></div>`;
@@ -253,7 +261,7 @@ function compareCol(res){
   const gateBadgeHtml = `<span class="badge ${res.gate&&res.gate.decision==="retrieve"?"retrieve":""}">gate · ${esc(res.gate?res.gate.decision:"…")}</span>`;
   if (res.streaming){
     return `<div class="cmp-col">
-      <div class="cmp-h"><span class="mm-prov">${esc(res.provider)}</span> <code>${esc(res.model)}</code>
+      <div class="cmp-h"><span class="mm-prov">${esc(res.provider)}</span> <code>${esc(res.model)}</code>${cutoffTag(res.cutoff)}
         <span class="live-dot"></span></div>
       <div class="cmp-stats">${gateBadgeHtml}</div>
       ${tools?`<div class="stages" style="flex-wrap:wrap">${tools}</div>`:""}
@@ -267,7 +275,7 @@ function compareCol(res){
   // per-card grade button — grade just this card if the referee skipped it (429)
   const gradeBtn = `<a class="reveal cmp-grade1" title="grade this card with the referee" onclick="gradeCard('${esc(res.spec)}')">${res._grading?"grading…":(q&&q.score!=null?"re-grade":"grade")}</a>`;
   return `<div class="cmp-col${c?(c.passed?" solved":" failed"):""}">
-    <div class="cmp-h"><span class="mm-prov">${esc(res.provider)}</span> <code>${esc(res.model)}</code>${completionBadge}${qualityBadge}${gradeBtn}</div>
+    <div class="cmp-h"><span class="mm-prov">${esc(res.provider)}</span> <code>${esc(res.model)}</code>${cutoffTag(res.cutoff)}${completionBadge}${qualityBadge}${gradeBtn}</div>
     <div class="cmp-stats">
       ${gateBadgeHtml}
       <span class="chip ${compareState.sortBy==="latency"?"sorted":""}">${secs(res.latency_ms)}</span>
@@ -384,7 +392,7 @@ function boardAggregate(){
       const r = (compareState.results || {})[spec];
       if (!r || r.streaming) return;   // column not finished yet
       const a = map[spec] || (map[spec] = {spec, provider: r.provider, model: r.model,
-        runs: 0, ok: 0, total_latency_ms: 0, total_tokens_in: 0, total_tokens_out: 0,
+        cutoff: r.cutoff, runs: 0, ok: 0, total_latency_ms: 0, total_tokens_in: 0, total_tokens_out: 0,
         total_tokens: 0, total_cost_usd: 0, cases_passed: 0, cases_scored: 0,
         _qsum: 0, quality_n: 0, quality_avg: null});
       a.runs += 1;
@@ -479,9 +487,10 @@ function compareHistoryHtml(){
       <a class="reveal" style="margin-left:auto;font-size:12px" onclick="clearCompareHistory()">clear all</a></h2>
     ${costQualityScatter(agg)}
     <div class="card" style="padding:4px 8px"><table>
-      <tr><th>model</th>${th("cases_passed","solved")}<th class="cmp-th ${bs.key==="quality_avg"?"on":""}" onclick="setBoardSort('quality_avg')" title="referee's mean 0-10 grade on the replies (correctness, honesty, concision) — referee is not a racing model">grade${arrow("quality_avg")}</th>${th("runs","races")}<th>ok</th>${th("total_latency_ms","total time")}${th("total_tokens_in","in tok")}${th("total_tokens_out","out tok")}${th("total_tokens","total tok")}<th title="list price per million tokens, input / output">rate $/M</th>${th("total_cost_usd","total cost")}</tr>
+      <tr><th>model</th><th title="knowledge cutoff — when each model's world knowledge ends; it cannot know releases after this date">cutoff</th>${th("cases_passed","solved")}<th class="cmp-th ${bs.key==="quality_avg"?"on":""}" onclick="setBoardSort('quality_avg')" title="referee's mean 0-10 grade on the replies (correctness, honesty, concision) — referee is not a racing model">grade${arrow("quality_avg")}</th>${th("runs","races")}<th>ok</th>${th("total_latency_ms","total time")}${th("total_tokens_in","in tok")}${th("total_tokens_out","out tok")}${th("total_tokens","total tok")}<th title="list price per million tokens, input / output">rate $/M</th>${th("total_cost_usd","total cost")}</tr>
       ${rows.map(a=>`<tr>
         <td><span class="mm-prov">${esc(a.provider)}</span> <code>${esc(a.model)}</code></td>
+        <td class="meta">${a.cutoff?esc(a.cutoff):"—"}</td>
         <td>${a.cases_scored?`<span class="cmp-score ${a.cases_passed===a.cases_scored?"pass":(a.cases_passed?"part":"fail")}">${a.cases_passed}/${a.cases_scored}</span>`:'<span class="meta">—</span>'}</td>
         <td>${a.quality_avg!=null?`<span class="cmp-q ${a.quality_avg>=7?"hi":a.quality_avg>=4?"mid":"lo"}">${a.quality_avg}</span>`:'<span class="meta">—</span>'}</td>
         <td class="meta">${a.runs}</td><td class="meta">${a.ok}/${a.runs}</td>


### PR DESCRIPTION
## What

Adds knowledge-cutoff dates to the Compare arena: a `MODEL_CUTOFF` table (sibling of `MODEL_PRICING` in `waku/ops/dashboard.py`), threaded through both race paths and the history/scoreboard endpoint, and surfaced in the frontend as "knows to YYYY-MM" next to each model name on arena cards plus a `cutoff` column in the scoreboard.

## Why

An arena comparing models must disclose when each brain's world knowledge ends, or stale knowledge is misread as low capability — Gemini 3.1 Pro (cutoff 2025-01) confidently denies that 2026 models exist. That's a calendar problem, not an intelligence problem, and now the card says so right next to the reply.

## Details

- Dates fact-checked (Jul 2026) against vendor model cards/docs. Kimi K2.7 cutoffs are unpublished → stored as `None`, UI shows a dash, never a guess.
- `_compare_history_response` re-tags stored races from the current table (same pattern as repricing), so a cutoff correction fixes past races too.
- New deterministic regression: every `MODEL_PRICING` id must have a `MODEL_CUTOFF` entry, format-checked, with the motivating gemini case pinned.

## Verification

- Deterministic evals 201/201 (includes the new test); ruff clean.
- Live UI check on a worktree dashboard with a seeded race: cards show "knows to 2025-01" beside Gemini's "No 2026 models exist." reply, scoreboard column renders, kimi-k2.7 shows a dash, no console errors.
- Gate note: the judge phase currently fails on deepeval API drift in `evals/judge/anthropic_judge.py` (pre-existing, untouched here) and the live `chitchat-no-action` case is flaky with kimi-k3 — both flagged as separate tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)