### PR TITLE
Mark the launch-day architecture diagram superseded instead of deleting it

### DIFF
--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -47,7 +47,32 @@
   footer{max-width:1300px;margin:26px auto 0;padding:0 6px;color:var(--muted);font-size:13px}
   footer a{color:var(--blue);text-decoration:none}
   @media (max-width:720px){.cap{grid-template-columns:1fr}h1{font-size:24px}}
+  /* Superseded notice — added 2026-07-26. See the <!-- SUPERSEDED --> block. */
+  .superseded{
+    margin:0 0 22px; padding:14px 18px; border-radius:10px;
+    border:2px solid var(--orange); background:var(--orange-soft); color:var(--ink);
+    font:15px/1.5 system-ui, -apple-system, sans-serif;
+  }
+  .superseded b{ color:var(--orange); }
+  .superseded a{ color:inherit; }
 </style>
+
+<!-- SUPERSEDED -------------------------------------------------------------
+     This diagram is from the original launch (last real edit 2026-07-11) and is
+     now WRONG, not merely old: it predates the Discord gateway, the model
+     Arena, delegate_task -> pi, the Notion episodic backend and Google
+     Calendar. Nothing in the repo links here; it is kept only so the first
+     picture of waku isn't lost. The current diagrams live in docs/whiteboards/.
+     If you are looking for how waku works TODAY, start with the README and
+     waku/ops/README.md.
+------------------------------------------------------------------------- -->
+<div class="superseded">
+  <b>Superseded — this is the launch-day diagram, kept for history.</b><br>
+  It predates the Discord gateway, the model Arena, <code>delegate_task &rarr; pi</code>,
+  the Notion memory backend and Google Calendar. For how waku works today see the
+  <a href="https://github.com/ShenSeanChen/waku-agent#readme">README</a> and
+  <code>docs/whiteboards/waku-architecture.excalidraw</code>.
+</div>
 
 <header>
   <h1><span class="hl">waku-agent</span> &mdash; the readable Waku</h1>


### PR DESCRIPTION
docs/architecture.html is linked from nothing and its last real edit was the
jarvis -> waku rename on 2026-07-11. I first proposed deleting it as
housekeeping, which was the wrong framing: 19KB of unlinked clutter is not a
problem worth a commit.

The actual problem is that the diagram is WRONG, not merely old. It shows Voice
and Telegram as the gateways; it predates Discord, the model Arena,
delegate_task -> pi, the Notion episodic backend and Google Calendar. For most
repos a stale doc is harmless. Not for this one — people come to waku-agent FOR
the architecture picture, so a confidently-drawn diagram of a system that no
longer exists, sitting in the repo with Sean's name on it, is worse than
clutter. Someone browsing files on GitHub will find it whether or not anything
links to it.

Deleting would have fixed the misinformation and lost the artifact. A banner
fixes the misinformation and keeps it — this was the first picture of waku and
it is the only place that version survives outside git history.

So: an orange notice at the top naming exactly what it predates and pointing at
the README and docs/whiteboards/waku-architecture.excalidraw, plus an HTML
comment saying the same thing for anyone reading the source rather than the
page. The notice uses the file's own CSS variables, so it themes with the rest
of the document instead of looking bolted on.

274/274 offline deterministic, ruff clean, HTML parses.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
