### PR TITLE
feat(gcal): replace gcloud ADC with InstalledAppFlow OAuth

### DIFF
--- a/evals/deterministic/test_gcal_oauth.py
+++ b/evals/deterministic/test_gcal_oauth.py
@@ -1,0 +1,207 @@
+"""DETERMINISTIC EVAL — Google Calendar InstalledAppFlow OAuth flow."""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+from waku.tools import calendar
+
+
+def _install_fake_oauth_modules(monkeypatch, *, execute_error: Exception | None = None):
+    captured = {}
+
+    google = ModuleType("google")
+
+    # google.auth
+    google_auth = ModuleType("google.auth")
+    google_auth_requests = ModuleType("google.auth.transport.requests")
+
+    class Request:
+        pass
+
+    google_auth_requests.Request = Request
+    google_auth.transport = ModuleType("google.auth.transport")
+    google_auth.transport.requests = google_auth_requests
+    google.auth = google_auth
+
+    # google.oauth2.credentials
+    google_oauth2 = ModuleType("google.oauth2")
+    google_oauth2_credentials = ModuleType("google.oauth2.credentials")
+
+    class FakeCredentials:
+        def __init__(self, valid=True, expired=False, refresh_token="ref-token"):
+            self.valid = valid
+            self.expired = expired
+            self.refresh_token = refresh_token
+            self.refreshed = False
+
+        @classmethod
+        def from_authorized_user_file(cls, path, scopes=None):
+            captured["loaded_token_path"] = path
+            captured["loaded_scopes"] = scopes
+            return FakeCredentials(valid=captured.get("creds_valid", True), expired=captured.get("creds_expired", False))
+
+        def refresh(self, request):
+            captured["refreshed"] = True
+            self.valid = True
+            self.expired = False
+
+        def to_json(self):
+            return '{"token": "fake-oauth-token"}'
+
+    google_oauth2_credentials.Credentials = FakeCredentials
+    google_oauth2.credentials = google_oauth2_credentials
+    google.oauth2 = google_oauth2
+
+    # google_auth_oauthlib.flow
+    google_auth_oauthlib = ModuleType("google_auth_oauthlib")
+    google_auth_oauthlib_flow = ModuleType("google_auth_oauthlib.flow")
+
+    class FakeInstalledAppFlow:
+        @classmethod
+        def from_client_secrets_file(cls, path, scopes=None):
+            captured["client_secrets_path"] = path
+            captured["flow_scopes"] = scopes
+            return FakeInstalledAppFlow()
+
+        def run_local_server(self, port=0):
+            captured["ran_local_server_port"] = port
+            return FakeCredentials()
+
+    google_auth_oauthlib_flow.InstalledAppFlow = FakeInstalledAppFlow
+    google_auth_oauthlib.flow = google_auth_oauthlib_flow
+
+    # httplib2 & google_auth_httplib2
+    httplib2 = ModuleType("httplib2")
+
+    def http(*, timeout):
+        captured["timeout"] = timeout
+        return "bounded-http"
+
+    httplib2.Http = http
+
+    google_auth_httplib2 = ModuleType("google_auth_httplib2")
+
+    def authorized_http(credentials, *, http):
+        captured["credentials"] = credentials
+        captured["http"] = http
+        return "authorized-http"
+
+    google_auth_httplib2.AuthorizedHttp = authorized_http
+
+    # googleapiclient.discovery
+    class FakeRequest:
+        def execute(self, *, num_retries):
+            captured["num_retries"] = num_retries
+            if execute_error is not None:
+                raise execute_error
+            return {"id": "google-event"}
+
+    class FakeEvents:
+        def insert(self, **kwargs):
+            captured["insert"] = kwargs
+            return FakeRequest()
+
+    class FakeService:
+        def events(self):
+            return FakeEvents()
+
+    discovery = ModuleType("googleapiclient.discovery")
+
+    def build(name, version, **kwargs):
+        captured["build"] = (name, version, kwargs)
+        return FakeService()
+
+    discovery.build = build
+    googleapiclient = ModuleType("googleapiclient")
+    googleapiclient.discovery = discovery
+
+    for name, module in {
+        "google": google,
+        "google.auth": google_auth,
+        "google.auth.transport": google_auth.transport,
+        "google.auth.transport.requests": google_auth_requests,
+        "google.oauth2": google_oauth2,
+        "google.oauth2.credentials": google_oauth2_credentials,
+        "google_auth_oauthlib": google_auth_oauthlib,
+        "google_auth_oauthlib.flow": google_auth_oauthlib_flow,
+        "httplib2": httplib2,
+        "google_auth_httplib2": google_auth_httplib2,
+        "googleapiclient": googleapiclient,
+        "googleapiclient.discovery": discovery,
+    }.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    return captured
+
+
+def test_missing_credentials_json_reports_honest_failure(tmp_path, monkeypatch):
+    _install_fake_oauth_modules(monkeypatch)
+
+    result = calendar.sync_to_google_calendar(
+        title="Sync test",
+        start="2026-07-28T10:00+08:00",
+        end="2026-07-28T11:00+08:00",
+        home=tmp_path,
+    )
+
+    assert "credentials.json not found" in result
+    assert "still in the local calendar" in result
+
+
+def test_oauth_flow_runs_and_caches_token(tmp_path, monkeypatch):
+    captured = _install_fake_oauth_modules(monkeypatch)
+    creds_file = tmp_path / "credentials.json"
+    creds_file.write_text('{"installed": {}}', encoding="utf-8")
+
+    result = calendar.sync_to_google_calendar(
+        title="Planning",
+        start="2026-07-28T10:00+08:00",
+        end="2026-07-28T11:00+08:00",
+        home=tmp_path,
+    )
+
+    assert captured["client_secrets_path"] == str(creds_file)
+    assert captured["ran_local_server_port"] == 0
+    token_file = tmp_path / "token.json"
+    assert token_file.exists()
+    assert 'fake-oauth-token' in token_file.read_text()
+    assert "Also added to Google Calendar" in result
+
+
+def test_valid_cached_token_is_reused_without_reauth(tmp_path, monkeypatch):
+    captured = _install_fake_oauth_modules(monkeypatch)
+    token_file = tmp_path / "token.json"
+    token_file.write_text('{"token": "existing"}', encoding="utf-8")
+
+    result = calendar.sync_to_google_calendar(
+        title="Planning",
+        start="2026-07-28T10:00+08:00",
+        end="2026-07-28T11:00+08:00",
+        home=tmp_path,
+    )
+
+    assert captured["loaded_token_path"] == str(token_file)
+    assert "client_secrets_path" not in captured
+    assert "Also added to Google Calendar" in result
+
+
+def test_expired_token_is_refreshed(tmp_path, monkeypatch):
+    captured = _install_fake_oauth_modules(monkeypatch)
+    captured["creds_valid"] = False
+    captured["creds_expired"] = True
+
+    token_file = tmp_path / "token.json"
+    token_file.write_text('{"token": "expired"}', encoding="utf-8")
+
+    result = calendar.sync_to_google_calendar(
+        title="Planning",
+        start="2026-07-28T10:00+08:00",
+        end="2026-07-28T11:00+08:00",
+        home=tmp_path,
+    )
+
+    assert captured.get("refreshed") is True
+    assert "client_secrets_path" not in captured
+    assert "Also added to Google Calendar" in result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ gcal = [
     "google-api-python-client>=2.0",
     "google-auth>=2.0",
     "google-auth-httplib2>=0.2",
+    "google-auth-oauthlib>=1.0",
     "httplib2>=0.22",
 ]
 # Optional gateway: message Waku from Discord

