### PR TITLE
Protect main properly, and document the flow that replaces direct pushes

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -18,6 +18,35 @@ description: Commit and push the current work properly — lint, run the release
    - Body: WHY the change exists, what evidence motivated it (live bug, trace,
      eval failure), and what verification it survived.
    - End with: `Co-Authored-By: Claude <the current model's attribution line>`
-5. `git push origin main`.
-6. Confirm CI: `gh run list --limit 1` — if CI fails, fix forward immediately;
-   don't leave main red.
+5. **Push via a branch and a PR — `git push origin main` will be REJECTED.**
+   Since 2026-07-26 `main` requires the `skills-and-evals` check to be green
+   BEFORE a commit can land, and `enforce_admins` is on, so this applies to Sean
+   and to Claude equally. There is no bypass and you should not look for one.
+
+   ```bash
+   git checkout -b <short-topic-branch>
+   git push -u origin HEAD
+   gh pr create --fill                    # body already written in step 4
+   gh pr checks --watch                   # ~30s
+   gh pr merge --squash --delete-branch   # ONLY Sean's own work, see below
+   git checkout main && git pull -q
+   ```
+
+   The rejection looks like `GH006: Protected branch update failed` — that is
+   the guard working, not a broken setup. Don't retry with `--force`; force
+   pushes to main are blocked too.
+
+6. **A community PR is never merged here.** This procedure covers Sean's own
+   work. Merging someone else's PR requires his explicit per-PR go-ahead — see
+   the `review-pr` skill's hard rule.
+
+7. If CI goes red after a merge, fix forward immediately — don't leave main red.
+
+## Why the extra steps
+
+Eight commits landed on main in one session on 2026-07-26 while
+`enforce_admins` was off. Every push printed `Bypassed rule violations` and
+went through anyway; CI ran AFTER each one rather than gating it. All eight
+happened to be green, so nothing broke — but a red commit would have landed
+exactly the same way. CI takes ~30 seconds. The branch-and-PR round trip costs
+about a minute and makes a broken main impossible rather than unlikely.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,12 +31,19 @@ for its own sake is not.
   *immediately before each run*. Permission never carries over from a previous run.
   The script backs up first, but restoring is a hassle — ask, wait for a clear yes,
   then run. It refuses to do anything without the `--yes` flag for this reason.
-- **Version control — commit AND push every milestone, same turn.** The moment a change
+- **Version control — commit AND ship every milestone, same turn.** The moment a change
   works (tests pass / verified live), commit it with a detailed message (subject = what,
-  body = WHY + what it survived) and `git push origin main` before moving on. Never end a
+  body = WHY + what it survived) and get it onto GitHub before moving on. Never end a
   turn or session with working changes left uncommitted — the repo must always be traceable
   from GitHub, and uncommitted work has been lost to branch switches before. Use the `/ship`
   skill. If several milestones land in one session, commit each as its own logical commit.
+- **`main` is protected — `git push origin main` is REJECTED, for everyone.** Since
+  2026-07-26 a commit only lands once `skills-and-evals` is green, and `enforce_admins`
+  is on, so the rule binds Sean and Claude identically. Ship via
+  `git checkout -b <topic>` → `gh pr create --fill` → `gh pr checks --watch` (~30s) →
+  `gh pr merge --squash --delete-branch`. `GH006: Protected branch update failed` is the
+  guard working; never route around it. Merging a COMMUNITY PR still needs Sean's
+  explicit per-PR yes (see `.claude/skills/review-pr/SKILL.md`).
 - **Gate before push**: `make gate` (deterministic must pass; judge runs with a key).
   When a live bug is found, fix it AND add a regression case to `evals/deterministic/`.
 - **No emojis** in any UI surface (dashboard, CLI output, README prose).


### PR DESCRIPTION
enforce_admins was off, so branch protection on main was advisory for the only
two accounts that can push to it. Every push this session printed "Bypassed
rule violations - Required status check skills-and-evals is expected" and went
through; CI ran AFTER the commit landed instead of gating it. All eight were
green, so nothing broke — but a red commit would have landed identically.

Now on. Verified by trying to push a probe commit straight to main:

    remote: error: GH006: Protected branch update failed for refs/heads/main.
    remote: - Required status check "skills-and-evals" is expected.
    ! [remote rejected] _gate_probe -> main (protected branch hook declined)

Rejected, not bypassed. The probe branch was deleted and main is untouched.

Checked while in there, and NOT changed, because they were already right:
  * ShenSeanChen is the ONLY account with push access. No contributor can write
    to this repo; forks + PRs are the only path in, and merging is a click Sean
    owns. This was never at risk.
  * the required check name "skills-and-evals" really does match the job name
    inside validate-skills.yml, and reports success — a mismatch there would
    have blocked every PR forever with no obvious cause.
  * force pushes and branch deletion on main: already blocked.

CLAUDE.md and the /ship skill said `git push origin main`, which is now simply
wrong and would have had the next session fighting the guard. Both now describe
the branch → PR → checks → squash-merge round trip, and both say plainly that
GH006 is the guard working rather than a broken setup, so nobody goes looking
for a bypass. /ship also picked up an explicit line that it covers Sean's OWN
work only — merging a community PR still needs his per-PR go-ahead.

This commit is itself the first trip through the new flow.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
