### PR TITLE
fix/wheel ships skills and evals ignore dotenv

### DIFF
--- a/evals/deterministic/test_packaging.py
+++ b/evals/deterministic/test_packaging.py
@@ -1,0 +1,124 @@
+"""DETERMINISTIC EVAL — what actually ships, and what a test is allowed to read.
+
+Two failures found on 2026-07-31, both invisible to every other test because
+every other test runs from a git checkout on the maintainer's machine.
+
+1. THE WHEEL SHIPPED NO SKILLS. `pyproject.toml` packages `waku`, but the
+   bundled skills live in `skills/` at the REPO ROOT, so `pip install
+   waku-agent` produced a Waku with zero procedural memory — one of the four
+   pillars, silently absent. The dashboard shipped fine (it lives under
+   `waku/ops/static`), which is exactly why nobody noticed: the thing you can
+   see worked. Nothing here can catch a broken wheel by inspecting a checkout,
+   so these tests pin the two halves of the fix instead — the build config that
+   copies the folder in, and the lookup that finds it once it's there.
+
+2. THE TEST SUITE READ THE DEVELOPER'S `.env`. `waku/config.py` calls
+   load_dotenv() at import, so a stale `WAKU_GRAPH_WORKFLOWS=1` routed every
+   scripted turn through the triage graph, spent one extra model call, and
+   failed 8 tests that were green in CI. A suite whose result depends on an
+   untracked file is not deterministic — it is a suite that lies in whichever
+   direction the local machine happens to point.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from waku.memory import bundled_skill_dirs
+from waku.memory.procedural.loader import SkillLoader
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def _pyproject() -> dict:
+    with (REPO / "pyproject.toml").open("rb") as fh:
+        return tomllib.load(fh)
+
+
+def test_the_bundled_skills_are_findable():
+    """Whatever the install shape, Waku must find the skills it ships with."""
+    dirs = bundled_skill_dirs()
+    assert dirs, (
+        "bundled_skill_dirs() found nothing — Waku would start with no "
+        "procedural memory and never say so"
+    )
+    for d in dirs:
+        assert d.is_dir()
+    names = {s.name for s in SkillLoader(dirs).skills}
+    assert {"schedule-meeting", "weekly-brief"} <= names, sorted(names)
+
+
+def test_the_wheel_carries_the_skills_folder():
+    """The build config half of the fix. `packages = ["waku"]` alone leaves the
+    repo-root skills/ out of the wheel, which is the bug — force-include copies
+    it to waku/skills so an installed Waku finds it beside the code."""
+    wheel = _pyproject()["tool"]["hatch"]["build"]["targets"]["wheel"]
+    assert wheel.get("force-include", {}).get("skills") == "waku/skills", (
+        "pyproject no longer force-includes skills/ into the wheel — a "
+        "`pip install waku-agent` would ship with zero skills again"
+    )
+
+
+def test_lookup_covers_both_install_shapes():
+    """The lookup half. A checkout has skills/ at the repo root; a wheel has it
+    at waku/skills. Exactly one exists at a time, so the function must look in
+    both — checking only one is how this broke."""
+    import inspect
+
+    from waku import memory
+
+    src = inspect.getsource(memory.bundled_skill_dirs)
+    assert 'parents[1] / "skills"' in src, "lost the installed-wheel location"
+    assert 'parents[2] / "skills"' in src, "lost the repo-checkout location"
+
+
+@pytest.mark.parametrize("field", ["urls", "keywords", "classifiers"])
+def test_pypi_metadata_is_present(field):
+    """A bare PyPI page is a bad first impression for a teaching repo, and the
+    project URLs are the only navigation a pip user gets back to the source."""
+    assert _pyproject()["project"].get(field), f"pyproject is missing {field}"
+
+
+def test_evals_never_inherit_the_developers_env():
+    """THE regression for #2. `make_waku` must pin every switch that changes
+    what a turn DOES, so the suite describes its own world instead of the
+    maintainer's .env. Deliberately NOT pinned: `experimental`, because
+    test_delegate.py drives it via monkeypatch.setenv to prove the env var
+    reaches Settings at all."""
+    import inspect
+
+    from evals import helpers
+
+    src = inspect.getsource(helpers.make_waku)
+    for switch in ("apple_calendar", "google_calendar", "apple_tools", "graph_workflows"):
+        assert switch in src, (
+            f"make_waku no longer pins {switch!r} — a stale value in the "
+            "maintainer's .env can now change what these tests measure"
+        )
+
+
+def test_a_scripted_turn_ignores_the_graph_flag(tmp_path, monkeypatch):
+    """The behavioural half of the same regression: with the flag set in the
+    environment, a scripted turn must still take the plain loop. When this
+    broke, the triage graph ate one queued response and the loop reported one
+    iteration where the test expected two."""
+    import dataclasses
+
+    from evals.helpers import ScriptedClient, make_waku, response, text_block
+    from waku.config import Settings
+
+    if "graph_workflows" not in {f.name for f in dataclasses.fields(Settings)}:
+        pytest.skip("graph workflows not built on this branch")
+
+    monkeypatch.setenv("WAKU_GRAPH_WORKFLOWS", "1")
+    # Exactly two responses: the retrieval gate, then the answer. That count IS
+    # the assertion — a triage graph would spend a third on classification and
+    # this client would raise IndexError instead of answering.
+    gate = response([text_block('{"retrieve": false, "reason": "greeting"}')])
+    app = make_waku(tmp_path / "home",
+                    client=ScriptedClient([gate, response([text_block("hi")])]))
+    assert app.settings.graph_workflows is False
+    assert app.respond("hello").reply == "hi"

--- a/evals/helpers.py
+++ b/evals/helpers.py
@@ -3,6 +3,7 @@ real-Waku factory for live ones."""
 
 from __future__ import annotations
 
