### PR TITLE
Add OpenCode Zen and Go providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # ── Provider ────────────────────────────────────────────────────────────────
 # Pick ONE provider and paste its key below. That's the whole setup.
-#   anthropic (default) · openai · gemini · deepseek · minimax · kimi · glm · openrouter
+#   anthropic (default) · openai · gemini · deepseek · minimax · kimi · glm · openrouter · opencode_zen · opencode_go
 # No paid key? openrouter's default models are $0 ":free" ids (rate-limited).
 WAKU_PROVIDER=anthropic
 
@@ -24,6 +24,10 @@ ZHIPU_API_KEY=
 OPENROUTER_API_KEY=
 # xai / grok → https://console.x.ai
 XAI_API_KEY=
+# opencode zen → https://opencode.ai/zen/v1
+OPENCODE_ZEN_API_KEY=
+# opencode go → https://opencode.ai/zen/go/v1
+OPENCODE_GO_API_KEY=
 
 # ── Models (optional) ───────────────────────────────────────────────────────
 # Each provider has sensible defaults (see waku/loop/models.py PROVIDERS):

--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ laptop. Set `TELEGRAM_BOT_TOKEN` and it starts your bot too. (`make dashboard` w
 file: `.waku/state.db`.
 
 **Use the model you already pay for.** Anthropic (default), OpenAI, Gemini, DeepSeek, MiniMax,
-Kimi, GLM, or OpenRouter (one key, hundreds of hosted models) — set `WAKU_PROVIDER=`, paste the key,
-done. One dialect in the loop; a [~60-line adapter](waku/loop/models.py) handles the rest.
+Kimi, GLM, OpenRouter (one key, hundreds of hosted models), OpenCode Zen, or OpenCode Go —
+set `WAKU_PROVIDER=`, paste the key, done. One dialect in the loop;
+a [~60-line adapter](waku/loop/models.py) handles the rest.
 
 ## Watch the harness run — the dashboard
 

--- a/evals/deterministic/test_pinned_models.py
+++ b/evals/deterministic/test_pinned_models.py
@@ -20,7 +20,7 @@ from waku.ops import settings_api as d
 
 PROVIDER_KEYS = ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY", "DEEPSEEK_API_KEY",
                  "MINIMAX_API_KEY", "MOONSHOT_API_KEY", "ZHIPU_API_KEY", "OPENROUTER_API_KEY",
-                 "XAI_API_KEY")
+                 "XAI_API_KEY", "OPENCODE_ZEN_API_KEY", "OPENCODE_GO_API_KEY")
 
 
 @pytest.fixture
@@ -33,6 +33,10 @@ def home(tmp_path, monkeypatch):
     (tmp_path / ".env").write_text("")
     for var in PROVIDER_KEYS:
         monkeypatch.delenv(var, raising=False)
+    # apply_settings bypasses monkeypatch and writes directly to os.environ,
+    # so WAKU_PROVIDER must also be tracked to prevent leaking into later
+    # tests (test_tool_trigger would inherit a stale provider and crash).
+    monkeypatch.delenv("WAKU_PROVIDER", raising=False)
     return tmp_path
 
 
