### PR TITLE
build: trim the sdist, and lead the README with `pip install waku-agent`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ Built for [Sean's AI Stories](https://www.youtube.com/@SeanAIStories).
 
 ## Quickstart
 
+Just want to run it:
+
+```bash
+pip install waku-agent
+waku                                    # talk to your Waku in the terminal
+waku dashboard                          # …or the browser cockpit → localhost:7777
+```
+
+It will tell you which key to set the first time. Want to **read the code** (the
+point of this repo) or contribute — clone it instead:
+
 ```bash
 git clone https://github.com/ShenSeanChen/waku-agent && cd waku-agent
 uv venv && uv pip install -e .          # create the env + install the `waku` command

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,17 @@ dev = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+# An sdist should be what you need to BUILD and TEST waku — source, bundled
+# skills, schema, evals. Left alone it was 2.6 MB, and 2.5 MB of that was a
+# whiteboard PNG and the .excalidraw sources, plus the agent tooling (.claude,
+# .agents, .pi) that only matters inside this repo. All of it stays on GitHub,
+# where people actually read it; none of it belongs in a package download.
+[tool.hatch.build.targets.sdist]
+exclude = [
+    "docs", "examples", "pi-pokedex",
+    ".claude", ".agents", ".pi", ".deepeval", ".github",
+]
+
 [tool.hatch.build.targets.wheel]
 packages = ["waku"]
 


### PR DESCRIPTION
Prep for the first PyPI release. Two changes, both about what a stranger gets.

The sdist was 2.6 MB, and 2.5 MB of it was docs/architecture-whiteboard.png
plus the .excalidraw sources — with .claude/, .agents/, .pi/ and .deepeval/
along for the ride. None of that is needed to build or test waku; all of it
stays on GitHub where people actually look at it. Excluding those directories
takes the sdist to 386 KB.

The README now offers `pip install waku-agent` first and the clone second,
because those are two different readers: one wants to run it, one wants to read
it. The clone path is unchanged and still the one the rest of the README
assumes.

Verified the whole publish path rather than just the happy one:
  * twine check passes on both artifacts
  * a wheel built FROM the sdist still carries all five skill files — that is
    pip's fallback path, and it exercises the force-include added in #44 from
    a different build root than the one it was written against
  * that sdist-built wheel installs into a clean venv outside the repo, the
    `waku` entry point runs, fails honestly on the missing API key, and
    SkillLoader finds all three bundled skills

298 deterministic tests pass, ruff clean.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