+import dataclasses
 import os
 from pathlib import Path
 from types import SimpleNamespace
@@ -55,9 +56,31 @@ def make_waku(home: Path, client=None, **settings_overrides):
     from waku.app import Waku
     from waku.config import Settings
 
-    # evals must NEVER touch a real calendar, whatever .env says
-    settings_overrides.setdefault("apple_calendar", False)
-    settings_overrides.setdefault("google_calendar", False)
+    # A test must describe its own world. `waku/config.py` calls load_dotenv()
+    # at import, so every Settings() default is quietly seeded from whatever is
+    # in the maintainer's .env — and a test that reads the developer's machine
+    # is not deterministic. Each entry below is a switch that changes what a
+    # turn DOES, pinned off unless a test asks for it:
+    #   apple/google_calendar  reach the real calendar (network + a Mac)
+    #   apple_tools            register four more tools and shell out to macOS
+    #   graph_workflows        route every message through the triage graph,
+    #                          which spends one extra model call — on 2026-07-31
+    #                          a stale WAKU_GRAPH_WORKFLOWS=1 ate a scripted
+    #                          response and failed 8 tests that pass in CI
+    # NOT pinned here: `experimental`. test_delegate.py drives it with
+    # monkeypatch.setenv to prove the env var really gates registration, and a
+    # hardcoded False here would make that wiring untestable. Pin a switch only
+    # when no test needs to observe the env reaching Settings.
+    #
+    # Only switches Settings actually HAS are pinned. Passing an unknown name
+    # is a TypeError, so a hardcoded list would break the moment a flag is
+    # renamed or lives only on a feature branch — which is exactly what
+    # happened to `graph_workflows` here. Filtering keeps this list a superset
+    # that costs nothing when an entry is absent.
+    known = {f.name for f in dataclasses.fields(Settings)}
+    for switch in ("apple_calendar", "google_calendar", "apple_tools", "graph_workflows"):
+        if switch in known:
+            settings_overrides.setdefault(switch, False)
     settings = Settings(home=home, **settings_overrides)
     if client is not None and not settings.api_key:
         settings.api_key = "offline"  # never read the real key for scripted runs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,12 +6,27 @@ readme = "README.md"
 license = { text = "MIT" }
 authors = [{ name = "Sean Chen (ShenSeanChen)" }]
 requires-python = ">=3.11"