@@ -157,7 +161,8 @@ def test_known_catalog_providers_can_list(home):
     they intentionally show their curated defaults until we wire+verify one."""
     from waku.loop.models import PROVIDERS
 
-    CAN_LIST = {"anthropic", "openai", "openrouter", "gemini", "deepseek", "kimi", "xai"}
+    CAN_LIST = {"anthropic", "openai", "openrouter", "gemini", "deepseek", "kimi", "xai",
+                "opencode_zen", "opencode_go"}
     for name in CAN_LIST:
         prov = PROVIDERS[name]
         can_list = bool(prov.catalog_url) or (prov.kind == "openai" and bool(prov.base_url))

--- a/waku/loop/models.py
+++ b/waku/loop/models.py
@@ -95,6 +95,17 @@ PROVIDERS: dict[str, Provider] = {
     "xai":       Provider("openai", "XAI_API_KEY", "https://api.x.ai/v1",
                           "grok-4", "grok-4-fast",
                           catalog_url="https://api.x.ai/v1/models"),
+    # OpenCode — OpenAI-compatible platform. Two endpoints: "zen" and "go"
+    # share the same platform key. zen offers free models (default:
+    # deepseek-v4-flash-free); go uses the standard deepseek-v4-flash.
+    # The live catalog (GET /models) lists whatever the endpoint serves,
+    # and the picker is the authoritative menu.
+    "opencode_zen": Provider("openai", "OPENCODE_ZEN_API_KEY",
+                               "https://opencode.ai/zen/v1",
+                               "deepseek-v4-flash-free", "deepseek-v4-flash-free"),
+    "opencode_go":  Provider("openai", "OPENCODE_GO_API_KEY",
+                               "https://opencode.ai/zen/go/v1",
+                               "deepseek-v4-flash", "deepseek-v4-flash"),
 }
 
 

--- a/waku/ops/catalog.py
+++ b/waku/ops/catalog.py
@@ -107,10 +107,13 @@ def list_models(provider: str | None = None) -> dict:
         return {**out, "listed": False,
                 "models": _known_default_ids(prov, out, name == s.provider), "error": msg}
     # send both auth styles — Bearer for OpenAI-compatible catalogs, x-api-key +
-    # version for Anthropic's; each server reads the header it knows
+    # version for Anthropic's; each server reads the header it knows.
+    # Set a browser-like User-Agent: some OpenAI-compatible proxies (e.g.
+    # opencode.ai) block Python-urllib/3.x with a 403 / error code 1010.
     req = urllib.request.Request(url, headers={
         "Authorization": f"Bearer {key}",
         "x-api-key": key, "anthropic-version": "2023-06-01",
+        "User-Agent": "Mozilla/5.0 (compatible; Waku)",
     })
     try:
         with urllib.request.urlopen(req, timeout=10) as resp:

--- a/waku/ops/coding_eval.py
+++ b/waku/ops/coding_eval.py
@@ -35,6 +35,7 @@ PI_PROVIDER = {
     "anthropic": "anthropic", "openai": "openai", "gemini": "google",
     "kimi": "moonshotai", "xai": "xai", "glm": "zai",
     "deepseek": "deepseek", "minimax": "minimax", "openrouter": "openrouter",
+    "opencode_zen": "opencode_zen", "opencode_go": "opencode_go",
 }
 
 

--- a/waku/ops/pricing.py
+++ b/waku/ops/pricing.py
@@ -31,6 +31,8 @@ PRICING = {
     "anthropic": (3.0, 15.0), "openai": (2.5, 15.0), "gemini": (0.3, 2.5),
     "deepseek": (0.435, 0.87), "minimax": (0.30, 1.20), "kimi": (0.6, 2.5), "glm": (0.6, 2.2),
     "xai": (3.0, 15.0),   # Grok — rough est; keyed users get exact from the catalog
+    "opencode_zen": (0.435, 0.87),   # rough est (matching deepseek — same underlying model)
+    "opencode_go": (0.435, 0.87),    # rough est
     # openrouter fallback for paid models when the live catalog is unreachable
     # (rough mid-catalog guess). ":free" ids and catalog-priced models never
     # hit this: see price_for().
@@ -69,6 +71,10 @@ MODEL_PRICING = {
     # xAI Grok — docs.x.ai/developers/pricing
     "grok-4.5": (2.0, 6.0),
     "grok-4.3": (1.25, 2.5),
+    # OpenCode / deepseek — the default model for opencode_go
+    "deepseek-v4-flash": (0.15, 0.30),
+    # free tier on opencode_zen
+    "deepseek-v4-flash-free": (0.0, 0.0),
 }
 
 
@@ -99,6 +105,9 @@ MODEL_CUTOFF = {
     # xAI Grok — docs.x.ai model list
     "grok-4.5": "2026-02",
     "grok-4.3": "2025-12",
+    # OpenCode / deepseek
+    "deepseek-v4-flash": "2026-04",
+    "deepseek-v4-flash-free": "2026-04",
 }
 
 


### PR DESCRIPTION
Add two new OpenAI-compatible LLM providers from OpenCode (opencode.ai):

- opencode_zen: https://opencode.ai/zen/v1 — default model deepseek-v4-flash-free
- opencode_go: https://opencode.ai/zen/go/v1 — default model deepseek-v4-flash

Both reuse the existing OpenAICompatClient (~60-line adapter that translates
Anthropic Messages shape to OpenAI chat.completions wire format). No new
dependencies, no new wire code.

Changes:
- waku/loop/models.py: register both providers in PROVIDERS dict
- waku/ops/pricing.py: add PRICING, MODEL_PRICING, MODEL_CUTOFF entries
- waku/ops/catalog.py: set a browser-like User-Agent for model listing
  (opencode.ai blocks Python-urllib/3.x with 403 error code 1010)
- waku/ops/coding_eval.py: add PI_PROVIDER mapping for pi sub-agent
- .env.example: document OPENCODE_ZEN_API_KEY and OPENCODE_GO_API_KEY
- README.md: list both in the provider intro paragraph
- evals/deterministic/test_pinned_models.py: add new keys to PROVIDER_KEYS
  fixture + track WAKU_PROVIDER to prevent env leak into test_tool_trigger

Tested: 275 offline deterministic evals pass, 40 provider tests pass,
real chat completion verified on opencode_go endpoint.