--- a/waku/tools/calendar.py
+++ b/waku/tools/calendar.py
@@ -153,6 +153,7 @@ def sync_to_google_calendar(
     attendees: str = "",
     notes: str = "",
     calendar_id: str = "primary",
+    home: Path | None = None,
 ) -> str:
     """Create one Google Calendar event without changing the local-first contract."""
     try:
@@ -168,7 +169,58 @@ def sync_to_google_calendar(
         )
 
     try:
-        credentials, _ = google.auth.default(scopes=[GOOGLE_CALENDAR_SCOPE])
+        credentials = None
+        if home is not None:
+            try:
+                from google.auth.transport.requests import Request
+                from google.oauth2.credentials import Credentials
+                from google_auth_oauthlib.flow import InstalledAppFlow
+            except ImportError:
+                return (
+                    "Google Calendar sync FAILED (support is not installed; "
+                    "install with pip install -e '.[gcal]') — the event is still in the "
+                    "local calendar."
+                )
+
+            token_path = home / "token.json"
+            creds_path = home / "credentials.json"
+
+            if token_path.exists():
+                try:
+                    credentials = Credentials.from_authorized_user_file(
+                        str(token_path), scopes=[GOOGLE_CALENDAR_SCOPE]
+                    )
+                except Exception:
+                    credentials = None
+
+            if credentials and credentials.expired and credentials.refresh_token:
+                try:
+                    credentials.refresh(Request())
+                    token_path.parent.mkdir(parents=True, exist_ok=True)
+                    token_path.write_text(credentials.to_json(), encoding="utf-8")
+                except Exception:
+                    credentials = None
+
+            if not credentials or not credentials.valid:
+                if not creds_path.exists():
+                    root_creds = Path("credentials.json")
+                    if root_creds.exists():
+                        creds_path = root_creds
+                    else:
+                        return (
+                            "Google Calendar sync FAILED (credentials.json not found in "
+                            f"{home / 'credentials.json'}; download OAuth 2.0 Client ID "
+                            "credentials from Google Cloud Console) — the event is still in the local calendar."
+                        )
+                flow = InstalledAppFlow.from_client_secrets_file(
+                    str(creds_path), scopes=[GOOGLE_CALENDAR_SCOPE]
+                )
+                credentials = flow.run_local_server(port=0)
+                token_path.parent.mkdir(parents=True, exist_ok=True)
+                token_path.write_text(credentials.to_json(), encoding="utf-8")
+        else:
+            credentials, _ = google.auth.default(scopes=[GOOGLE_CALENDAR_SCOPE])
+
         bounded_http = httplib2.Http(timeout=GOOGLE_CALENDAR_TIMEOUT)
         authorized_http = google_auth_httplib2.AuthorizedHttp(
             credentials, http=bounded_http
@@ -253,6 +305,7 @@ def make_tool(
                 attendees,
                 notes,
                 calendar_id=google_calendar_id,
+                home=home,
             )
         if not apple_calendar and not google_calendar:
             where += (


### PR DESCRIPTION
Closes #31

## Summary of Changes
- **Dependencies**: Added \google-auth-oauthlib>=1.0\ under the \gcal\ extra in \pyproject.toml\.
- **OAuth Authentication**: Replaced \google.auth.default()\ with \InstalledAppFlow.from_client_secrets_file\ for in-app browser consent flow.
- **Token Caching & Auto-Refresh**: Saved authorization token to \.waku/token.json\ (gitignored). Refreshes token automatically when expired.
- **Honest Error Handling**: If \.waku/credentials.json\ is missing, returns an explicit error explaining where to obtain OAuth Client ID credentials.
- **Backward Compatibility & Testing**: Added \home: Path | None = None\ parameter to \sync_to_google_calendar\. Retained \google.auth.default()\ fallback when \home=None\ so existing \	est_google_calendar.py\ passes completely unchanged. Added new deterministic tests in \evals/deterministic/test_gcal_oauth.py\.