+keywords = ["ai-agent", "llm", "agent-framework", "local-first", "llmops", "memory", "eval"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
 dependencies = [
     "anthropic>=0.40",   # anthropic wire format: Anthropic, Kimi, GLM, MiniMax
     "openai>=1.50",      # openai wire format: OpenAI, Gemini, DeepSeek (and embeddings)
     "python-dotenv>=1.0",
     "rich>=13.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/ShenSeanChen/waku-agent"
+Repository = "https://github.com/ShenSeanChen/waku-agent"
+Issues = "https://github.com/ShenSeanChen/waku-agent/issues"
+Changelog = "https://github.com/ShenSeanChen/waku-agent/releases"
 
 [project.scripts]
 # Branded CLI: `waku dashboard`, `waku voice`, `waku` to chat, etc.
@@ -96,6 +111,17 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["waku"]
+
+# The bundled skills live at the repo root because that is where contributors
+# add them (CONTRIBUTING.md, CI's validate-skills job, `skills/community/`).
+# But `packages = ["waku"]` ships only the package, so before 2026-07-31 a
+# `pip install waku-agent` arrived with ZERO skills — procedural memory, one of
+# the four pillars, silently absent while the dashboard shipped fine (it lives
+# under waku/ops/static). Copying them in at build time keeps one contributor-
+# facing location and still ships them; waku.memory.bundled_skill_dirs() looks
+# in both places and explains why.
+[tool.hatch.build.targets.wheel.force-include]
+"skills" = "waku/skills"
 
 [tool.ruff]
 line-length = 100

--- a/waku/memory/__init__.py
+++ b/waku/memory/__init__.py
@@ -22,7 +22,24 @@ from waku.memory.episodic.store import SqliteEpisodeStore
 from waku.memory.procedural.loader import SkillLoader
 from waku.memory.semantic.store import SqliteFactStore
 
-REPO_SKILLS = Path(__file__).resolve().parents[2] / "skills"
+
+def bundled_skill_dirs() -> list[Path]:
+    """Where the skills that SHIP with Waku live — and why there are two answers.
+
+    Contributors add skills to `skills/` at the repo root: that is what
+    CONTRIBUTING.md documents, what CI validates, and what a checkout has. But
+    the wheel only packages the `waku/` directory, so a `pip install waku-agent`
+    would have found nothing there and silently started with zero skills —
+    procedural memory, one of the four pillars, quietly missing. (It did, until
+    2026-07-31.) pyproject force-includes the same folder into the wheel at
+    `waku/skills`, so an installed Waku finds it next to the code.
+
+    Exactly one of these exists at a time — the package copy only in a built
+    wheel, the repo copy only in a checkout — so returning both is not a
+    double-load, it is "wherever you installed from, the skills came too".
+    """
+    here = Path(__file__).resolve()
+    return [p for p in (here.parents[1] / "skills", here.parents[2] / "skills") if p.is_dir()]
 
 
 class Memory:
@@ -36,7 +53,7 @@ class Memory:
         self.client = client
         self.facts = self._make_fact_store(conn, settings)
         self.episodes = episode_store if episode_store is not None else self._make_episode_store(conn, settings)
-        self.skills = SkillLoader([REPO_SKILLS, settings.home / "skills"])
+        self.skills = SkillLoader([*bundled_skill_dirs(), settings.home / "skills"])
 
     @staticmethod
     def _make_fact_store(conn, settings):

--- a/waku/ops/dashboard.py
+++ b/waku/ops/dashboard.py
@@ -248,7 +248,7 @@ def collect() -> dict:
     def pct(p: float) -> int:
         return latencies[min(len(latencies) - 1, int(len(latencies) * p))] if latencies else 0
 
-    from waku.memory import REPO_SKILLS
+    from waku.memory import bundled_skill_dirs
     from waku.memory.procedural.loader import SkillLoader
 
     skills = [{"name": s.name, "description": s.description, "body": s.body,
@@ -256,7 +256,7 @@ def collect() -> dict:
                # relative path (for reveal) + whether it lives in the editable home dir
                "rel": _rel_to_home(s.path, home),
                "editable": str((home / "skills").resolve()) in str(s.path.resolve())}
-              for s in SkillLoader([REPO_SKILLS, home / "skills"]).skills]
+              for s in SkillLoader([*bundled_skill_dirs(), home / "skills"]).skills]
 
     eval_report = None
     report_path = home / "eval_report.json"
@@ -669,12 +669,12 @@ def memory_action(payload: dict) -> dict:
         # skills folders; validates the frontmatter before writing.
         from pathlib import Path
 
-        from waku.memory import REPO_SKILLS
+        from waku.memory import bundled_skill_dirs
         from waku.memory.procedural.loader import _parse_text
 
         text = (payload.get("content") or "").strip()
         dest = Path(payload.get("path") or "").resolve()
-        allowed = [REPO_SKILLS.resolve(), (settings.home / "skills").resolve()]
+        allowed = [d.resolve() for d in bundled_skill_dirs()] + [(settings.home / "skills").resolve()]
         if dest.name != "SKILL.md" or not any(a in dest.parents for a in allowed):
             return {"error": "can only edit SKILL.md files inside the skills folders"}
         if _parse_text(text, dest) is None:

--- a/waku/tools/memory_admin.py
+++ b/waku/tools/memory_admin.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import re
 
-from waku.memory import REPO_SKILLS
+from waku.memory import bundled_skill_dirs
 from waku.memory.procedural.loader import _parse_text
 from waku.tools.registry import Tool
 
@@ -114,7 +114,7 @@ def make_create_skill_tool(settings, memory) -> Tool:
             return "Skill name must be a short slug like 'weekly-review' (lowercase, hyphens)."
         dest = settings.home / "skills" / name / "SKILL.md"
         # never silently overwrite an existing skill (built-in or user)
-        if dest.exists() or (REPO_SKILLS / name / "SKILL.md").exists():
+        if dest.exists() or any((d / name / "SKILL.md").exists() for d in bundled_skill_dirs()):
             return f"A skill named '{name}' already exists — pick another name."
         text = f"---\nname: {name}\ndescription: {description.strip()}\n---\n\n{body.strip()}\n"
         if _parse_text(text, dest) is None:


### PR DESCRIPTION
- **docs(graph): system design for agent graphs — engine, workflows, phasing**
- **feat(graph): graph workflow engine + node factories + deterministic evals**
- **feat(graph): triage graph workflow — the auto-decide front door, behind a flag**
- **feat(graph): dashboard Graph tab + Overview panel + README — loop and graph, one story**
- **fix: the wheel shipped no skills, and the evals read the maintainer's .env**
