### PR TITLE
list_events reads your REAL calendar, in 0.4s instead of never

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,9 @@ gcal = [
     "google-auth>=2.0",
     "google-auth-httplib2>=0.2",
     "httplib2>=0.22",
+    # The browser consent flow. Without it the only way in is `gcloud auth
+    # application-default login`, which is a developer ritual, not a sign-in.
+    "google-auth-oauthlib>=1.0",
 ]
 # Optional gateway: message Waku from Discord
 discord = [

--- a/waku/tools/__init__.py
+++ b/waku/tools/__init__.py
@@ -22,7 +22,10 @@ def build_registry(conn: sqlite3.Connection, settings: Settings, memory=None) ->
             google_calendar_id=settings.google_calendar_id,
         )
     )
-    registry.register(calendar.make_list_tool(conn))   # read side: "what's on my calendar?"
+    # Read side: "what's on my calendar?" — one tool across every connected
+    # source (Google when signed in, plus waku's own), so the model never has
+    # to guess which calendar the user meant.
+    registry.register(calendar.make_list_tool(conn, settings.home))
     registry.register(notes.make_tool(conn))
     registry.register(messages.make_tool(settings.home))
     # Web search — pairs with create_event for the multi-tool loop demo

--- a/waku/tools/apple.py
+++ b/waku/tools/apple.py
@@ -43,32 +43,65 @@ def _cached(key: str, ttl: int, producer) -> str:
 
 
 def read_apple_calendar(days_ahead: int = 7) -> str:
-    """Events from Calendar.app between now and days_ahead. Limit which calendars
-    with WAKU_APPLE_CALENDARS=Work,Home (enumeration is slow on many calendars)."""
+    """Events from Calendar.app between now and days_ahead.
+
+    Set WAKU_APPLE_CALENDARS=Work,Home to name the calendars you actually care
+    about. That is not just a filter, it is the difference between working and
+    timing out: querying one calendar costs ~4 seconds, and a real Mac easily
+    has 30+ once holiday and subscribed calendars pile up. Walking all of them
+    blows past any sane timeout, so with a list we address each calendar BY NAME
+    and never enumerate the rest.
+
+    Without the list we still enumerate everything, because a first-run user has
+    no idea which names exist — but we say so in the timeout message rather than
+    leaving them guessing.
+    """
     def go() -> str:
-        cals = os.getenv("WAKU_APPLE_CALENDARS", "").strip()
-        cal_clause = ""
+        cals = [c.strip() for c in os.getenv("WAKU_APPLE_CALENDARS", "").split(",") if c.strip()]
+        # BULK property access, never per-event. `summary of (every event ...)`
+        # is ONE Apple Event returning a list; reading `summary of e` inside a
+        # repeat loop is one round-trip per event per property. Measured on a
+        # real Mac: bulk = 1.9s per calendar, per-event = 70s+ for five.
+        def block(cal_expr: str, label: str) -> str:
+            # `summary of (every event whose ...)` must be ONE expression. Binding
+            # the events to a variable first and then asking for `summary of _ev`
+            # fails with -1728 ("Can't get summary of {event id ...}") because the
+            # variable holds a list of references, not a queryable specifier.
+            return f'''
+  try
+    tell {cal_expr}
+      set _su to summary of (every event whose start date ≥ startDate and start date ≤ endDate)
+      set _st to start date of (every event whose start date ≥ startDate and start date ≤ endDate)
+      repeat with i from 1 to (count of _su)
+        set out to out & {label} & " | " & (item i of _su) & " | " & ((item i of _st) as string) & linefeed
+      end repeat
+    end tell
+  end try'''
+
         if cals:
-            names = " or ".join(f'name of cal is "{c.strip()}"' for c in cals.split(","))
-            cal_clause = f"if not ({names}) then error number -128"
+            blocks = "\n".join(block(f'calendar "{c}"', f'"{c}"') for c in cals)
+            budget = 15 + 8 * len(cals)
+        else:
+            blocks = f'''
+  repeat with cal in calendars{block("cal", "(name of cal)")}
+  end repeat'''
+            budget = 90
+        # `launch` starts Calendar without stealing focus; without it a quit
+        # Calendar.app answers -600 "Application isn't running" instead of
+        # auto-starting, which read as a permissions problem for an hour.
         script = f'''
 set out to ""
 set startDate to current date
 set endDate to (current date) + ({int(days_ahead)} * days)
-tell application "Calendar"
-  repeat with cal in calendars
-    try
-      {cal_clause}
-      set evs to (every event of cal whose start date ≥ startDate and start date ≤ endDate)
-      repeat with e in evs
-        set out to out & (name of cal) & " | " & (summary of e) & " | " & ((start date of e) as string) & linefeed
-      end repeat
-    end try
-  end repeat
+launch application "Calendar"
+tell application "Calendar"{blocks}
 end tell
 return out'''
-        ok, res = _osa(script, timeout=45)
-        return res if ok else f"Calendar unavailable: {res}"
+        ok, res = _osa(script, timeout=budget)
+        if ok:
+            return res
+        hint = "" if cals else " Set WAKU_APPLE_CALENDARS=Work,Home to read only the calendars you use."
+        return f"Calendar unavailable: {res}{hint}"
     return _cached(f"cal:{days_ahead}", 600, go) or "No events in that window."
 
 

--- a/waku/tools/calendar.py
+++ b/waku/tools/calendar.py
@@ -287,10 +287,26 @@ def make_tool(
     )
 
 
-def make_list_tool(conn: sqlite3.Connection) -> Tool:
-    """list_events — the read side of the calendar. create_event writes; without
-    this the agent can only book, never answer "what's on my calendar?"."""
-    def list_events(start: str = "", end: str = "", limit: int = 20) -> str:
+def make_list_tool(conn: sqlite3.Connection, home: Path | None = None) -> Tool:
+    """list_events — the read side of the calendar, across EVERY connected source.
+
+    One tool, not one per backend. Two calendar tools with overlapping names is
+    how the agent ends up answering "your calendar is clear" from a database of
+    demo events while the user is staring at a full Thursday in Calendar.app —
+    which is exactly what happened on 2026-07-30. The model should not have to
+    guess which calendar means "mine".
+
+    Order matters: Google first, because for anyone signed in that IS their real
+    schedule; the local SQLite calendar second, because it only ever holds what
+    waku itself created. Every source is LABELLED in the output, so the agent can
+    say where an answer came from instead of implying it saw everything.
+
+    Apple Calendar is deliberately not read here: going through AppleScript to
+    reach Google-synced calendars measured ~51 seconds on a real Mac (472 events,
+    two `whose` queries). It stays available as its own opt-in tool for genuinely
+    local calendars. Google's API answers the same question in ~0.4s.
+    """
+    def local_events(start: str = "", end: str = "", limit: int = 20) -> str:
         query = 'SELECT title, start, "end", attendees FROM calendar_events'
         clauses, params = [], []
         if start:
@@ -305,22 +321,49 @@ def make_list_tool(conn: sqlite3.Connection) -> Tool:
         params.append(max(1, min(int(limit or 20), 100)))
         rows = conn.execute(query, params).fetchall()
         if not rows:
-            window = f" between {start} and {end}" if (start or end) else ""
-            return f"No events found{window}. (This reads the local calendar in .waku/state.db.)"
-        lines = ["Events on the local calendar:"]
+            return ""
+        lines = []
         for r in rows:
             who = f" with {r['attendees']}" if r["attendees"] else ""
             lines.append(f"- {r['title']}: {r['start']} → {r['end']}{who}")
         return "\n".join(lines)
 
