### PR TITLE
chore: untrack the stray .venv symlink, make the worktree skill portable

### DIFF
--- a/.claude/skills/pr-worktree/SKILL.md
+++ b/.claude/skills/pr-worktree/SKILL.md
@@ -14,7 +14,7 @@ must never leave a second copy of Sean's API keys on disk. Both have happened.
 ## Setting one up
 
 ```bash
-REPO=/Users/shenseanchen/Developer/waku-agent
+REPO=$(git rev-parse --show-toplevel)
 N=<pr-number>
 git -C $REPO fetch -q origin pull/$N/head:pr-$N
 git -C $REPO worktree add -q ~/Developer/waku-prs/pr$N pr-$N
@@ -78,7 +78,7 @@ the contributor. Leaving it costs disk, confuses future greps, and may be sittin
 on a copy of every key.
 
 ```bash
-REPO=/Users/shenseanchen/Developer/waku-agent
+REPO=$(git rev-parse --show-toplevel)
 # 1. rescue any new env vars into the MAIN .env first (see above)
 # 2. stop anything still running from it
 lsof -ti:7778 | xargs kill -9 2>/dev/null

--- a/.venv
+++ b/.venv
@@ -1,1 +1,0 @@
-/Users/shenseanchen/Developer/waku-agent/.venv


### PR DESCRIPTION
Two things that should never have been public.

.venv was committed as a mode-120000 symlink pointing at
/Users/shenseanchen/Developer/waku-agent/.venv — itself. It arrived via a
stray `ln -sfn` during PR-worktree cleanup and rode into main on 7dbe6bf.

Three separate problems from one entry:
  * it publishes the maintainer's absolute home path
  * a fresh clone that runs `python -m venv .venv` hits a self-referential
    symlink instead of an empty directory
  * it makes `git checkout` refuse to switch branches once a real .venv
    exists at that path, which is how it was finally noticed

.venv/ was already in .gitignore — the entry predated the ignore, so ignore
never applied. `git rm --cached` is the whole fix. No history rewrite: the
path is a directory name, not a secret, and rewriting would break every
contributor's clone for nothing.

The same skill that caused it also hardcoded that path twice, so the
worktree instructions only worked on one machine. $(git rev-parse
--show-toplevel) is correct anywhere, including inside a worktree.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
