### PR TITLE
feat(tools): read-only GitHub through the gh CLI, off by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,6 +84,17 @@ OPENCODE_GO_API_KEY=
 # Limit calendar reads to named calendars (faster; comma-separated):
 # WAKU_APPLE_CALENDARS=Work,Home
 
+# ── GitHub, read-only (optional) ────────────────────────────────────────────
+# Lets the agent read pull requests and issues through the `gh` CLI. There is
+# no token here: gh keeps its own credentials, so run `gh auth login` once and
+# nothing sensitive lands in this file. The tool is READ-ONLY by construction —
+# it can list/view PRs and issues and read a diff, and refuses to merge,
+# comment, close or push. Off by default because every registered tool ships in
+# every prompt, and this is maintainer capability, not assistant capability.
+# WAKU_GH_TOOL=1
+# Repo to assume when a call omits one (for running outside a checkout):
+# WAKU_GH_REPO=ShenSeanChen/waku-agent
+
 # ── Google Calendar writes (optional): pip install -e '.[gcal]' ────────────
 # SQLite + calendar.ics remain the source of truth. This only mirrors events
 # created by create_event; list_events stays local and requests use sendUpdates=none.

--- a/evals/deterministic/test_gh_tool.py
+++ b/evals/deterministic/test_gh_tool.py
@@ -1,0 +1,236 @@
+"""DETERMINISTIC EVAL — the gh tool's read-only boundary, proven offline.
+
+CI has no `gh` and no GitHub credentials, so nothing here asserts "reading
+really works" — that is verified by hand against a live repo. What CAN be
+pinned in CI is the part that would actually hurt if it broke: that a model
+cannot get a WRITE command past this tool, and that every failure comes back as
+a sentence rather than an exception.
+
+The design being defended, from the module docstring:
+
+    ARGV IS CONSTRUCTED, NEVER FILTERED.
+
+The model picks a label from a table of five; every other argv element is
+either a literal in the source or a value that matched a regex. So the tests
+below check the boundary in two independent ways — the refusal text, and the
+stronger claim that the subprocess is never reached at all. The second is what
+matters: a tool that spawns `gh pr merge` and then inspects the result has
+already merged the PR.
+
+Lesson carried over from test_apple_tools.py, where four tools sat broken for
+weeks behind a green suite: assert on the command that WOULD run, not on prose
+describing it.
+"""
+
+from __future__ import annotations
+
+import inspect
+import subprocess
+
+import pytest
+
+from waku.tools import github
+
+
+class Boom(Exception):
+    """Raised by the fake subprocess. Reaching it at all is the failure."""
+
+
+@pytest.fixture
+def no_subprocess(monkeypatch):
+    """Make any subprocess call explode. A test that passes with this installed
+    has proven the code path never spawned a process."""
+    def explode(*a, **k):
+        raise Boom(f"a subprocess was spawned: {a!r}")
+
+    monkeypatch.setattr(github.subprocess, "run", explode)
+
+
+@pytest.fixture
+def capture(monkeypatch):
+    """Record argv and return a canned result instead of running gh."""
+    seen: dict = {}
+
+    def fake(argv, **kwargs):
+        seen["argv"] = argv
+        seen["kwargs"] = kwargs
+        return subprocess.CompletedProcess(argv, 0, stdout=seen.get("stdout", "[]"), stderr="")
+
+    monkeypatch.setattr(github.subprocess, "run", fake)
+    return seen
+
+
+# --- the boundary -----------------------------------------------------------
+
+@pytest.mark.parametrize("command", [
+    "pr merge", "pr create", "pr close", "pr comment", "pr edit",
+    "issue close", "issue create", "issue comment",
+    "repo delete", "api", "auth token", "", "pr", "PR LIST",
+])
+def test_write_commands_never_reach_a_subprocess(command, no_subprocess):
+    """THE test. Refusal must happen before a process exists — not after, and
+    not by inspecting what gh did. `gh api` and `auth token` are in the list on
+    purpose: both read innocuous but are general-purpose escape hatches."""
+    out = github.gh_read(command, number=1)
+    assert "read-only" in out.lower(), out
+    assert "pr list" in out, "the refusal should name what IS allowed"
+
+
+def test_the_allowlist_is_exactly_the_five_read_commands():
+    """Adding a sixth entry should be a deliberate, reviewed act. If this fails,
+    someone widened the tool's reach — check that they meant to."""
+    assert set(github._ALLOWED) == {
+        "pr list", "pr view", "pr diff", "issue list", "issue view",
+    }
+    for argv in github._ALLOWED.values():
+        assert not ({"merge", "close", "create", "comment", "edit", "delete"} & set(argv))
+
+
+def test_a_hostile_repo_is_refused_not_escaped(no_subprocess):
+    """Shell metacharacters are moot (there is no shell), but a bad repo value
+    could still become a stray gh argument. Match a regex, refuse otherwise."""
+    for bad in ("owner/repo; rm -rf ~", "--repo=x", "owner", "a/b/c", "$(whoami)/x", "-x/y"):
+        out = github.gh_read("pr list", repo=bad)
+        assert "not a valid repo" in out, (bad, out)
+
+
+def test_view_and_diff_require_a_real_number(no_subprocess):
+    for command in ("pr view", "pr diff", "issue view"):
+        assert "number" in github.gh_read(command, number=0)
+        assert "number" in github.gh_read(command, number=-3)
+        assert "number" in github.gh_read(command, number="not-a-number")  # type: ignore[arg-type]
+
+
+# --- argv construction ------------------------------------------------------
+
+def test_argv_is_built_from_literals(capture):
+    github.gh_read("pr view", number=42, repo="ShenSeanChen/waku-agent")
+    argv = capture["argv"]
+    assert argv[:3] == ["gh", "pr", "view"]
+    assert argv[3] == "42", "the number must be placed by us, as its own element"
+    assert argv[4:6] == ["--repo", "ShenSeanChen/waku-agent"]
+
+
+def test_list_commands_ask_for_json_and_clamp_the_limit(capture):
+    github.gh_read("pr list", limit=9999)
+    argv = capture["argv"]
+    assert "--json" in argv, "list output is parsed, so it must be requested as JSON"
+    assert argv[argv.index("--limit") + 1] == "50", "an unbounded limit must be clamped"
+    # 0 means "didn't say", not "give me zero rows" — a tool that honoured a
+    # literal 0 would return nothing and look broken rather than unconfigured.
+    github.gh_read("issue list", limit=0)
+    assert capture["argv"][capture["argv"].index("--limit") + 1] == "10"
+
+
+def _code_lines(module) -> list[str]:
+    """Source with docstrings and comments removed.
+
+    github.py DISCUSSES `shell=True` at length on purpose — the docstring is
+    where the rule is explained. A naive substring search over the raw source
+    therefore trips over the very sentence forbidding the thing, which is
+    exactly the trap test_apple_tools.py hit with its `whose` rule. Assert on
+    the CODE, not on the prose about the code.
+    """
+    import ast
+
+    src = inspect.getsource(module)
+    doc_spans: set[int] = set()
+    for node in ast.walk(ast.parse(src)):
+        if isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant) \
+                and isinstance(node.value.value, str):
+            doc_spans.update(range(node.lineno, (node.end_lineno or node.lineno) + 1))
+    return [ln for i, ln in enumerate(src.splitlines(), 1)
+            if i not in doc_spans and not ln.strip().startswith("#")]
+
+
+def test_no_shell_true_anywhere():
+    """`shell=True` would turn every argument back into a string the shell
+    parses, undoing the entire design of this file."""
+    offenders = [ln.strip() for ln in _code_lines(github) if "shell=True" in ln]
+    assert offenders == [], offenders
+
+
+def test_every_gh_call_is_bounded(capture):
+    """One hung network call must not hang a chat turn — same rule as apple.py."""
+    sig = inspect.signature(github._run)
+    assert sig.parameters["timeout"].default, "_run must always have a timeout default"
+    github.gh_read("pr list")
+    assert capture["kwargs"].get("timeout"), "the timeout must reach subprocess.run"
+
+
+# --- honest failure ---------------------------------------------------------
+
+@pytest.mark.parametrize("exc,expect", [
+    (FileNotFoundError(), "not installed"),
+    (subprocess.TimeoutExpired(cmd="gh", timeout=20), "timed out"),
+])
+def test_failures_return_a_sentence_and_never_raise(monkeypatch, exc, expect):
+    def raiser(*a, **k):
+        raise exc
+
+    monkeypatch.setattr(github.subprocess, "run", raiser)
+    out = github.gh_read("pr list")
+    assert expect in out, out
+
+
+def test_an_unauthenticated_gh_says_how_to_fix_it(monkeypatch):
+    """The most likely first-run failure, and the one worth naming precisely:
+    'gh failed' would send someone hunting for a bug that is really a login."""
+    monkeypatch.setattr(github.subprocess, "run", lambda *a, **k: subprocess.CompletedProcess(
+        a[0], 1, stdout="", stderr="gh auth login required to use this command"))
+    out = github.gh_read("pr list")
+    assert "gh auth login" in out
+
+
+def test_a_huge_diff_is_truncated_by_the_tool(monkeypatch):
+    """Truncation lives in the tool so no caller can forget it, and the model is
+    told it happened rather than silently reasoning about half a diff."""
+    monkeypatch.setattr(github.subprocess, "run", lambda *a, **k: subprocess.CompletedProcess(
+        a[0], 0, stdout="x" * 200_000, stderr=""))
+    out = github.gh_read("pr diff", number=1)
+    assert len(out) < github._MAX_CHARS + 300
+    assert "truncated" in out
+
+
+def test_list_helpers_return_rows_for_the_router(monkeypatch):
+    """The gather workflow routes on COUNTS, so the list helpers must hand back
+    data, not prose. Same underlying call as the model's text view, so the two
+    can never disagree about what is open."""
+    payload = '[{"number":42,"title":"Fix the thing","author":{"login":"octocat"},' \
+              '"updatedAt":"2026-07-31T10:00:00Z","url":"http://x"}]'
+    monkeypatch.setattr(github.subprocess, "run", lambda *a, **k: subprocess.CompletedProcess(
+        a[0], 0, stdout=payload, stderr=""))
+    ok, rows = github.list_prs("ShenSeanChen/waku-agent")
+    assert ok and isinstance(rows, list) and rows[0]["number"] == 42
+    assert "#42 Fix the thing — @octocat" in github.gh_read("pr list")
+
+
+def test_malformed_json_does_not_raise(monkeypatch):
+    monkeypatch.setattr(github.subprocess, "run", lambda *a, **k: subprocess.CompletedProcess(
+        a[0], 0, stdout="<html>rate limited</html>", stderr=""))
+    ok, res = github.list_prs()
+    assert ok is False
+    assert "not JSON" in str(res)
+
+
+# --- registration -----------------------------------------------------------
+
+def test_the_tool_is_off_unless_asked_for(tmp_path):
+    """Every registered tool ships in every prompt, so a maintainer-only tool
+    must not appear for people who never asked for it (CLAUDE.md's footprint
+    ladder). The gather workflow imports this module directly and works with
+    the switch off — the switch only decides whether the MODEL can reach it."""
+    from evals.helpers import ScriptedClient, make_waku
+
+    off = make_waku(tmp_path / "off", client=ScriptedClient([]), gh_tool=False)
+    assert "github_read" not in off.tools._tools
+    on = make_waku(tmp_path / "on", client=ScriptedClient([]), gh_tool=True)
+    assert "github_read" in on.tools._tools
+
+
+def test_the_description_tells_the_model_the_boundary():
+    """The model should not have to discover the refusal by trying to merge."""
+    desc = github.make_tool().description.lower()
+    assert "read-only" in desc
+    for verb in ("merge", "comment", "close"):
+        assert verb in desc