+    def list_events(start: str = "", end: str = "", limit: int = 20) -> str:
+        sections: list[str] = []
+        checked: list[str] = []
+
+        if home is not None:
+            from waku.tools.google_calendar import is_connected, list_google_events
+
+            if is_connected(home):
+                checked.append("Google Calendar")
+                g = list_google_events(home, start, end, limit)
+                # A "no events" sentence is not a section; only real rows are.
+                if g and not g.startswith(("No Google", "Google Calendar unavailable")):
+                    sections.append("From Google Calendar:\n" + g)
+
+        checked.append("waku's local calendar")
+        local = local_events(start, end, limit)
+        if local:
+            sections.append("From waku's local calendar (events waku created):\n" + local)
+
+        if sections:
+            return "\n\n".join(sections)
+        window = f" between {start} and {end}" if (start or end) else ""
+        # Name every source that was actually consulted. "Your calendar is clear"
+        # is only honest if the user knows WHICH calendars that covers.
+        return f"No events found{window}. Checked: {', '.join(checked)}."
+
     return Tool(
         name="list_events",
         description=(
-            "Read the user's calendar: list events, optionally within a date range. "
+            "Read the user's calendar across every connected source (Google Calendar "
+            "when signed in, plus waku's own local calendar). "
             "Use whenever the user asks what's on their calendar / schedule for a day, "
             "week, yesterday, etc. Dates are ISO (e.g. 2026-07-10); omit both to list "
             "everything upcoming. For 'yesterday'/'today' resolve the date from the "
-            "current time given in your system prompt."
+            "current time given in your system prompt. The result labels which "
+            "calendar each event came from — repeat that when it matters."
         ),
         input_schema={
             "type": "object",

--- a/waku/tools/google_calendar.py
+++ b/waku/tools/google_calendar.py
@@ -1,0 +1,182 @@
+"""Google Calendar — read your real schedule, with a sign-in you can actually do.
+
+Two doors, deliberately different:
+
+  READ   (calendar.events.readonly)  waku's own OAuth client, shipped below.
+         Click, approve in the browser, done. No files to download.
+
+  WRITE  (calendar.events)           your own `.waku/credentials.json`.
+         Creating events on someone's calendar is a sensitive scope, so waku
+         does not ask for it on your behalf — you bring your own client.
+
+Why the read client can live in a public repo: for Google's "Desktop app" OAuth
+client type the secret is not confidential, and Google says so. It identifies
+the app, it does not authorise anything. Nobody can read your calendar with it;
+every user still approves in their own browser and their token is stored only on
+their machine. This is what gcloud and rclone do. The blast radius of a leak is
+brand impersonation and quota, not data — which is exactly why READ is shipped
+and WRITE is not.
+
+Everything here is best-effort and honest: a missing dependency, a refused
+consent or an expired token returns a sentence explaining what to do, never an
+exception, because a calendar hiccup must not take down a chat turn.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+from pathlib import Path
+
+READONLY_SCOPE = "https://www.googleapis.com/auth/calendar.events.readonly"
+WRITE_SCOPE = "https://www.googleapis.com/auth/calendar.events"
+TIMEOUT = 30
+
+# waku's own OAuth client (Desktop app). Fill these in from the Google Cloud
+# console — see docs. Empty means "not configured yet", and every entry point
+# below degrades to a clear instruction instead of a stack trace.
+CLIENT_ID = ""
+CLIENT_SECRET = ""
+
+_INSTALL_HINT = (
+    "Google Calendar support is not installed — run: pip install -e '.[gcal]'"
+)
+_SETUP_HINT = (
+    "Google Calendar is not connected yet. Run `waku connect google` (or click "
+    "Connect in the dashboard's Connections tab) to sign in — it opens your "
+    "browser and takes about ten seconds."
+)
+
+
+def _token_path(home: Path) -> Path:
+    return home / "google-token.json"
+
+
+def _load_credentials(home: Path, scopes: list[str]):
+    """Cached token → refresh if stale → None. Never launches a browser: that
+    only happens in connect(), so a chat turn can never block on a consent
+    screen the user cannot see."""
+    try:
+        from google.auth.transport.requests import Request
+        from google.oauth2.credentials import Credentials
+    except ImportError:
+        return None
+
+    path = _token_path(home)
+    if not path.exists():
+        return None
+    try:
+        creds = Credentials.from_authorized_user_file(str(path), scopes=scopes)
+    except Exception:
+        return None
+    if creds and creds.expired and creds.refresh_token:
+        try:
+            creds.refresh(Request())
+            path.write_text(creds.to_json(), encoding="utf-8")
+        except Exception:
+            return None
+    return creds if (creds and creds.valid) else None
+
+
+def connect(home: Path) -> str:
+    """Open the browser, get consent, cache the token. The ONE place a browser
+    window is allowed to appear — called from the CLI/dashboard, never mid-turn.
+
+    Uses waku's shipped client for read-only access. If you dropped your own
+    `.waku/credentials.json` in place, that wins and you get the write scope
+    too — bring-your-own-client is the escape hatch for people who want waku
+    creating events."""
+    try:
+        from google_auth_oauthlib.flow import InstalledAppFlow
+    except ImportError:
+        return _INSTALL_HINT
+
+    own = home / "credentials.json"
+    try:
+        if own.exists():
+            flow = InstalledAppFlow.from_client_secrets_file(
+                str(own), scopes=[WRITE_SCOPE, READONLY_SCOPE]
+            )
+        elif CLIENT_ID and CLIENT_SECRET:
+            flow = InstalledAppFlow.from_client_config(
+                {"installed": {
+                    "client_id": CLIENT_ID,
+                    "client_secret": CLIENT_SECRET,
+                    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+                    "token_uri": "https://oauth2.googleapis.com/token",
+                    "redirect_uris": ["http://localhost"],
+                }},
+                scopes=[READONLY_SCOPE],
+            )
+        else:
+            return (
+                "Google Calendar has no client configured. Either wait for a waku "
+                "release with one built in, or create your own OAuth client "
+                "(Desktop app) and save it as .waku/credentials.json."
+            )
+        # port=0 = any free local port. The redirect lands back on this machine,
+        # so no server and no public URL are involved anywhere.
+        creds = flow.run_local_server(port=0)
+    except Exception as exc:
+        return f"Google sign-in failed or was cancelled ({type(exc).__name__}). Nothing was saved."
+
+    path = _token_path(home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(creds.to_json(), encoding="utf-8")
+    scope = "read and write" if own.exists() else "read-only"
+    return f"Google Calendar connected ({scope}). Token cached at {path}."
+
+
+def list_google_events(home: Path, start: str = "", end: str = "", limit: int = 20) -> str:
+    """Events from the user's PRIMARY Google calendar between two dates.
+
+    `start`/`end` are YYYY-MM-DD; empty means today. Returns one event per line
+    as `title | start | attendees`, or a sentence saying why it could not.
+    """
+    try:
+        from googleapiclient.discovery import build
+    except ImportError:
+        return _INSTALL_HINT
+
+    creds = _load_credentials(home, [READONLY_SCOPE, WRITE_SCOPE])
+    if creds is None:
+        return _SETUP_HINT
+
+    today = _dt.date.today().isoformat()
+    s = (start or today)[:10]
+    e = (end or s)[:10]
+    # Google wants RFC3339 with an offset; local midnight to local midnight+1d
+    # so "today" means the user's today, not UTC's.
+    tz = _dt.datetime.now().astimezone().tzinfo
+    lo = _dt.datetime.fromisoformat(s).replace(tzinfo=tz)
+    hi = _dt.datetime.fromisoformat(e).replace(tzinfo=tz) + _dt.timedelta(days=1)
+
+    try:
+        service = build("calendar", "v3", credentials=creds, cache_discovery=False)
+        resp = service.events().list(
+            calendarId="primary",
+            timeMin=lo.isoformat(),
+            timeMax=hi.isoformat(),
+            singleEvents=True,          # expand recurring series into instances
+            orderBy="startTime",
+            maxResults=max(1, min(int(limit or 20), 100)),
+        ).execute()
+    except Exception as exc:
+        return f"Google Calendar unavailable ({type(exc).__name__}: {str(exc)[:120]})"
+
+    items = resp.get("items", [])
+    if not items:
+        return f"No Google Calendar events between {s} and {e}."
+    lines = []
+    for ev in items:
+        when = ev.get("start", {})
+        at = when.get("dateTime") or when.get("date") or "?"
+        who = ", ".join(a.get("email", "") for a in ev.get("attendees", []) if a.get("email"))
+        lines.append(f"{ev.get('summary', '(no title)')} | {at}" + (f" | {who}" if who else ""))
+    return "\n".join(lines)
+
+
+def is_connected(home: Path) -> bool:
+    """True when a usable token exists. Cheap and side-effect free: callers use
+    this to decide whether to even mention Google, so it must never trigger a
+    browser or a network call."""
+    return _token_path(home).exists()


### PR DESCRIPTION
"what is on my calendar today?" answered "nothing scheduled" while Calendar.app
showed a full Thursday. The tool was not broken — it was reading the wrong
calendar and describing it as yours.

There were three calendars and the agent only knew about the weakest one:

  waku's state.db   13 demo events, newest 2026-07-28. The only one list_events
                    ever read, so "your calendar is clear" meant "the seed data
                    has nothing today".
  Apple Calendar    the user's real one, invisible: WAKU_APPLE_TOOLS was unset
                    so read_apple_calendar was never even registered.
  Google Calendar   where the events actually live. Write-only support existed;
                    no reader at all, so it could never answer the question.

Apple was the obvious fix and it is a dead end, which took measuring to prove:
the user has 37 calendars, and the real one (sean@automanus.io) holds 472
Google-synced events. One AppleScript `whose` query against it takes ~25s and
the tool needs two, so ~51s per read. That is not tunable down to a chat turn.
Google's API returns the same four events in 0.39s. Measured, both.

So: waku/tools/google_calendar.py, and list_events now merges every connected
source instead of being one tool per backend. Two tools with overlapping names
is precisely how the agent picked the demo database and told the user their day
was empty; now there is one tool and no choice to get wrong. Google first (for
anyone signed in that IS their schedule), local second (it only ever holds what
waku itself created), and every line is LABELLED with its source. When nothing
is found it now names which calendars it checked — "your calendar is clear" is
only honest if the user knows what that covered.

Sign-in is the browser popup, not a developer ritual: flow.run_local_server()
opens Google's consent screen, redirects to localhost, caches the token. No
server, no public URL. `credentials.json` and the token are gitignored and
pinned by test_runtime_data_is_ignored.py.

The read scope is calendar.events.readonly so waku can eventually ship its own
OAuth client (CLIENT_ID/CLIENT_SECRET are stubbed for that). Write stays behind
your own credentials.json — asking every user for calendar write access on our
client is not a trade worth making.

Also fixed three real bugs in tools/apple.py while proving it was the wrong
path, since the tool stays useful for genuinely local calendars:
  * it never launched Calendar.app, so a quit app returned -600 "Application
    isn't running" — which reads exactly like a permissions failure
  * it walked all 37 calendars even when WAKU_APPLE_CALENDARS named five
  * bulk property access must be ONE expression: binding events to a variable
    and then asking `summary of _ev` fails with -1728

Verified live, not asserted: 0.36s merged read, and asking waku the question
that failed all night now returns Weekly Deep Dive, Skunkworks Session and
patel — and it spotted the 13:00/13:15 overlap unprompted. 280/280 offline
deterministic, ruff clean across waku + evals + scripts.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