--- a/waku/config.py
+++ b/waku/config.py
@@ -75,6 +75,17 @@ class Settings:
     apple_tools: bool = field(
         default_factory=lambda: os.getenv("WAKU_APPLE_TOOLS", "") in ("1", "true", "yes")
     )
+    # Read-only GitHub access through the `gh` CLI's own auth (no token here).
+    # Off by default and deliberately so: every registered tool ships in every
+    # prompt, and reading PRs is maintainer capability, not assistant capability.
+    # The gather workflow calls waku/tools/github.py as a library and does NOT
+    # need this on — the switch only decides whether the MODEL can reach it.
+    gh_tool: bool = field(
+        default_factory=lambda: os.getenv("WAKU_GH_TOOL", "") in ("1", "true", "yes")
+    )
+    # owner/name to assume when a call omits it — for when Waku runs outside a
+    # checkout, where `gh` has no remote to infer from.
+    gh_repo: str = field(default_factory=lambda: os.getenv("WAKU_GH_REPO", ""))
     # Register the experimental tools (delegate_task -> pi sub-agent, ...). Env is
     # the global switch; the arena sets this per-race so a coding race can hand
     # work to pi WITHOUT flipping it on for the whole process.

--- a/waku/tools/__init__.py
+++ b/waku/tools/__init__.py
@@ -61,6 +61,12 @@ def build_registry(conn: sqlite3.Connection, settings: Settings, memory=None) ->
         for t in apple.make_tools():
             registry.register(t)
 
+    # Read-only GitHub via the gh CLI (opt-in; uses gh's own auth, no token here).
+    if getattr(settings, "gh_tool", False):
+        from waku.tools import github
+
+        registry.register(github.make_tool(default_repo=getattr(settings, "gh_repo", "")))
+
     # MCP servers (opt-in via .waku/mcp.json).
     mcp_config = settings.home / "mcp.json"
     if mcp_config.exists():

--- a/waku/tools/github.py
+++ b/waku/tools/github.py
@@ -1,0 +1,201 @@
+"""GitHub, read-only, through the `gh` CLI you already signed into.
+
+Waku stores no GitHub token. It shells out to `gh`, which keeps its own
+credentials in the system keychain — so nothing sensitive lands in `.env`, in
+`.waku/`, or in a config file somebody might commit. If you have never run
+`gh auth login`, every call here says so in a sentence.
+
+THE SAFETY RULE, and why this file is shaped the way it is:
+
+    ARGV IS CONSTRUCTED, NEVER FILTERED.
+
+The model does not hand us a command string that we sanitise. It hands us a
+label we look up in a table of five read-only commands, plus a couple of typed
+scalars we validate and then place ourselves. Everything the subprocess sees is
+either a literal written in this file or a value that matched a regex. There is
+no code path where model output becomes a `gh` flag.
+
+That is a stronger guarantee than blocklisting `merge`, `close` and friends,
+because a blocklist has to imagine every dangerous verb in advance and `gh` adds
+subcommands every release. An allowlist only has to be right about the five we
+want. Refusal happens BEFORE a process exists, which is what
+test_gh_tool.py::test_write_commands_never_reach_a_subprocess pins.
+
+Same subprocess discipline as apple.py: an explicit timeout on every call,
+never `shell=True`, and failures come back as a sentence rather than an
+exception, because a GitHub hiccup must not take down a chat turn.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+
+from waku.tools.registry import Tool
+
+_TIMEOUT = 20
+# A PR diff is unbounded — waku-agent has had 400-line ones and the wider world
+# has 40,000-line ones. Truncating in the TOOL rather than at each call site
+# means no caller can forget to, and the model is told plainly that it happened
+# instead of silently reasoning about half a diff.
+_MAX_CHARS = 8000
+# owner/name. Both halves must START with an alphanumeric or underscore: a
+# value like `-x/y` matches the looser [\w.-]+ form, and an argv element
+# beginning with a hyphen is exactly the thing that gets read as a flag. GitHub
+# does not allow such names anyway, so nothing legitimate is lost.
+_REPO_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_.-]*/[A-Za-z0-9_][A-Za-z0-9_.-]*$")
+
+# The whole allowlist. The VALUE is the fixed argv prefix; the key is the only
+# thing the model gets to choose. Read-only, exhaustively — no create, comment,
+# merge, close, edit, or `gh api` (which would be a write primitive wearing a
+# read-only name).
+_ALLOWED: dict[str, list[str]] = {
+    "pr list": ["pr", "list"],
+    "pr view": ["pr", "view"],
+    "pr diff": ["pr", "diff"],
+    "issue list": ["issue", "list"],
+    "issue view": ["issue", "view"],
+}
+_NEEDS_NUMBER = {"pr view", "pr diff", "issue view"}
+_IS_LIST = {"pr list", "issue list"}
+_JSON_FIELDS = "number,title,author,updatedAt,url"
+
+_REFUSAL = (
+    "Waku's GitHub tool is read-only. Allowed commands: "
+    + ", ".join(sorted(_ALLOWED))
+    + ". It cannot merge, comment, close, edit or push — do those yourself."
+)
+
+
+def _run(argv: list[str], timeout: int = _TIMEOUT) -> tuple[bool, str]:
+    """One `gh` invocation. Returns (ok, text); the text is an explanation when
+    ok is False. Mirrors apple.py::_osa — same contract, different binary."""
+    try:
+        r = subprocess.run(argv, capture_output=True, text=True, timeout=timeout, check=False)
+    except FileNotFoundError:
+        return False, ("The gh CLI is not installed. Install it (brew install gh) "
+                       "and run `gh auth login`.")
+    except subprocess.TimeoutExpired:
+        return False, (f"gh timed out after {timeout}s — GitHub or the network is slow. "
+                       "Try again, or check status.github.com.")
+    except OSError as exc:
+        return False, f"could not run gh ({exc})"
+    if r.returncode != 0:
+        err = (r.stderr or "gh failed").strip()[:200]
+        if "auth" in err.lower() or "logged in" in err.lower():
+            return False, f"gh is not authenticated. Run `gh auth login`. ({err})"
+        return False, err
+    return True, r.stdout.strip()
+
+
+def _argv(command: str, number: int, repo: str, limit: int) -> tuple[bool, list[str] | str]:
+    """Validate, then BUILD. Returns (ok, argv) or (False, refusal sentence).
+
+    Every rejection here happens before a subprocess exists. `repo` is matched
+    against a regex rather than escaped, so a hostile value like
+    `owner/repo; rm -rf ~` is refused outright instead of being passed along in
+    a form we hope is safe.
+    """
+    if command not in _ALLOWED:
+        return False, _REFUSAL
+    if repo and not _REPO_RE.match(repo):
+        return False, f"'{repo}' is not a valid repo — use the owner/name form, e.g. octocat/Hello-World."
+    argv = ["gh", *_ALLOWED[command]]
+    if command in _NEEDS_NUMBER:
+        try:
+            n = int(number)
+        except (TypeError, ValueError):
+            return False, f"'{command}' needs a PR/issue number."
+        if n <= 0:
+            return False, f"'{command}' needs a positive PR/issue number."
+        argv.append(str(n))
+    if repo:
+        argv += ["--repo", repo]
+    if command in _IS_LIST:
+        argv += ["--limit", str(max(1, min(int(limit or 10), 50)))]
+        argv += ["--json", _JSON_FIELDS]
+    return True, argv
+
+
+def _rows(command: str, repo: str, limit: int) -> tuple[bool, list[dict] | str]:
+    """A list command as structured rows. The gather workflow routes on counts,
+    so it needs data; the model needs prose. Both come from this one call so
+    they can never disagree about what is open."""
+    ok, argv = _argv(command, 0, repo, limit)
+    if not ok:
+        return False, argv  # type: ignore[return-value]
+    ok, out = _run(argv)  # type: ignore[arg-type]
+    if not ok:
+        return False, out
+    try:
+        return True, json.loads(out or "[]")
+    except json.JSONDecodeError:
+        return False, f"gh returned something that was not JSON: {out[:200]}"
+
+
+def _format(rows: list[dict]) -> str:
+    if not rows:
+        return "(none open)"
+    lines = []
+    for r in rows:
+        who = (r.get("author") or {}).get("login", "?")
+        lines.append(f"#{r.get('number')} {r.get('title', '')} — @{who} "
+                     f"(updated {(r.get('updatedAt') or '')[:10]})")
+    return "\n".join(lines)
+
+
+def list_prs(repo: str = "", limit: int = 10) -> tuple[bool, list[dict] | str]:
+    """Open PRs as rows. Used directly by the gather workflow — no registry, no
+    model in the loop, which is why gather works with the tool switched off."""
+    return _rows("pr list", repo, limit)
+
+
+def list_issues(repo: str = "", limit: int = 10) -> tuple[bool, list[dict] | str]:
+    """Open issues as rows. Same contract as list_prs."""
+    return _rows("issue list", repo, limit)
+
+
+def gh_read(command: str, number: int = 0, repo: str = "", limit: int = 10) -> str:
+    """The single entry point the model reaches. Always returns text."""
+    if command in _IS_LIST:
+        ok, res = _rows(command, repo, limit)
+        return _format(res) if ok else str(res)  # type: ignore[arg-type]
+    ok, argv = _argv(command, number, repo, limit)
+    if not ok:
+        return str(argv)
+    ok, out = _run(argv)  # type: ignore[arg-type]
+    if not ok:
+        return out
+    if len(out) > _MAX_CHARS:
+        return out[:_MAX_CHARS] + (
+            f"\n\n… truncated at {_MAX_CHARS} chars. Run `gh {command} {number}` "
+            "in a terminal to read the rest."
+        )
+    return out
+
+
+def make_tool(default_repo: str = "") -> Tool:
+    def run(command: str, number: int = 0, repo: str = "", limit: int = 10) -> str:
+        return gh_read(command, number, repo or default_repo, limit)
+
+    return Tool(
+        name="github_read",
+        description=(
+            "Read pull requests and issues from GitHub via the gh CLI. "
+            "command must be one of: " + ", ".join(sorted(_ALLOWED)) + ". "
+            "READ-ONLY — it cannot merge, comment, close, edit or push, and will "
+            "refuse if asked to. Use it to review what is open and what changed."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "command": {"type": "string", "description": "one of: " + ", ".join(sorted(_ALLOWED))},
+                "number": {"type": "integer", "description": "PR/issue number (required for view and diff)"},
+                "repo": {"type": "string", "description": "owner/name; omit to use the current repo"},
+                "limit": {"type": "integer", "description": "max rows for list commands, default 10"},
+            },
+            "required": ["command"],
+        },
+        fn=run,
+    )


### PR DESCRIPTION
The first half of the morning-gather workflow: Waku needs to see what is open
on a repo. This is the narrowest thing that does that.

No token. It shells out to `gh`, which keeps its credentials in the system
keychain — so nothing sensitive lands in .env or .waku/, and there is no new
secret for a contributor to leak. If you have never run `gh auth login`, every
call says exactly that instead of failing obscurely.

THE DESIGN: ARGV IS CONSTRUCTED, NEVER FILTERED.

The model does not hand over a command string we then sanitise. It picks a
label from a table of five read-only commands; every other argv element is
either a literal in the source or a scalar that matched a regex. There is no
path where model output becomes a gh flag.

That beats blocklisting merge/close/comment, because a blocklist must imagine
every dangerous verb in advance and gh grows subcommands every release. An
allowlist only has to be right about the five we want. `gh api` and `auth
token` are excluded on purpose — both read innocent and are general-purpose
escape hatches.

Refusal happens BEFORE a subprocess exists, and that is what the load-bearing
test proves: it installs a fake subprocess.run that RAISES, then asserts
fourteen write commands still come back as a refusal. A tool that spawns
`gh pr merge` and then inspects the result has already merged the PR.

Two things the tests caught that I had wrong:

  * `-x/y` passed the first repo regex, because [\w.-]+ allows a leading
    hyphen — and an argv element starting with `-` is precisely what gets read
    as a flag. Both halves now must start alphanumeric. GitHub forbids such
    names anyway, so nothing real is lost.
  * the no-shell=True test tripped over the docstring EXPLAINING the rule —
    the same trap test_apple_tools.py hit with its `whose` rule. Assert on the
    code with docstrings stripped, not on the prose about the code.

Gated behind WAKU_GH_TOOL=1, off by default, following apple_tools. CLAUDE.md's
footprint ladder is explicit that every registered tool ships in every prompt,
and reading PRs is maintainer capability, not assistant capability. The gather
workflow imports list_prs()/list_issues() as plain functions and works with the
switch off — the flag only decides whether the MODEL can reach it, which keeps
this commit independently revertible.

Also: a PR diff is unbounded, so truncation at 8000 chars lives in the tool
rather than at each call site, and the model is told it happened.

29 new offline tests; 327 deterministic pass, ruff clean. Verified live against
this repo: `pr list` returned #42 and #36, `issue list` returned #45 and #32,
and `pr merge` was refused.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
