### PR TITLE
feat(graph): agent graphs — engine, triage, and the morning gather

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -112,6 +112,10 @@ OPENCODE_GO_API_KEY=
 #   npm install -g --ignore-scripts @earendil-works/pi-coding-agent
 # The terminal/browser/cron skeletons still just report "coming soon".
 # WAKU_EXPERIMENTAL=1
+# Graph workflows: triage every message through a graph (small-model classify +
+# calendar peek in parallel -> quick reply, or the normal loop as a node).
+# Fails open to the plain loop on any error. See waku/graph/.
+# WAKU_GRAPH_WORKFLOWS=1
 # Max seconds pi may spend on one delegated task (default 300):
 # WAKU_DELEGATE_TIMEOUT=300
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,9 @@ for its own sake is not.
 - `waku/gateway/` — cli, voice (wake word), telegram. Gateways only move text.
 - `waku/runtime/session.py` — working memory assembly (SOUL.md + memory + history)
 - `waku/loop/agent.py` — THE loop; `loop/models.py` — pluggable providers, 2 wire formats
+- `waku/graph/` — engine + node factories + `workflows/` (triage) — opt-in structure
+  AROUND the loop (the loop never changes; a graph node can BE a loop turn); every
+  failure fails open to the plain loop
 - `waku/tools/` — create_event / save_note / send_message (flagship task only)
 - `waku/memory/` — semantic (FTS5) / episodic / procedural (SKILL.md) +
   `retrieval_gate.py` (hero 1) + `consolidation.py` (every N exchanges)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,11 @@ when the rung above genuinely can't do it:
    `waku.respond()`, out again. No memory, no tools, no loop logic.
 6. **A new core tool — last resort.** It has to earn its place in every prompt.
 
+One thing the ladder deliberately has no rung for: **a new top-level package**
+(like `waku/graph/`). That's not a contribution size, it's an architecture
+decision — it needs a written design doc and a maintainer yes before any code
+(see `docs/agent-graphs-design.md` for the precedent and the bar it had to clear).
+
 If you're unsure which rung you're on, open an issue and ask before writing
 code. That conversation is cheaper than a rejected PR.
 

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,11 @@ discord:        ## Discord → laptop (needs DISCORD_BOT_TOKEN in .env)
 whatsapp:       ## WhatsApp → laptop (needs WHATSAPP_TOKEN in .env, public URL)
 	$(PY) -m waku whatsapp
 
-brief:          ## morning briefing from calendar + mail + memory
+brief:          ## morning briefing from calendar + mail + memory (as a LOOP)
 	$(PY) -m waku brief
+
+gather:         ## same job as a GRAPH: 4 sources in parallel, then one digest
+	$(PY) -m waku gather
 
 # The server holds dashboard.py in memory: static JS/CSS reload on refresh, but
 # Python routes do NOT. After pulling a change that touches dashboard.py (or any

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Each tab is one pillar, linked to the real files:
 | **Overview** | cost, latency, the gate skip/retrieve split, the clickable architecture map |
 | **Gateway** | one conversation across every channel, each message tagged by source (dashboard / telegram / voice / cli) |
 | **Loop** | every turn with its gate decision, tool calls, tokens, and cost |
+| **Graph** | graph workflows: the live triage topology (drawn from the engine itself) + which door each turn took |
 | **Memory** | sub-tabs per pillar — semantic facts, episodes, editable skills + SOUL, consolidation |
 | **Tools** | the agent's available tools (grouped by origin), its results, and MCP connectors |
 | **Data** | a live SQLite browser: per-table tabs, schema, and a read-only SQL console over `state.db` |
@@ -173,6 +174,7 @@ Every box is one module (full version with every file path: [docs/architecture.m
 | Gateway Interface (CLI / voice / Telegram / web) | [`waku/gateway/`](waku/gateway) |
 | Ephemeral Agent Run → Working Memory | [`waku/runtime/session.py`](waku/runtime/session.py) |
 | The Loop (LLM ↔ tools, end-loop guardrails) | [`waku/loop/agent.py`](waku/loop/agent.py) |
+| Graph workflows (structure around the loop) | [`waku/graph/`](waku/graph) |
 | Agentic Tools (schedule / note / message) | [`waku/tools/`](waku/tools) |
 | Procedural Memory (SKILL.md, "how to act") | [`waku/memory/procedural/`](waku/memory/procedural) + [`skills/`](skills) |
 | Semantic Memory (durable facts, profile) | [`waku/memory/semantic/`](waku/memory/semantic) |
@@ -193,7 +195,9 @@ raw `state.db` tables.
 ## The Loop — reason → act → repeat
 
 Yes, there's a real agent loop, and it's [~95 lines of plain Python](waku/loop/agent.py) —
-no LangGraph, no hidden control flow:
+no LangGraph, no hidden control flow (and when a task needs structure *around* the loop,
+that structure is another ~200 readable lines — see
+[Graph workflows](#graph-workflows--when-a-turn-needs-shape) below):
 
 ```
 while not done:
@@ -228,6 +232,53 @@ reasons over the results, then calls [`create_event`](waku/tools/calendar.py) on
 several iterations in a single turn. You'll see `iter 4`, `iter 5`… on the Loop tab and the
 LOOP box pulse for each cycle. `search_web` works keyless via DuckDuckGo but that endpoint
 rate-limits bots, so for a clean take set a free `TAVILY_API_KEY` (see [`.env.example`](.env.example)).
+
+## Graph workflows — when a turn needs shape
+
+The loop is one agent turn: the model picks tools until it stops, and that covers chat.
+But some work has **shape** — steps that could run *at the same time*, and explicit
+"if this, go here" routing. A **graph workflow** makes that shape first-class: nodes
+(each does one job — a function, one LLM call, or a whole loop turn) connected by edges
+(what happens next). It's an extension of the Loop pillar, not a replacement:
+[`loop/agent.py`](waku/loop/agent.py) did not change one line — a graph *arranges calls
+around it, and to it*. And it's still no-framework: the entire engine is
+[one readable file](waku/graph/engine.py), same trick as the loop.
+
+```mermaid
+flowchart LR
+  subgraph L["The loop — one path, step after step"]
+    T["think"] --> A["act"] --> O["observe"] --> T
+  end
+  subgraph G["A graph workflow — a map of steps"]
+    S(["START"]) --> C["classify<br/>small model"]
+    S --> K["check calendar<br/>local read"]
+    C --> R{"route"}
+    K --> R
+    R -. quick .-> Q["quick reply<br/>small model"] --> E(["END"])
+    R -. full .-> F["full agent<br/>THE loop, as a node"] --> E
+  end
+```
+
+**The shipped example: triage.** Flip `WAKU_GRAPH_WORKFLOWS=1` (in `.env`, or the
+dashboard's Settings) and *every* message enters the triage graph first — you never
+choose a mode, the harness decides. A small model classifies the message **while**
+today's calendar loads in parallel; *"thanks!"* gets a fast small-model reply and never
+wakes the big model; *"schedule a swim Saturday"* routes into the exact same loop as
+before, running as one node. Any failure anywhere — classifier, engine, anything —
+**fails open** to the plain loop, so the flag can only ever save time and tokens. This
+is the retrieval-gate idea generalized from one gate to a structure. (A graph is *not*
+a swarm of chatting agents: the edges decide everything, deterministically — which is
+why it can be traced and eval'd like everything else here.)
+
+**How to show it on camera:**
+1. Switch the flag on, then send *"thanks!"* — on **Overview**, the graph panel lights
+   the quick path while the LOOP boxes stay dark: proof the big model never woke.
+2. Send *"schedule a swim Saturday 9am"* — watch `route → full_agent` light up, then the
+   familiar loop animation take over. Same loop, one graph node.
+3. Open the **Graph** tab: the live topology there is drawn from the engine's own
+   `describe()` — the picture *cannot* drift from the code. The trace
+   (`.waku/traces/<today>.jsonl`) shows the run on tape:
+   `graph_start → node_start … route → graph_end`.
 
 ## The two hero moments
 
@@ -474,6 +525,7 @@ something, but nothing is over-promised (they report "coming soon", and the dash
 | Whiteboard box | Tool | Status |
 |---|---|---|
 | Sub-Agents | `delegate_task` | **live** — delegates coding tasks to pi |
+| Graph workflows | [`waku/graph/`](waku/graph) | **live** behind `WAKU_GRAPH_WORKFLOWS=1` — [triage-first turns](#graph-workflows--when-a-turn-needs-shape) |
 | Terminal tool | `run_command` | skeleton — needs a real sandbox + safety surface first |
 | Browser tool | `browse_web` | skeleton — `search_web` already covers read-only lookups |
 | Cron Job | `schedule_task` | skeleton — `make brief` + a system cron line covers it today |

--- a/docs/agent-graphs-design.md
+++ b/docs/agent-graphs-design.md
@@ -1,6 +1,11 @@
 # Agent Graphs — system design
 
-Status: DESIGN, not built. Nothing in this doc exists in code yet.
+Status: phases 1–3 SHIPPED (engine + triage graph workflow behind
+`WAKU_GRAPH_WORKFLOWS` + dashboard Graph tab). The content workflow (§4.2) and the
+AutoManus port (§5) remain future work. Two shipped deviations from this doc:
+triage has no `search_memory` fan-out node (the full path's retrieval gate already
+covers it — a parallel prefetch would double-retrieve), and a `gather` fan-in node
+sits before the router so it waits on both parallel branches.
 Scope: a fifth pillar candidate — **Graph** — sitting beside Harness, Loop, Memory, Eval.
 
 ## 1. What we're adding and why

--- a/docs/agent-graphs-design.md
+++ b/docs/agent-graphs-design.md
@@ -1,0 +1,218 @@
+# Agent Graphs — system design
+
+Status: DESIGN, not built. Nothing in this doc exists in code yet.
+Scope: a fifth pillar candidate — **Graph** — sitting beside Harness, Loop, Memory, Eval.
+
+## 1. What we're adding and why
+
+`waku/loop/agent.py` is one agent turn: a while-loop where the model picks tools until
+it stops. That covers every conversational task. What it cannot express:
+
+- **Parallel work** — three research calls that could run at once run one after another.
+- **Explicit routing** — "if X go here, else go there" lives buried in prompt text, not
+  in inspectable structure.
+- **Multi-step pipelines** — generate → check (several checks at once) → publish-or-revise
+  has shape; a single loop turn flattens it into one long transcript.
+
+A **graph** makes that shape first-class: nodes (a function, an LLM call, or a whole
+`run_loop` turn) connected by edges, some conditional, some parallel. The loop stays the
+default path for chat; graphs are opt-in per workflow.
+
+**Relationship to sub-agents/swarms** (for the docs): a graph is *structure*, not a kind
+of agent. A node MAY be a sub-agent (a scoped `run_loop` call), but most nodes are plain
+functions or single LLM calls. No peer-to-peer agent messaging, no swarm — execution
+follows the edges, deterministically. That determinism is the point: you can trace it,
+eval it, and explain it on a whiteboard.
+
+## 2. Decision: no LangGraph
+
+Build a small engine in-repo. Reasons, in Waku terms:
+
+1. **No new dependencies** rule — core stays stdlib + anthropic/openai.
+2. The teaching bar: "each pillar legible on its own." A ~200-line engine you can read
+   beats a framework you have to trust. Same trick as `loop/agent.py`: show the whole
+   mechanism in one file.
+3. Our needs are: fan-out/fan-in, conditional edges, bounded cycles, tracing. That is a
+   topological sort plus a thread pool — not a framework's worth of surface.
+
+Revisit only if graphs become the center of gravity (checkpointing/resume across
+processes, distributed nodes). Not now.
+
+## 3. The engine — `waku/graph/`
+
+```
+waku/graph/
+  engine.py       # Graph, Node, run_graph — the whole mechanism, one file
+  nodes.py        # node factories: llm_node, tool_node, agent_node, router helpers
+  workflows/      # one file per real workflow (triage.py, content.py, ...)
+```
+
+### 3.1 Core model (engine.py)
+
+```python
+NodeFn = Callable[[GraphState], dict]      # reads state, returns keys to merge
+RouteFn = Callable[[GraphState], str]      # reads state, returns next node's name
+
+@dataclass
+class Node:
+    name: str
+    fn: NodeFn
+    max_visits: int = 1        # >1 only on nodes that sit inside an intended cycle
+
+class Graph:
+    def add_node(self, node: Node) -> None
+    def add_edge(self, src: str, dst: str) -> None            # unconditional
+    def add_router(self, src: str, route: RouteFn,
+                   targets: dict[str, str]) -> None           # conditional
+    # special names: START, END
+
+def run_graph(graph: Graph, state: dict,
+              observer: Observer | None = None,
+              max_steps: int = 25) -> GraphState
+```
+
+- **State is a single dict** (the blackboard). Every node receives the whole state and
+  returns a dict of keys to merge. No typed channels, no reducers — a newcomer can
+  print(state) at any point and understand the run. Parallel branches write **disjoint
+  keys** (enforced: merging a key another live branch already wrote raises — collisions
+  are a graph bug, not a race to silently lose).
+- **Execution**: ready-queue over the DAG. A node is ready when all its in-edges have
+  fired. Ready nodes run **concurrently on a ThreadPoolExecutor** (stdlib; the whole
+  codebase is sync — asyncio would force a rewrite of tools and models for zero gain).
+- **Routers** are ordinary Python functions over state — not LLM calls by default. When
+  a decision needs a model, the node *before* the router makes the LLM call and writes
+  e.g. `state["score"]`; the router just reads it. Keeps routing testable with 0/1 evals.
+- **Cycles**: allowed only via an explicit router edge pointing backwards, guarded twice:
+  per-node `max_visits` and global `max_steps` — the same two-guardrail pattern as
+  `run_loop`'s natural-stop + max_iterations.
+- **Errors**: a node exception is written to `state["errors"][node]` and routes to END
+  through an optional `on_error` target — mirrors `ToolRegistry.execute`'s
+  surface-don't-crash rule.
+
+### 3.2 Node types (nodes.py) — factories, not classes
+
+Everything is a `NodeFn`; these helpers just build common ones:
+
+| factory | wraps | typical use |
+|---|---|---|
+| `tool_node(fn, in_keys, out_key)` | plain function | DB lookup, FTS5 search, ICS read |
+| `llm_node(prompt_template, out_key, small=True)` | ONE model call, no tools | classify, score, extract |
+| `agent_node(system, tools, out_key)` | a full `run_loop` turn with a **scoped ToolRegistry** | a step that genuinely needs multi-step tool use |
+| `human_node(question, out_key)` | pause; gateway asks, answer resumes | approval gates (phase 2+) |
+
+`agent_node` is the sub-agent story: same loop, same tracing, just a narrow tool subset
+and its own working memory. Graphs don't replace the loop — they arrange calls to it.
+
+### 3.3 Observability
+
+`run_graph` takes the **same `Observer` signature** as `run_loop` and emits:
+`graph_start`, `node_start`, `node_end` (with duration + state keys written), `route`
+(router name + chosen target), `graph_end`. Inside an `agent_node`, the inner loop's
+`llm`/`tool` events pass through with a `node=` field. Traces land in the same JSONL →
+the dashboard gets a graph timeline view later without touching the engine.
+
+### 3.4 Evals
+
+- `evals/deterministic/test_graph_engine.py` — pure-function nodes, no LLM:
+  topology order, fan-out runs in parallel (assert wall-clock < sum), fan-in waits for
+  all branches, router picks correct edge, disjoint-key enforcement raises, cycle stops
+  at max_visits, error path routes to on_error, max_steps hard stop.
+- Each shipped workflow gets its own deterministic eval with LLM nodes stubbed
+  (inject fake `NodeFn`s), plus judge evals on real end-to-end output where scoring
+  is fuzzy (content quality).
+
+Gate rule unchanged: `make gate` before any push; live bug → fix + regression case.
+
+## 4. Workflows in Waku (use cases 2 & 3)
+
+### 4.1 `workflows/triage.py` — inbound message triage (phase 2)
+
+For messages arriving via telegram/discord gateways: decide fast, in parallel, what an
+incoming message needs before the main loop ever spends a big-model turn on it.
+
+```
+START
+  ├─ classify_intent   (llm_node, small model: question/task/urgent/social)
+  ├─ search_memory     (tool_node: FTS5 semantic store)
+  └─ check_calendar    (tool_node: today's events from calendar.ics)
+        ↓ (fan-in)
+  route(intent, urgency):
+      social/trivial → quick_reply   (llm_node, small model)         → END
+      task/question  → full_agent    (agent_node: the normal loop,
+                                      pre-loaded with memory+calendar context) → END
+      urgent         → notify_now    (tool_node: send_message)       → END
+```
+
+Value over today: the three context fetches run at once, and trivial messages never
+touch the big model. This is the retrieval-gate idea generalized from one gate to a
+structure.
+
+### 4.2 `workflows/content.py` — draft → parallel checks → publish/revise (phase 3)
+
+```
+START → draft (agent_node: writing tools)
+  ├─ check_tone       (llm_node, small)
+  ├─ check_facts      (agent_node: search tool only)
+  └─ check_length     (tool_node: pure function)
+        ↓ (fan-in) → aggregate (tool_node: min of scores + collected feedback)
+  route(score):
+      pass            → save_note → END
+      fixable         → revise (llm_node, gets feedback) → back to checks   [max_visits=2]
+      unsalvageable   → human_node → END
+```
+
+Demonstrates the bounded cycle and the human gate — the two riskiest engine features —
+in a low-stakes personal task.
+
+## 5. AutoManus — lead qualification (use case 1)
+
+Different repo, different constraints. Design here, build separately.
+
+- **Where**: the FastAPI backend (`app-backend-AutoManus`), NOT the Next.js frontend —
+  "AI agents live in the backend" rule. The backend repo is not cloned in this session,
+  so this section is a spec.
+- **How**: port the ~200-line engine pattern into `ai_utils/graph/` (copy, don't share a
+  package — the repos stay independent; the engine is small enough that a fork is
+  cheaper than a shared dependency).
+- **Endpoint**: `POST /api/v1/leads/qualify` (verify_token + business scoping as usual).
+
+```
+START (contact_id, business_id)
+  ├─ fetch_history     (Supabase: whatsapp_messages filtered by agent_id, deals)
+  ├─ research_company  (LLM + web/company enrichment)
+  └─ recent_activity   (last-touch recency, channel, response latency)
+        ↓ (fan-in) → score (LLM node → {score, reasons})
+  route(score):
+      hot  (≥0.8)      → draft_followup (existing follow-up plan machinery) → END
+      warm (0.5–0.8)   → add_to_nurture → END
+      cold (<0.5)      → tag_and_skip   → END
+```
+
+- **Credits**: deduct via the credit service BEFORE the LLM nodes, per repo convention.
+- **Frontend**: one hook (`useLeadQualification`) calling the endpoint; results render
+  on the deal — no graph engine in the frontend at all.
+- **Output contract**: `{score, band, reasons[], action_taken, drafted_message?}` so the
+  UI and the daily "who to chase" brief consume the same shape.
+
+## 6. Phasing
+
+| phase | deliverable | proves |
+|---|---|---|
+| 1 | `graph/engine.py` + `nodes.py` + full deterministic eval suite | the mechanism, with zero LLM spend |
+| 2 | `workflows/triage.py` wired behind a flag + tracing events | real value on the live assistant |
+| 3 | `workflows/content.py` | cycles + human gate |
+| 4 | AutoManus backend port + `/leads/qualify` | the pattern travels |
+
+Each phase is one PR (topic branch → gate → squash-merge), shippable alone.
+
+## 7. Decisions taken (flag disagreement before phase 1)
+
+1. **No LangGraph** — in-repo engine, stdlib only.
+2. **Threads, not asyncio** — matches the sync codebase; parallelism is I/O-bound
+   (API calls), so the GIL is irrelevant.
+3. **Dict blackboard with disjoint-key writes** — over typed state/reducers; legibility
+   wins, collisions fail loudly.
+4. **Routers are code, not LLM calls** — models produce state, functions read it.
+5. **Graphs are opt-in structure around the loop** — `run_loop` untouched; `agent_node`
+   composes it. The loop pillar's file does not change.
+6. **Copy the engine into AutoManus** rather than extracting a shared library.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,8 +66,17 @@ flowchart TB
 - **Every layer has a boring default and a documented upgrade** — FTS5 → pgvector,
   mock calendar → Google Calendar, JSONL → Phoenix/Langfuse. The default is always
   zero-signup.
+- **Graphs wrap the loop, never replace it.** When a turn needs shape (parallel
+  steps, explicit routing), an opt-in graph workflow (`waku/graph/`) arranges nodes
+  around the untouched loop — the `full_agent` node IS `run_loop`. Routers are plain
+  code reading state a model wrote; every failure fails open to the plain loop; the
+  dashboard renders the topology from the engine's own `describe()` so the picture
+  can't drift. See `docs/agent-graphs-design.md`.
 
 ## What this deliberately is not
 
-Not a framework, not multi-agent, not production. It's the readable blueprint —
-OpenClaw and Hermes are the products; this is the afternoon read that explains them.
+Not a framework, not multi-agent, not production. (Still not multi-agent even with
+graph workflows: a graph's `agent_node` is the same loop invoked as one step — no
+peer-to-peer agent messaging, execution follows the edges deterministically.) It's
+the readable blueprint — OpenClaw and Hermes are the products; this is the afternoon
+read that explains them.

--- a/evals/deterministic/test_dashboard_routes.py
+++ b/evals/deterministic/test_dashboard_routes.py
@@ -90,7 +90,7 @@ def test_collect_returns_the_keys_the_page_reads():
     frontend indexes into; dropping one blanks a tab with no error."""
     expected = {
         "settings", "tools", "facts", "episodes", "soul", "chat_log", "sessions",
-        "turns", "stats", "db", "skills", "trace_file", "chat_pending",
+        "turns", "stats", "db", "skills", "trace_file", "chat_pending", "graph",
     }
     src = inspect.getsource(dashboard.collect)
     for key in expected:

--- a/evals/deterministic/test_gather_workflow.py
+++ b/evals/deterministic/test_gather_workflow.py
@@ -1,0 +1,264 @@
+"""DETERMINISTIC EVAL — the gather workflow: really parallel, and unable to act.
+
+Two claims this workflow makes, both of which would be embarrassing to make
+falsely on camera:
+
+  1. THE FOUR SCANS RUN AT THE SAME TIME. Not "are drawn side by side" — the
+     engine puts them in one wave and a ThreadPoolExecutor runs them together.
+     test_the_four_scans_really_overlap measures it rather than trusting the
+     picture.
+
+  2. IT PROPOSES, IT NEVER ACTS. No agent_node, no run_loop, no ToolRegistry,
+     and the single model call passes no tools. A model that is never handed a
+     tool schema cannot call a tool. test_the_workflow_cannot_act reads the
+     source, because that is the only way to catch someone adding a tool-using
+     node later "just to make the digest smarter".
+
+Everything here runs offline: injected callables, no model, no network, no gh.
+"""
+
+from __future__ import annotations
+
+import inspect
+import threading
+import time
+
+import pytest
+
+from waku.graph import END, run_graph
+from waku.graph.workflows.gather import (
+    SCAN_KEYS,
+    build_gather_graph,
+    gather_topology,
+    needs_action,
+)
+
+
+def _graph(**overrides):
+    """A gather with harmless stubs; override one callable per test."""
+    base = {
+        "github_fn": lambda: {"gh_text": "prs", "gh_open_prs": 2, "gh_open_issues": 1},
+        "web_fn": lambda: "web",
+        "calendar_fn": lambda: {"cal_text": "cal", "cal_event_count": 1},
+        "memory_fn": lambda s=None: "mem",
+        "synth_fn": lambda s: "DIGEST",
+        "draft_fn": lambda s: "/tmp/gather.md",
+    }
+    base.update(overrides)
+    return build_gather_graph(**base)
+
+
+# --- claim 1: it is really parallel -----------------------------------------
+
+def test_the_four_scans_really_overlap():
+    """The claim the whole video rests on. Each scan records when it started and
+    sleeps; if the engine ran them one after another the last would start ~3
+    sleeps after the first. Asserting on OVERLAP rather than on total duration
+    keeps this stable on a loaded CI box."""
+    SLEEP = 0.15
+    started: dict[str, float] = {}
+    lock = threading.Lock()
+
+    def slow(name: str, out: dict):
+        def fn():
+            with lock:
+                started[name] = time.perf_counter()
+            time.sleep(SLEEP)
+            return out
+        return fn
+
+    # All four use the same helper so every one records its start BEFORE
+    # sleeping — timing the sleep itself would just measure the sleep.
+    g = _graph(
+        github_fn=slow("gh", {"gh_text": "", "gh_open_prs": 0, "gh_open_issues": 0}),
+        web_fn=lambda: slow("web", {"web_text": ""})()["web_text"],
+        calendar_fn=slow("cal", {"cal_text": "", "cal_event_count": 0}),
+        memory_fn=lambda: slow("mem", {"mem_text": ""})()["mem_text"],
+    )
+    t0 = time.perf_counter()
+    run_graph(g, {})
+    elapsed = time.perf_counter() - t0
+
+    spread = max(started.values()) - min(started.values())
+    assert spread < SLEEP, (
+        f"the scans started {spread:.3f}s apart — more than one sleep, so they "
+        "ran in sequence, not together"
+    )
+    assert elapsed < SLEEP * 3, (
+        f"the whole gather took {elapsed:.3f}s; three sequential sleeps would be "
+        f"{SLEEP * 3:.3f}s, so the wave is not running in parallel"
+    )
+
+
+def test_synthesize_waits_for_every_scan():
+    """Fan-in: the digest must not be written from three of four sources. The
+    engine enforces this through static deps; this pins it against someone
+    'simplifying' an edge away."""
+    order: list[str] = []
+    lock = threading.Lock()
+
+    def note(name, out):
+        def fn():
+            with lock:
+                order.append(name)
+            return out
+        return fn
+
+    g = _graph(
+        github_fn=note("scan", {"gh_text": "", "gh_open_prs": 0, "gh_open_issues": 0}),
+        web_fn=lambda: (order.append("scan"), "")[-1],
+        calendar_fn=note("scan", {"cal_text": "", "cal_event_count": 0}),
+        memory_fn=lambda: (order.append("scan"), "")[-1],
+        synth_fn=lambda s: (order.append("synth"), "D")[-1],
+    )
+    run_graph(g, {})
+    assert order.count("scan") == 4
+    assert order.index("synth") == 4, f"synthesize ran before all four scans: {order}"
+
+
+def test_scan_nodes_write_disjoint_keys():
+    """Parallel nodes writing the same key raise GraphStateCollision. The prefix
+    convention is what stops that happening; check it holds."""
+    seen: set[str] = set()
+    for node, keys in SCAN_KEYS.items():
+        clash = seen & set(keys)
+        assert not clash, f"{node} reuses {clash} — parallel branches must be disjoint"
+        seen |= set(keys)
+
+
+# --- claim 2: one dead branch must not kill the briefing ---------------------
+
+def test_one_dead_branch_still_yields_a_digest():
+    """A node that raises fires no edges, so synthesize's deps would never
+    complete and the run would produce NOTHING — no error, no digest, an empty
+    outbox. Silence is the worst failure for a morning routine. _safe exists to
+    prevent exactly this; removing it must fail here."""
+    def boom():
+        raise RuntimeError("github is down")
+
+    state = run_graph(_graph(github_fn=boom), {})
+    assert state.get("digest") == "DIGEST", "a dead scan silently killed the whole gather"
+    assert "unavailable" in state["gh_text"] and "github is down" in state["gh_text"]
+    assert state["gh_open_prs"] == 0
+
+
+def test_every_branch_can_die_and_the_briefing_survives():
+    for killed in ("github_fn", "web_fn", "calendar_fn", "memory_fn"):
+        def boom():
+            raise RuntimeError("nope")
+
+        state = run_graph(_graph(**{killed: boom}), {})
+        assert state.get("digest") == "DIGEST", f"{killed} failing killed the gather"
+
+
+# --- the router --------------------------------------------------------------
+
+@pytest.mark.parametrize("state,expected", [
+    ({"gh_open_prs": 2}, "propose"),
+    ({"gh_open_issues": 1}, "propose"),
+    ({"cal_event_count": 3}, "propose"),
+    ({"gh_open_prs": 0, "gh_open_issues": 0, "cal_event_count": 0}, "quiet"),
+    ({}, "quiet"),
+])
+def test_the_router_is_code_over_counts(state, expected):
+    """Routing on counts, never on the digest's wording — the engine's rule is
+    'routers are code, never models'. It also means this table exists at all."""
+    assert needs_action(state) == expected
+
+
+def test_a_quiet_morning_writes_nothing():
+    """Nothing open, nothing on: no file. A briefing that writes an empty digest
+    every morning trains you to ignore the folder."""
+    wrote: list[str] = []
+    g = _graph(
+        github_fn=lambda: {"gh_text": "", "gh_open_prs": 0, "gh_open_issues": 0},
+        calendar_fn=lambda: {"cal_text": "", "cal_event_count": 0},
+        draft_fn=lambda s: (wrote.append("x"), "/tmp/x")[-1],
+    )
+    state = run_graph(g, {})
+    assert wrote == [], "drafted a digest on a morning with nothing to report"
+    assert "draft_path" not in state
+
+
+def test_a_busy_morning_drafts():
+    state = run_graph(_graph(), {})
+    assert state["draft_path"] == "/tmp/gather.md"
+
+
+# --- the propose-never-act guarantee ----------------------------------------
+
+def test_the_workflow_cannot_act():
+    """THE structural guarantee, checked at the source level because there is no
+    runtime signal for 'someone added a tool-using node'.
+
+    The day an agent_node appears here to make the digest smarter, this graph
+    gains the ability to send messages and create events, and nothing else in
+    the system would notice. The model call in the binder passes NO tools
+    parameter — a model handed no tool schemas cannot call a tool, which is a
+    guarantee about capability rather than about instructions.
+    """
+    from waku.graph.workflows import gather as workflow
+    from waku.ops import gather as binder
+
+    for module in (workflow, binder):
+        code = _code_lines(module)
+        for banned in ("agent_node", "run_loop", "ToolRegistry", "send_message",
+                       "create_event", "subprocess"):
+            offenders = [ln.strip() for ln in code if banned in ln]
+            assert offenders == [], (
+                f"{module.__name__} now references {banned!r}: {offenders}. The gather "
+                "PROPOSES and never ACTS — it drafts into the outbox for a human. "
+                "Adding a tool-using node here silently removes that guarantee."
+            )
+    # Assert on the CALL, via the AST — not on a substring, because the function
+    # docstring explains the rule and would match itself. This also states the
+    # property exactly: whatever else the call grows, it must never gain a
+    # `tools=` keyword.
+    import ast
+
+    calls = [n for n in ast.walk(ast.parse(inspect.getsource(binder._synthesize)))
+             if isinstance(n, ast.Call)
+             and isinstance(n.func, ast.Attribute) and n.func.attr == "create"]
+    assert calls, "expected a messages.create call in _synthesize"
+    for call in calls:
+        passed = {kw.arg for kw in call.keywords}
+        assert "tools" not in passed, (
+            "the synthesis call now passes tools — the model could act from "
+            "inside a workflow whose entire contract is that it cannot"
+        )
+
+
+def _code_lines(module) -> list[str]:
+    """Source minus docstrings and comments — these modules DISCUSS the banned
+    names at length in prose explaining why they are banned, and a test that
+    trips over its own explanation is a bad test (the lesson from
+    test_apple_tools.py's `whose` rule)."""
+    import ast
+
+    src = inspect.getsource(module)
+    doc: set[int] = set()
+    for node in ast.walk(ast.parse(src)):
+        if isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant) \
+                and isinstance(node.value.value, str):
+            doc.update(range(node.lineno, (node.end_lineno or node.lineno) + 1))
+    return [ln for i, ln in enumerate(src.splitlines(), 1)
+            if i not in doc and not ln.strip().startswith("#")]
+
+
+# --- the topology the dashboard draws ---------------------------------------
+
+def test_the_topology_matches_the_graph_that_runs():
+    """The chart is rendered from describe(), so it cannot drift — as long as
+    the stub build and the real build stay the same shape."""
+    assert gather_topology() == _graph().describe()
+
+
+def test_the_chart_shows_a_four_way_fan_out():
+    topo = gather_topology()
+    from_start = {e["dst"] for e in topo["edges"] if e["src"] == "START"}
+    assert from_start == set(SCAN_KEYS), from_start
+    into_synth = {e["src"] for e in topo["edges"] if e["dst"] == "synthesize"}
+    assert into_synth == set(SCAN_KEYS), "every scan must feed the fan-in"
+    conditional = {(e["src"], e["dst"]) for e in topo["edges"] if e["conditional"]}
+    assert conditional == {("synthesize", "draft_digest"), ("synthesize", END)}
+    assert {n["name"] for n in topo["nodes"]} == set(SCAN_KEYS) | {"synthesize", "draft_digest"}

--- a/evals/deterministic/test_graph_engine.py
+++ b/evals/deterministic/test_graph_engine.py
@@ -1,0 +1,205 @@
+"""Graph engine mechanics — pure-function nodes, zero LLM, zero network.
+
+These pin the contracts everything downstream relies on: execution order
+(graph_end.path), real parallelism inside a wave, the disjoint-key rule, both
+cycle guards, error draining, and the observer event schemas the dashboard
+renders from.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from waku.graph import END, START, Graph, GraphStateCollision, Node, run_graph
+from waku.graph.nodes import key_router
+
+
+def collect_events():
+    events: list[tuple[str, dict]] = []
+    return events, lambda kind, ev: events.append((kind, ev))
+
+
+def linear_graph() -> Graph:
+    g = Graph("linear")
+    g.add_node(Node("a", lambda s: {"a": 1}))
+    g.add_node(Node("b", lambda s: {"b": s["a"] + 1}))
+    g.add_node(Node("c", lambda s: {"c": s["b"] + 1}))
+    g.add_edge(START, "a")
+    g.add_edge("a", "b")
+    g.add_edge("b", "c")
+    g.add_edge("c", END)
+    return g
+
+
+def test_linear_topology_runs_in_edge_order():
+    events, observer = collect_events()
+    state = run_graph(linear_graph(), {}, observer=observer)
+    assert (state["a"], state["b"], state["c"]) == (1, 2, 3)
+    end = dict(events)["graph_end"]
+    assert end["path"] == ["a", "b", "c"]
+    assert end["error"] is None
+
+
+def test_fanout_runs_in_parallel_and_fanin_waits_for_all():
+    g = Graph("fan")
+
+    def slow(key):
+        def fn(state):
+            time.sleep(0.15)
+            return {key: key}
+        return fn
+
+    for key in ("x", "y", "z"):
+        g.add_node(Node(key, slow(key)))
+        g.add_edge(START, key)
+    g.add_node(Node("join", lambda s: {"joined": s["x"] + s["y"] + s["z"]}))
+    for key in ("x", "y", "z"):
+        g.add_edge(key, "join")
+    g.add_edge("join", END)
+
+    t0 = time.perf_counter()
+    state = run_graph(g, {})
+    elapsed = time.perf_counter() - t0
+    assert state["joined"] == "xyz"          # fan-in saw all three keys
+    assert elapsed < 0.35                    # 3 x 0.15s ran together, not in series
+
+
+def routed_graph() -> Graph:
+    g = Graph("routed")
+    g.add_node(Node("decide", lambda s: {"route": s["want"]}))
+    g.add_node(Node("quick", lambda s: {"took": "quick"}))
+    g.add_node(Node("full", lambda s: {"took": "full"}))
+    g.add_edge(START, "decide")
+    g.add_router("decide", key_router("route", default="full"),
+                 {"quick": "quick", "full": "full"})
+    g.add_edge("quick", END)
+    g.add_edge("full", END)
+    return g
+
+
+def test_router_picks_the_target_from_state():
+    events, observer = collect_events()
+    state = run_graph(routed_graph(), {"want": "quick"}, observer=observer)
+    assert state["took"] == "quick"
+    route = dict(events)["route"]
+    assert route["target"] == "quick" and route["reason"] == "quick"
+    assert run_graph(routed_graph(), {"want": "full"})["took"] == "full"
+
+
+def test_router_unknown_label_records_error_and_drains():
+    events, observer = collect_events()
+    state = run_graph(routed_graph(), {"want": "sideways"}, observer=observer)
+    assert "took" not in state
+    assert "unknown label" in state["errors"]["decide"]
+    assert dict(events)["graph_end"]["error"] is not None
+
+
+def test_unknown_edge_and_router_targets_raise_at_build_time():
+    g = Graph("bad")
+    g.add_node(Node("a", lambda s: {}))
+    with pytest.raises(ValueError):
+        g.add_edge("a", "ghost")
+    with pytest.raises(ValueError):
+        g.add_router("a", key_router("k", default="x"), {"x": "ghost"})
+
+
+def test_parallel_key_collision_raises():
+    g = Graph("collide")
+    g.add_node(Node("left", lambda s: {"same": 1}))
+    g.add_node(Node("right", lambda s: {"same": 2}))
+    g.add_edge(START, "left")
+    g.add_edge(START, "right")
+    with pytest.raises(GraphStateCollision):
+        run_graph(g, {})
+
+
+def test_sequential_overwrite_is_allowed():
+    state = run_graph(linear_graph(), {"a": 99})  # node 'a' rewrites key 'a'
+    assert state["a"] == 1
+
+
+def cycle_graph(max_visits: int) -> Graph:
+    g = Graph("cycle")
+    g.add_node(Node("work", lambda s: {"count": s.get("count", 0) + 1},
+                    max_visits=max_visits))
+    g.add_edge(START, "work")
+    g.add_router("work", lambda s: "again" if s["count"] < 99 else "done",
+                 {"again": "work", "done": END})
+    return g
+
+
+def test_cycle_stops_at_max_visits():
+    state = run_graph(cycle_graph(max_visits=3), {})
+    assert state["count"] == 3
+    assert "max_visits=3" in state["errors"]["work"]
+
+
+def test_max_steps_is_the_global_hard_stop():
+    events, observer = collect_events()
+    state = run_graph(cycle_graph(max_visits=99), {}, observer=observer, max_steps=5)
+    assert state["count"] == 5
+    assert "max_steps=5" in state["errors"]["engine"]
+    assert dict(events)["graph_end"]["steps"] == 5
+
+
+def test_node_exception_routes_to_on_error_and_never_raises():
+    g = Graph("boom")
+    g.add_node(Node("explode", lambda s: 1 / 0, on_error="fallback"))
+    g.add_node(Node("fallback", lambda s: {"saved": True}))
+    g.add_edge(START, "explode")
+    g.add_edge("fallback", END)
+    state = run_graph(g, {})
+    assert state["saved"] is True
+    assert "ZeroDivisionError" in state["errors"]["explode"]
+
+
+def test_node_exception_without_on_error_drains_to_end():
+    g = Graph("boom2")
+    g.add_node(Node("explode", lambda s: 1 / 0))
+    g.add_node(Node("after", lambda s: {"ran": True}))
+    g.add_edge(START, "explode")
+    g.add_edge("explode", "after")
+    events, observer = collect_events()
+    state = run_graph(g, {}, observer=observer)
+    assert "ran" not in state                     # downstream starved, run ended
+    assert dict(events)["graph_end"]["error"] is not None
+
+
+def test_observer_event_sequence_and_payload_schemas():
+    """Pins the exact kinds + keys the dashboard's graph view consumes."""
+    events, observer = collect_events()
+    run_graph(routed_graph(), {"want": "quick"}, observer=observer)
+    kinds = [k for k, _ in events]
+    assert kinds[0] == "graph_start" and kinds[-1] == "graph_end"
+    assert kinds == ["graph_start", "node_start", "node_end", "route",
+                     "node_start", "node_end", "graph_end"]
+    schemas = {"graph_start": {"workflow", "nodes"},
+               "node_start": {"workflow", "node", "visit"},
+               "node_end": {"workflow", "node", "ms", "keys", "error"},
+               "route": {"workflow", "router", "target", "reason"},
+               "graph_end": {"workflow", "ms", "steps", "path", "error"}}
+    for kind, ev in events:
+        assert schemas[kind] <= set(ev), f"{kind} missing {schemas[kind] - set(ev)}"
+
+
+def test_describe_reports_every_node_and_edge():
+    d = routed_graph().describe()
+    assert d["name"] == "routed"
+    assert {n["name"] for n in d["nodes"]} == {"decide", "quick", "full"}
+    conditional = {(e["src"], e["dst"]) for e in d["edges"] if e["conditional"]}
+    static = {(e["src"], e["dst"]) for e in d["edges"] if not e["conditional"]}
+    assert conditional == {("decide", "quick"), ("decide", "full")}
+    assert static == {(START, "decide"), ("quick", END), ("full", END)}
+
+
+def test_reserved_underscore_keys_never_merge_or_leak():
+    g = Graph("private")
+    g.add_node(Node("sneaky", lambda s: {"_secret": 1, "open": 2}))
+    g.add_edge(START, "sneaky")
+    events, observer = collect_events()
+    state = run_graph(g, {}, observer=observer)
+    assert "_secret" not in state and state["open"] == 2
+    assert dict(events)["node_end"]["keys"] == ["open"]
+    assert "_notify" not in state                 # engine plumbing stays internal

--- a/evals/deterministic/test_graph_flag.py
+++ b/evals/deterministic/test_graph_flag.py
@@ -1,0 +1,47 @@
+"""The WAKU_GRAPH_WORKFLOWS flag — same toggle contract as WAKU_EXPERIMENTAL.
+
+Clone of test_experimental_toggle.py's shape: the UI can render it, turning it
+OFF is not swallowed, an explicit Settings value beats the env, and
+load_settings reads the env var.
+"""
+
+from __future__ import annotations
+
+from waku.config import Settings, load_settings
+
+
+def test_settings_exposes_the_flag_so_the_ui_can_render_a_toggle(monkeypatch):
+    from waku.ops import settings_api
+
+    monkeypatch.delenv("WAKU_GRAPH_WORKFLOWS", raising=False)
+    assert settings_api.settings_info()["graph_workflows"] is False
+    monkeypatch.setenv("WAKU_GRAPH_WORKFLOWS", "1")
+    assert settings_api.settings_info()["graph_workflows"] is True
+
+
+def test_turning_it_off_is_not_swallowed():
+    """settings_save must use `is not None` — "" means OFF, absent means
+    don't touch. `if graph_workflows:` would make the toggle one-way."""
+    def rule(payload: dict):
+        graph_workflows = payload.get("graph_workflows")
+        if graph_workflows is None:
+            return None
+        return "1" if str(graph_workflows).strip() else ""
+
+    assert rule({"graph_workflows": "1"}) == "1"
+    assert rule({"graph_workflows": ""}) == ""
+    assert rule({}) is None
+
+
+def test_an_explicit_setting_beats_the_global_env_switch(tmp_path, monkeypatch):
+    monkeypatch.setenv("WAKU_GRAPH_WORKFLOWS", "1")
+    assert Settings(home=tmp_path, graph_workflows=False).graph_workflows is False
+    monkeypatch.delenv("WAKU_GRAPH_WORKFLOWS", raising=False)
+    assert Settings(home=tmp_path, graph_workflows=True).graph_workflows is True
+
+
+def test_env_var_is_what_load_settings_reads(monkeypatch):
+    monkeypatch.delenv("WAKU_GRAPH_WORKFLOWS", raising=False)
+    assert load_settings().graph_workflows is False
+    monkeypatch.setenv("WAKU_GRAPH_WORKFLOWS", "1")
+    assert load_settings().graph_workflows is True

--- a/evals/deterministic/test_graph_nodes.py
+++ b/evals/deterministic/test_graph_nodes.py
@@ -1,0 +1,62 @@
+"""Node factories — scripted LLM, real run_loop, zero network.
+
+agent_node is the one that matters: a whole loop turn as a single graph node,
+with its inner llm/tool events surfacing at the outer observer tagged node=.
+"""
+
+from __future__ import annotations
+
+from evals.helpers import ScriptedClient, response, text_block, tool_block
+from waku.graph import END, START, Graph, run_graph
+from waku.graph.nodes import agent_node, llm_node, tool_node
+from waku.tools.registry import Tool, ToolRegistry
+
+
+def one_node_graph(node) -> Graph:
+    g = Graph("solo")
+    g.add_node(node)
+    g.add_edge(START, node.name)
+    g.add_edge(node.name, END)
+    return g
+
+
+def test_tool_node_maps_in_keys_to_out_key():
+    node = tool_node("add", lambda a, b: a + b, in_keys=["x", "y"], out_key="total")
+    state = run_graph(one_node_graph(node), {"x": 2, "y": 3})
+    assert state["total"] == 5
+
+
+def test_llm_node_formats_prompt_from_state_and_writes_reply():
+    client = ScriptedClient([response([text_block("quick")])])
+    node = llm_node("classify", "Message: {message}", out_key="route",
+                    client=client, model="small-model")
+    state = run_graph(one_node_graph(node), {"message": "thanks!"})
+    assert state["route"] == "quick"
+
+
+def test_agent_node_runs_a_real_loop_turn_with_tagged_events():
+    registry = ToolRegistry()
+    calls: list[dict] = []
+    registry.register(Tool(
+        name="save_note", description="save a note",
+        input_schema={"type": "object", "properties": {"text": {"type": "string"}}},
+        fn=lambda text: (calls.append({"text": text}), "saved")[1],
+    ))
+    client = ScriptedClient([
+        response([tool_block("save_note", {"text": "milk"})], "tool_use"),
+        response([text_block("Noted!")]),
+    ])
+    node = agent_node("full_agent", out_key="result", client=client,
+                      model="main-model", system="You are a test agent.",
+                      tools=registry)
+
+    events: list[tuple[str, dict]] = []
+    state = run_graph(one_node_graph(node), {"message": "note milk"},
+                      observer=lambda kind, ev: events.append((kind, ev)))
+
+    assert calls == [{"text": "milk"}]                    # the tool really ran
+    assert state["result"].reply == "Noted!"              # a real LoopResult
+    assert state["result"].iterations == 2
+    inner = [(k, ev) for k, ev in events if k in ("llm", "tool")]
+    assert inner, "inner loop events must pass through to the outer observer"
+    assert all(ev["node"] == "full_agent" for _, ev in inner)

--- a/evals/deterministic/test_graph_topology_payload.py
+++ b/evals/deterministic/test_graph_topology_payload.py
@@ -1,0 +1,45 @@
+"""The dashboard's graph chart can never lie about the engine's topology.
+
+archSVG had to be byte-frozen because a hand-drawn picture and its animation
+ids drift apart silently. The graph chart avoids that fate structurally: it is
+rendered from Graph.describe(), and this eval pins that the payload the
+dashboard serves IS the graph app.py actually runs.
+"""
+
+from __future__ import annotations
+
+from waku.graph.workflows.triage import build_triage_graph, triage_topology
+
+
+def real_graph():
+    return build_triage_graph(classify_fn=lambda m: ("full", ""),
+                              calendar_fn=lambda: "", quick_fn=lambda s: "",
+                              full_fn=lambda s: None)
+
+
+def test_topology_payload_matches_the_real_graph():
+    payload = triage_topology()
+    graph = real_graph()
+    assert {n["name"] for n in payload["nodes"]} == set(graph.nodes)
+    assert payload["name"] == graph.name == "triage"
+    described = {(e["src"], e["dst"]) for e in payload["edges"]}
+    rebuilt = {(e["src"], e["dst"]) for e in graph.describe()["edges"]}
+    assert described == rebuilt
+
+
+def test_topology_has_the_shape_the_readme_promises():
+    """classify and check_calendar fan out from START in parallel; the router
+    (a conditional edge) picks quick_reply or full_agent; both reach END."""
+    payload = triage_topology()
+    static = {(e["src"], e["dst"]) for e in payload["edges"] if not e["conditional"]}
+    conditional = {(e["src"], e["dst"]) for e in payload["edges"] if e["conditional"]}
+    assert ("START", "classify") in static and ("START", "check_calendar") in static
+    assert conditional == {("gather", "quick_reply"), ("gather", "full_agent")}
+    assert ("quick_reply", "END") in static and ("full_agent", "END") in static
+
+
+def test_node_kinds_are_labelled_for_the_chart():
+    kinds = {n["name"]: n["kind"] for n in triage_topology()["nodes"]}
+    assert kinds["classify"] == "llm"
+    assert kinds["check_calendar"] == "tool"
+    assert kinds["full_agent"] == "agent"      # THE loop, as a node — the story

--- a/evals/deterministic/test_triage_workflow.py
+++ b/evals/deterministic/test_triage_workflow.py
@@ -1,0 +1,150 @@
+"""The triage graph workflow + its app.py wiring — scripted, zero network.
+
+SCRIPTED-RESPONSE ORDER, read this before adding cases: with graph_workflows
+ON, the FIRST scripted response is the triage classifier. A quick turn then
+consumes one quick-reply response. A full turn consumes the retrieval gate
+next, THEN the loop's responses — i.e. everything test_tool_trigger.py taught
+you, shifted one response later.
+"""
+
+from __future__ import annotations
+
+import json
+
+from evals.helpers import ScriptedClient, make_waku, response, text_block, tool_block
+from waku.graph.workflows.triage import classify_message, todays_events
+
+
+def last_meta(app) -> dict:
+    """The persisted turn meta, exactly as a reopened thread would read it."""
+    row = app.conn.execute(
+        "SELECT meta FROM chat_log WHERE role='assistant' ORDER BY id DESC LIMIT 1"
+    ).fetchone()
+    return json.loads(row["meta"])
+
+
+class Boom:
+    """A client whose every call explodes — for the fail-open cases."""
+
+    def __init__(self):
+        from types import SimpleNamespace
+        self.messages = SimpleNamespace(create=self._create)
+
+    def _create(self, **kwargs):
+        raise RuntimeError("boom")
+
+
+def classify(reply_text: str):
+    return classify_message(ScriptedClient([response([text_block(reply_text)])]),
+                            "small-model", "hello")
+
+
+def test_classifier_parses_routes_and_fails_open_on_garbage():
+    assert classify('{"route": "quick", "reason": "just a greeting"}') == (
+        "quick", "just a greeting")
+    assert classify('{"route": "full", "reason": "needs calendar"}')[0] == "full"
+    # every malformed shape falls open to full — capability over latency
+    assert classify("no json here at all")[0] == "full"
+    assert classify('{"route": "sideways"}')[0] == "full"
+    assert classify_message(Boom(), "small-model", "hi")[0] == "full"
+
+
+def test_todays_events_reads_the_ics(tmp_path):
+    assert todays_events(tmp_path) == "(no calendar)"
+    from datetime import datetime
+    today = datetime.now().strftime("%Y%m%d")
+    (tmp_path / "calendar.ics").write_text(
+        "BEGIN:VCALENDAR\nBEGIN:VEVENT\nSUMMARY:swim\n"
+        f"DTSTART:{today}T090000\nEND:VEVENT\nEND:VCALENDAR\n", encoding="utf-8")
+    assert todays_events(tmp_path) == "swim"
+
+
+def test_flag_off_is_byte_for_byte_the_old_world(tmp_path):
+    gate = response([text_block('{"retrieve": false, "query": "", "reason": "test"}')])
+    app = make_waku(tmp_path / "home",
+                    client=ScriptedClient([gate, response([text_block("Hi!")])]),
+                    graph_workflows=False)
+    events = []
+    result = app.respond("hello", observer=lambda k, ev: events.append(k))
+    assert result.reply == "Hi!"
+    assert not any(k in ("graph_start", "route", "graph_end") for k in events)
+    meta = last_meta(app)
+    assert meta["graph"] is None
+
+
+def test_quick_turn_answers_on_the_small_model_and_skips_the_gate(tmp_path):
+    script = [
+        response([text_block('{"route": "quick", "reason": "just thanks"}')]),  # triage
+        response([text_block("You're welcome!")]),                              # quick reply
+    ]
+    app = make_waku(tmp_path / "home", client=ScriptedClient(script),
+                    graph_workflows=True, small_model="small-model")
+    events: list[tuple[str, dict]] = []
+    result = app.respond("thanks!", observer=lambda k, ev: events.append((k, ev)))
+
+    assert result.reply == "You're welcome!"
+    assert result.iterations == 1 and result.tool_calls == []
+    kinds = [k for k, _ in events]
+    assert "graph_start" in kinds and "route" in kinds and "graph_end" in kinds
+    assert "gate" not in kinds, "quick turns never touch memory retrieval"
+    assert "llm" not in kinds, "quick turns never wake the big model's loop"
+    meta = last_meta(app)
+    assert meta["graph"]["route"] == "quick"
+    assert meta["graph"]["reason"] == "just thanks"
+    assert meta["gate"] is None
+    assert meta["model"] == "small-model"          # honest per-path model
+
+
+def test_full_turn_runs_the_real_loop_with_both_funnel_stages(tmp_path):
+    script = [
+        response([text_block('{"route": "full", "reason": "wants an event"}')]),   # triage
+        response([text_block('{"retrieve": false, "query": "", "reason": "n"}')]),  # gate
+        response([tool_block("create_event", {"title": "Swim", "start": "2026-08-01 09:00",
+                                              "end": "2026-08-01 10:00"})], "tool_use"),
+        response([text_block("Booked!")]),
+    ]
+    app = make_waku(tmp_path / "home", client=ScriptedClient(script),
+                    graph_workflows=True)
+    events: list[str] = []
+    result = app.respond("swim saturday 9am", observer=lambda k, ev: events.append(k))
+
+    assert result.reply == "Booked!"
+    assert result.tool_calls and result.tool_calls[0]["tool"] == "create_event"
+    assert "route" in events and "gate" in events   # both funnel stages recorded
+    meta = last_meta(app)
+    assert meta["graph"]["route"] == "full"
+    assert meta["gate"] is not None
+    assert meta["model"] == app.settings.model
+    assert "full_agent" in meta["graph"]["path"]
+
+
+def test_broken_classifier_fails_open_to_the_full_loop(tmp_path):
+    script = [
+        response([text_block("not json — classifier had a bad day")]),               # triage
+        response([text_block('{"retrieve": false, "query": "", "reason": "n"}')]),   # gate
+        response([text_block("Still here.")]),                                        # loop
+    ]
+    app = make_waku(tmp_path / "home", client=ScriptedClient(script),
+                    graph_workflows=True)
+    assert app.respond("hello?").reply == "Still here."
+
+
+def test_broken_graph_engine_fails_open_to_the_plain_loop(tmp_path, monkeypatch):
+    """Layer two: even if graph construction itself explodes, respond() answers."""
+    from waku.graph.workflows import triage
+
+    def explode(**kwargs):
+        raise RuntimeError("graph machinery on fire")
+    monkeypatch.setattr(triage, "build_triage_graph", explode)
+    script = [
+        response([text_block('{"retrieve": false, "query": "", "reason": "n"}')]),   # gate
+        response([text_block("Saved by the loop.")]),
+    ]
+    app = make_waku(tmp_path / "home", client=ScriptedClient(script),
+                    graph_workflows=True)
+    events: list[str] = []
+    result = app.respond("hello", observer=lambda k, ev: events.append(k))
+    assert result.reply == "Saved by the loop."
+    assert "graph_end" in events                     # the failure is on tape
+    meta = last_meta(app)
+    assert meta["graph"] is None                     # no route happened — honest meta

--- a/waku/__init__.py
+++ b/waku/__init__.py
@@ -3,6 +3,7 @@
 Four pillars, one module each:
   harness  → waku/runtime + waku/gateway  (scaffolding around the raw LLM)
   loop     → waku/loop                      (observe → reason → act → repeat)
+             waku/graph                     (opt-in structure around the loop — extends this pillar)
   memory   → waku/memory                    (procedural / semantic / episodic)
   ops      → waku/ops + evals/              (trace → eval → gate → release)
 """

--- a/waku/__main__.py
+++ b/waku/__main__.py
@@ -6,7 +6,9 @@
   waku telegram              phone → laptop (needs TELEGRAM_BOT_TOKEN)
   waku discord               Discord → laptop (needs DISCORD_BOT_TOKEN)
   waku whatsapp              WhatsApp → laptop (needs WHATSAPP_TOKEN, public URL)
-  waku brief                 morning briefing (calendar + mail + memory)
+  waku brief                 morning briefing (calendar + mail + memory) — as a LOOP
+  waku gather                same job as a GRAPH: github, web, calendar and
+                             memory fetched together, then one digest
   waku skill install <url>   install a community skill
 """
 
@@ -45,6 +47,10 @@ def main() -> None:
         from waku.ops.brief import main as brief_main
 
         brief_main()
+    elif args[0] == "gather":
+        from waku.ops.gather import main as gather_main
+
+        gather_main()
     elif args[0] == "skill" and len(args) >= 3 and args[1] == "install":
         from waku.memory.procedural.installer import install
 

--- a/waku/app.py
+++ b/waku/app.py
@@ -46,37 +46,40 @@ class Waku:
         telegram / dashboard), so the unified chat can show its origin.
         `stream=True` streams the reply text token by token to the observer.
         Everything that happens is both shown (observer) and recorded (tracer)."""
-        # capture the gate decision as it flows by, so we can persist it with
-        # the turn (the reopened-thread telemetry the dashboard shows live)
+        # capture the gate + graph decisions as they flow by, so we can persist
+        # them with the turn (the reopened-thread telemetry the dashboard shows)
         import time
         captured: dict = {}
 
         def _capture(kind, ev):
             if kind == "gate":
                 captured["gate"] = {"decision": ev.get("decision"), "reason": ev.get("reason")}
+            if kind == "route":
+                captured["graph_route"] = {"target": ev.get("target"), "reason": ev.get("reason")}
+            if kind == "triage":
+                captured["triage_reason"] = ev.get("reason")
+            if kind == "graph_end":
+                captured["graph_path"] = ev.get("path")
         notify = compose(observer, self.tracer.event, _capture)
         t0 = time.perf_counter()
 
         with self.tracer.turn(user_message):
-            system = self.session.build_system(user_message, notify=notify)
-            # Working memory is a bounded window: only the last N turns (2 rows
-            # each) enter the prompt, so context/cost/latency stay flat no matter
-            # how long the conversation runs. Older turns live in state.db and
-            # come back via the retrieval gate + episodic memory when relevant.
-            window = self.settings.history_turns * 2
-            messages = self.session.history[-window:] + [{"role": "user", "content": user_message}]
+            # The graph front door is optional and can NEVER make Waku worse:
+            # flag off → this is exactly the old code path; flag on → the triage
+            # graph decides quick vs full, and any failure anywhere falls open
+            # to the plain loop below (same fail-open rule as the retrieval gate).
+            result = None
+            if self.settings.graph_workflows:
+                try:
+                    result = self._respond_via_graph(user_message, notify, stream)
+                except Exception as exc:
+                    notify("graph_end", {"workflow": "triage", "ms": 0, "steps": 0,
+                                         "path": [], "error": repr(exc)})
+                    result = None
+            if result is None:
+                result = self._run_full_turn(user_message, notify, stream)
 
-            result = run_loop(
-                client=self.client,
-                model=self.settings.model,
-                system=system,
-                messages=messages,
-                tools=self.tools,
-                max_iterations=self.settings.max_iterations,
-                max_tokens=self.settings.max_tokens,
-                observer=notify,
-                stream=stream,
-            )
+            quick = captured.get("graph_route", {}).get("target") == "quick_reply"
 
             def _status(out: str) -> str:
                 low = (out or "").lower()
@@ -84,13 +87,19 @@ class Waku:
                                    or low.startswith("error")) else "ok"
             meta = {
                 "gate": captured.get("gate"),
+                "graph": ({"workflow": "triage",
+                           "route": "quick" if quick else "full",
+                           "reason": captured.get("triage_reason", ""),
+                           "path": captured.get("graph_path")}
+                          if "graph_route" in captured else None),
                 "iterations": result.iterations,
                 "latency_ms": int((time.perf_counter() - t0) * 1000),
                 "tools": [{"tool": c["tool"], "status": _status(c["output"])}
                           for c in result.tool_calls],
                 # which brain answered this turn — so a reopened thread (or a
-                # thread you switched models mid-way) shows it per card.
-                "model": self.settings.model,
+                # thread you switched models mid-way) shows it per card. A quick
+                # graph turn was answered by the small model; say so honestly.
+                "model": self.settings.small_model if quick else self.settings.model,
                 "provider": self.settings.provider,
             }
             self.session.add_exchange(user_message, result.reply, tool_calls=result.tool_calls,
@@ -101,3 +110,63 @@ class Waku:
 
         self.tracer.end_turn(result.reply, result.iterations)
         return result
+
+    def _run_full_turn(self, user_message: str, notify, stream: bool) -> LoopResult:
+        """The classic turn: assemble working memory, run THE loop. Extracted
+        verbatim so the graph's full_agent node calls the SAME code as the
+        flag-off default — loop-as-a-node can never drift from loop-as-default."""
+        system = self.session.build_system(user_message, notify=notify)
+        # Working memory is a bounded window: only the last N turns (2 rows
+        # each) enter the prompt, so context/cost/latency stay flat no matter
+        # how long the conversation runs. Older turns live in state.db and
+        # come back via the retrieval gate + episodic memory when relevant.
+        window = self.settings.history_turns * 2
+        messages = self.session.history[-window:] + [{"role": "user", "content": user_message}]
+
+        return run_loop(
+            client=self.client,
+            model=self.settings.model,
+            system=system,
+            messages=messages,
+            tools=self.tools,
+            max_iterations=self.settings.max_iterations,
+            max_tokens=self.settings.max_tokens,
+            observer=notify,
+            stream=stream,
+        )
+
+    def _respond_via_graph(self, user_message: str, notify, stream: bool) -> LoopResult | None:
+        """One turn through the triage graph workflow. Returns None whenever
+        the graph didn't produce an answer — respond() then falls open to the
+        plain loop, so this path can only ever ADD speed, never lose a reply."""
+        from waku.graph import run_graph
+        from waku.graph.workflows.triage import (
+            QUICK_REPLY_PROMPT,
+            build_triage_graph,
+            classify_message,
+            todays_events,
+        )
+
+        def quick_reply(state: dict) -> str:
+            prompt = QUICK_REPLY_PROMPT.format(calendar=state.get("calendar", ""),
+                                               message=state["message"])
+            response = self.client.messages.create(
+                model=self.settings.small_model, max_tokens=600,
+                messages=[{"role": "user", "content": prompt}])
+            return "".join(b.text for b in response.content if b.type == "text")
+
+        graph = build_triage_graph(
+            classify_fn=lambda m: classify_message(self.client, self.settings.small_model, m),
+            calendar_fn=lambda: todays_events(self.settings.home),
+            quick_fn=quick_reply,
+            # the full path is the SAME method the flag-off default runs; the
+            # engine's tagged notifier stamps its inner events with node=
+            full_fn=lambda state: self._run_full_turn(
+                state["message"], state.get("_notify", notify), stream),
+        )
+        state = run_graph(graph, {"message": user_message}, observer=notify)
+        if isinstance(state.get("result"), LoopResult):
+            return state["result"]
+        if state.get("reply"):
+            return LoopResult(reply=state["reply"], tool_calls=[], iterations=1)
+        return None  # graph produced nothing → caller falls open to the loop

--- a/waku/config.py
+++ b/waku/config.py
@@ -92,6 +92,13 @@ class Settings:
     experimental: bool = field(
         default_factory=lambda: os.getenv("WAKU_EXPERIMENTAL", "") in ("1", "true", "yes")
     )
+    # Route every message through the triage graph workflow first (a small model
+    # classifies it; trivial messages get a fast small-model reply, real tasks
+    # run the normal loop as a graph node). Any failure anywhere fails open to
+    # the plain loop, so this can never make Waku worse — only faster/cheaper.
+    graph_workflows: bool = field(
+        default_factory=lambda: os.getenv("WAKU_GRAPH_WORKFLOWS", "") in ("1", "true", "yes")
+    )
 
     # --- Optional gateway
     telegram_token: str = field(default_factory=lambda: os.getenv("TELEGRAM_BOT_TOKEN", ""))

--- a/waku/graph/__init__.py
+++ b/waku/graph/__init__.py
@@ -1,0 +1,17 @@
+"""Graph workflows — opt-in structure AROUND the loop, not a fifth pillar.
+
+`waku/loop/agent.py` is one agent turn: the model picks tools until it stops.
+A graph workflow arranges *steps* around (and to) that loop: nodes that each do
+one job, edges that say what happens next, fan-outs that run at the same time,
+and routers that pick a path. The loop file never changes — a node can simply
+BE a whole loop turn (see `nodes.agent_node`).
+
+The entire mechanism is `engine.py`, same trick as the loop: read one file,
+understand the whole thing. Shipped graphs live in `workflows/` — in docs they
+are always "graph workflows" (two words), to keep them distinct from the
+skills-as-workflows language in procedural memory.
+"""
+
+from waku.graph.engine import END, START, Graph, GraphStateCollision, Node, run_graph
+
+__all__ = ["END", "START", "Graph", "GraphStateCollision", "Node", "run_graph"]

--- a/waku/graph/engine.py
+++ b/waku/graph/engine.py
@@ -1,0 +1,206 @@
+"""THE GRAPH — nodes, edges, waves. This file is the whole mechanism.
+
+A graph workflow is a map of steps: each node does one job, each edge says
+"when this finishes, go there". The engine runs it in waves:
+
+    while some nodes are ready:
+        run every ready node (at the same time, if there are several)
+        merge what they wrote into the shared state
+        fire their edges / ask their routers where to go next
+
+That's it. Three ideas carry everything:
+
+  state    one plain dict (the blackboard). Every node reads it, returns the
+           keys it wants to merge. Parallel nodes must write DISJOINT keys —
+           a collision raises instead of silently losing a write.
+  routers  plain Python functions over state. Models write state; code reads
+           it and picks the edge. No LLM ever decides control flow directly.
+  guards   the loop's two-guardrail pattern, generalized: per-node max_visits
+           (bounded cycles) + global max_steps (never spin forever). A node
+           exception is recorded and surfaced, never raised out of the run —
+           same surface-don't-crash rule as ToolRegistry.execute.
+
+Waves trade a little pipelining for a lot of legibility: execution order is
+deterministic, so traces read the same way twice and evals can pin the path.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import defaultdict
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from typing import Any
+
+# Same observer protocol as the loop: notify(kind, event). Graph runs emit
+# graph_start / node_start / node_end / route / graph_end, and pass through
+# whatever a node emits (an agent_node's llm/tool events) tagged with node=.
+Observer = Callable[[str, dict], None]
+
+START = "START"
+END = "END"
+
+NodeFn = Callable[[dict], dict]  # reads state, returns keys to merge
+RouteFn = Callable[[dict], str]  # reads state, returns a target label
+
+
+class GraphStateCollision(Exception):
+    """Two nodes in the same wave wrote the same key — a graph bug, not a race."""
+
+
+@dataclass
+class Node:
+    name: str
+    fn: NodeFn
+    kind: str = "fn"          # tool / llm / agent / router label for describe()
+    max_visits: int = 1       # >1 only on nodes inside an intended cycle
+    on_error: str | None = None  # node to jump to if fn raises (default: drain to END)
+
+
+@dataclass
+class Graph:
+    name: str
+    nodes: dict[str, Node] = field(default_factory=dict)
+    edges: list[tuple[str, str]] = field(default_factory=list)
+    routers: dict[str, tuple[RouteFn, dict[str, str]]] = field(default_factory=dict)
+
+    def add_node(self, node: Node) -> None:
+        if node.name in (START, END):
+            raise ValueError(f"'{node.name}' is reserved")
+        self.nodes[node.name] = node
+
+    def add_edge(self, src: str, dst: str) -> None:
+        """Unconditional: when src finishes, dst gets one step closer to ready.
+        Add nodes before edges — unknown endpoints fail here, not mid-run."""
+        for end in (src, dst):
+            if end not in self.nodes and end not in (START, END):
+                raise ValueError(f"unknown node '{end}'")
+        self.edges.append((src, dst))
+
+    def add_router(self, src: str, route: RouteFn, targets: dict[str, str]) -> None:
+        """Conditional: when src finishes, `route(state)` returns a label and
+        execution jumps to targets[label]. Routers are code, never models."""
+        if src not in self.nodes:
+            raise ValueError(f"unknown node '{src}'")
+        for label, dst in targets.items():
+            if dst not in self.nodes and dst != END:
+                raise ValueError(f"router target '{dst}' (label '{label}') is unknown")
+        self.routers[src] = (route, targets)
+
+    def describe(self) -> dict[str, Any]:
+        """The topology as data — what the dashboard draws. Rendering from this
+        (never from a hand-copied picture) is what keeps the chart honest."""
+        edges = [{"src": s, "dst": d, "conditional": False} for s, d in self.edges]
+        for src, (_route, targets) in self.routers.items():
+            edges += [{"src": src, "dst": dst, "conditional": True}
+                      for dst in dict.fromkeys(targets.values())]
+        return {"name": self.name,
+                "nodes": [{"name": n.name, "kind": n.kind} for n in self.nodes.values()],
+                "edges": edges}
+
+
+def run_graph(graph: Graph, state: dict, observer: Observer | None = None,
+              max_steps: int = 25) -> dict:
+    """Run one graph workflow to completion. Returns the final state; errors
+    land in state["errors"] and the graph_end event, they are never raised."""
+    lock = threading.Lock()
+    raw = observer or (lambda kind, ev: None)
+
+    def notify(kind: str, ev: dict) -> None:
+        with lock:  # pool threads share the tracer's file append — keep lines whole
+            raw(kind, ev)
+
+    deps: dict[str, set] = defaultdict(set)      # static in-edges per node
+    for src, dst in graph.edges:
+        if dst != END:
+            deps[dst].add(src)
+    fired: dict[str, set] = defaultdict(set)     # which in-edges have fired
+    runs: dict[str, int] = defaultdict(int)
+    path: list[str] = []
+    errors: dict[str, str] = state.setdefault("errors", {})
+    t0 = time.perf_counter()
+    notify("graph_start", {"workflow": graph.name, "nodes": list(graph.nodes)})
+
+    def next_wave(jumps: list[str]) -> list[str]:
+        """Forcible router/error jumps + nodes whose static deps have all fired."""
+        wave: list[str] = []
+        for name in jumps + [n for n in graph.nodes
+                             if deps[n] and deps[n] <= fired[n] and runs[n] == 0]:
+            if name == END or name in wave:
+                continue
+            if runs[name] >= graph.nodes[name].max_visits:
+                errors.setdefault(name, f"max_visits={graph.nodes[name].max_visits} reached")
+                continue
+            wave.append(name)
+        return wave
+
+    def run_one(name: str) -> tuple[str, dict | None, str | None, int]:
+        node = graph.nodes[name]
+        snapshot = dict(state)
+        snapshot["_notify"] = lambda kind, ev, _n=name: notify(kind, {**ev, "node": _n})
+        t = time.perf_counter()
+        try:
+            out = node.fn(snapshot)
+            return name, out or {}, None, int((time.perf_counter() - t) * 1000)
+        except Exception as exc:  # surface, don't crash — the run drains cleanly
+            return name, None, repr(exc), int((time.perf_counter() - t) * 1000)
+
+    for src, dst in graph.edges:  # START fires its edges before the first wave
+        if src == START:
+            fired[dst].add(START)
+    wave = next_wave([])
+
+    while wave:
+        if len(path) + len(wave) > max_steps:
+            errors.setdefault("engine", f"max_steps={max_steps} reached")
+            break
+        for name in wave:
+            runs[name] += 1
+            notify("node_start", {"workflow": graph.name, "node": name, "visit": runs[name]})
+        if len(wave) == 1:  # solo node runs on this thread: trace order stays exact
+            results = [run_one(wave[0])]
+        else:
+            with ThreadPoolExecutor(max_workers=len(wave)) as pool:
+                results = [f.result() for f in [pool.submit(run_one, n) for n in wave]]
+
+        jumps: list[str] = []
+        wave_writes: dict[str, str] = {}
+        for name, out, error, ms in results:  # merge in wave order — deterministic
+            path.append(name)
+            keys = [k for k in (out or {}) if not k.startswith("_")]
+            for key in keys:
+                if wave_writes.get(key, name) != name:
+                    raise GraphStateCollision(
+                        f"'{name}' and '{wave_writes[key]}' both wrote '{key}' — "
+                        f"parallel branches must write disjoint keys")
+                wave_writes[key] = name
+                state[key] = out[key]
+            notify("node_end", {"workflow": graph.name, "node": name,
+                                "ms": ms, "keys": keys, "error": error})
+            if error:
+                errors[name] = error
+                if graph.nodes[name].on_error:
+                    jumps.append(graph.nodes[name].on_error)
+                continue  # no on_error → fire nothing; the run drains to END
+            if name in graph.routers:
+                route, targets = graph.routers[name]
+                label = route(state)
+                target = targets.get(label)
+                notify("route", {"workflow": graph.name, "router": name,
+                                 "target": target or END, "reason": label})
+                if target is None:
+                    errors[name] = f"router returned unknown label '{label}'"
+                elif target != END:
+                    jumps.append(target)  # a route is a jump, not a dependency
+            else:
+                for src, dst in graph.edges:
+                    if src == name and dst != END:
+                        fired[dst].add(name)
+        wave = next_wave(jumps)
+
+    first_error = next(iter(errors.values()), None)
+    notify("graph_end", {"workflow": graph.name, "ms": int((time.perf_counter() - t0) * 1000),
+                         "steps": len(path), "path": path, "error": first_error})
+    return state

--- a/waku/graph/nodes.py
+++ b/waku/graph/nodes.py
@@ -1,0 +1,78 @@
+"""Node factories — the common shapes a graph node takes.
+
+Everything is just a NodeFn (state in, keys-to-merge out); these helpers build
+the four kinds you actually reach for. The important one is `agent_node`: a
+node that IS a whole loop turn. Graphs don't replace the loop — they arrange
+calls around it, and to it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+
+from waku.graph.engine import Node, NodeFn, RouteFn
+from waku.loop.agent import run_loop
+from waku.tools.registry import ToolRegistry
+
+
+def tool_node(name: str, fn: Callable[..., object], in_keys: Iterable[str],
+              out_key: str, **node_kwargs) -> Node:
+    """A plain function as a node: reads `in_keys` from state, writes `out_key`.
+    For DB lookups, file reads, pure computation — anything deterministic."""
+    keys = list(in_keys)
+
+    def run(state: dict) -> dict:
+        return {out_key: fn(*[state.get(k) for k in keys])}
+
+    return Node(name=name, fn=run, kind="tool", **node_kwargs)
+
+
+def llm_node(name: str, prompt_template: str, out_key: str, *,
+             client, model: str, max_tokens: int = 600, **node_kwargs) -> Node:
+    """ONE model call, no tools: the prompt template is formatted from state,
+    the reply text lands in `out_key`. For classify / score / rewrite steps.
+    Control flow never lives here — a router reads what this node wrote."""
+
+    def run(state: dict) -> dict:
+        prompt = prompt_template.format(**{k: v for k, v in state.items()
+                                           if not k.startswith("_")})
+        response = client.messages.create(model=model, max_tokens=max_tokens,
+                                          messages=[{"role": "user", "content": prompt}])
+        text = "".join(b.text for b in response.content if b.type == "text")
+        return {out_key: text}
+
+    return Node(name=name, fn=run, kind="llm", **node_kwargs)
+
+
+def agent_node(name: str, out_key: str, *, client, model: str, system: str,
+               tools: ToolRegistry, max_iterations: int = 10, max_tokens: int = 2048,
+               message_key: str = "message", **node_kwargs) -> Node:
+    """A full run_loop turn as one node — the sub-agent story. Same loop, same
+    tracing (its llm/tool events pass through tagged with node=), just a scoped
+    tool registry and its own working memory. run_loop itself is untouched."""
+
+    def run(state: dict) -> dict:
+        messages = [{"role": "user", "content": state[message_key]}]
+        result = run_loop(client=client, model=model, system=system,
+                          messages=messages, tools=tools,
+                          max_iterations=max_iterations, max_tokens=max_tokens,
+                          observer=state.get("_notify"))
+        return {out_key: result}
+
+    return Node(name=name, fn=run, kind="agent", **node_kwargs)
+
+
+def key_router(key: str, default: str) -> RouteFn:
+    """The house router: read one state key, return it as the route label
+    (falling back to `default`). Models write the key; this code reads it."""
+
+    def route(state: dict) -> str:
+        value = state.get(key)
+        return value if isinstance(value, str) and value else default
+
+    return route
+
+
+def fn_node(name: str, fn: NodeFn, **node_kwargs) -> Node:
+    """Escape hatch: any callable(state) -> dict as a node, unwrapped."""
+    return Node(name=name, fn=fn, **node_kwargs)

--- a/waku/graph/workflows/__init__.py
+++ b/waku/graph/workflows/__init__.py
@@ -1,0 +1,7 @@
+"""Shipped graph workflows — one file per graph.
+
+In docs these are always "graph workflows" (two words): a graph built for one
+job. Not to be confused with the skills-as-workflows language in procedural
+memory (`SKILL.md` — "a repeatable workflow the user teaches you"); a skill is
+instructions the model reads, a graph workflow is structure the engine runs.
+"""

--- a/waku/graph/workflows/gather.py
+++ b/waku/graph/workflows/gather.py
@@ -1,0 +1,157 @@
+"""The morning gather — the workflow that is genuinely a graph.
+
+Every morning the same four questions: what is open on the repo, what is being
+said about the things it touches, what is on today, and what do I already know
+about it. You do not discover that list — you know it before you wake up. So
+letting a model work it out one tool call at a time buys nothing and costs four
+round trips, and on a bad day it forgets one.
+
+    START ─┬─ scan_github  ─┐
+           ├─ scan_web      │
+           ├─ scan_calendar ├─► synthesize ──router──► draft_digest → END
+           └─ scan_memory  ─┘                    └──── quiet ──────► END
+
+The four scans have no dependencies on each other, so the engine puts them in
+one wave and runs them together. That is the whole argument for a graph here:
+the shape is known in advance, so it can be drawn, and once drawn the
+independent parts are obviously independent.
+
+Contrast with the loop, which is still the right tool for "work this PR": read
+the diff, run the tests, discover it needs a rebase, decide what next. You
+cannot draw that in advance — any shape you commit to is wrong by step three.
+
+TWO RULES THIS FILE OBEYS, both load-bearing:
+
+1. IT PROPOSES, IT NEVER ACTS. There is no agent_node here, no run_loop, no
+   ToolRegistry. The one model call is a bare messages.create with NO tools
+   parameter — so the model is never handed a schema it could use to send,
+   merge, or create anything. Not "instructed not to": *unable to*. The only
+   write in the entire graph is a markdown file in the outbox for a human to
+   read. test_gather_workflow.py enforces this by reading this file's source.
+
+2. EVERY BRANCH CATCHES ITS OWN FAILURE. A node that raises fires no edges, so
+   synthesize's dependencies would never complete and the run would produce
+   NOTHING — no error, no digest, an empty outbox. Silence is the worst
+   possible failure mode for a morning routine, so each scan returns honest
+   text instead of raising. See _safe below.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from waku.graph.engine import END, START, Graph, Node
+
+# Each scan writes only keys carrying its own prefix. Parallel nodes that write
+# the same key raise GraphStateCollision — the engine's backstop — but a
+# convention a reviewer can check by eye is the actual defence.
+SCAN_KEYS = {
+    "scan_github": ("gh_text", "gh_open_prs", "gh_open_issues"),
+    "scan_web": ("web_text",),
+    "scan_calendar": ("cal_text", "cal_event_count"),
+    "scan_memory": ("mem_text",),
+}
+
+DIGEST_PROMPT = """You are preparing a morning briefing for the maintainer of an
+open-source project. Below is everything gathered a moment ago.
+
+OPEN PULL REQUESTS AND ISSUES:
+{gh_text}
+
+WHAT THE WEB SAYS:
+{web_text}
+
+TODAY'S CALENDAR:
+{cal_text}
+
+WHAT YOU ALREADY KNOW:
+{mem_text}
+
+Write a short briefing in markdown:
+- Lead with the two or three things that actually matter today, and say why.
+- Then anything waiting on the maintainer, grouped, one line each.
+- End with a single suggested focus for the day.
+
+You are DRAFTING A PROPOSAL for a human to act on. You have not done anything
+and cannot do anything — never write as if you have replied, merged, or sent.
+Be brief. If a section gathered nothing, say so in a few words and move on."""
+
+
+def _safe(fn: Callable[[], dict], fallback: dict) -> dict:
+    """Run a scan, or return honest text saying why it could not.
+
+    Chosen over the engine's `on_error` jumps deliberately. `on_error` would
+    happen to work here — all four scans share one wave, so their jumps are
+    collected in a single merge pass — but that is an accident of this
+    topology, and it would break silently if someone re-shaped the graph. A
+    wrapper is correct regardless of shape. Same surface-don't-crash rule as
+    ToolRegistry.execute.
+    """
+    try:
+        return fn()
+    except Exception as exc:  # noqa: BLE001 — the whole point is to not propagate
+        return {**fallback, **{k: f"unavailable ({type(exc).__name__}: {exc})"
+                               for k in fallback if isinstance(fallback[k], str)}}
+
+
+def needs_action(state: dict) -> str:
+    """The router: CODE, over counts the scans wrote — never the digest's prose.
+
+    The engine's rule is "routers are code, never models". Routing on the
+    model's wording would hand control flow to the model AND make the branch
+    impossible to test without a scripted response per case. Counts are exact,
+    cheap, and a test can drive them directly.
+    """
+    if (state.get("gh_open_prs") or state.get("gh_open_issues")
+            or state.get("cal_event_count")):
+        return "propose"
+    return "quiet"
+
+
+def build_gather_graph(*, github_fn: Callable[[], dict],
+                       web_fn: Callable[[], str],
+                       calendar_fn: Callable[[], dict],
+                       memory_fn: Callable[[], str],
+                       synth_fn: Callable[[dict], str],
+                       draft_fn: Callable[[dict], str]) -> Graph:
+    """Callables injected exactly as triage does it: evals script them with
+    lambdas, gather_topology() passes stubs to describe the shape without
+    running it, and waku/ops/gather.py binds the real ones."""
+    g = Graph("gather")
+
+    g.add_node(Node("scan_github", lambda s: _safe(
+        github_fn, {"gh_text": "", "gh_open_prs": 0, "gh_open_issues": 0}), kind="tool"))
+    g.add_node(Node("scan_web", lambda s: _safe(
+        lambda: {"web_text": web_fn()}, {"web_text": ""}), kind="tool"))
+    g.add_node(Node("scan_calendar", lambda s: _safe(
+        calendar_fn, {"cal_text": "", "cal_event_count": 0}), kind="tool"))
+    g.add_node(Node("scan_memory", lambda s: _safe(
+        lambda: {"mem_text": memory_fn()}, {"mem_text": ""}), kind="tool"))
+
+    # One model call, no tools. See rule 1 in the module docstring.
+    g.add_node(Node("synthesize", lambda s: {"digest": synth_fn(s)}, kind="llm"))
+    # The one write in the whole graph, and it is a file a human opens.
+    g.add_node(Node("draft_digest", lambda s: {"draft_path": draft_fn(s)}, kind="tool"))
+
+    for scan in SCAN_KEYS:
+        g.add_edge(START, scan)          # no deps between them -> one wave
+        g.add_edge(scan, "synthesize")   # synthesize waits for all four
+
+    # The router lives on synthesize: it IS the barrier, so triage's separate
+    # join node would be dead weight here.
+    g.add_router("synthesize", needs_action,
+                 {"propose": "draft_digest", "quiet": END})
+    g.add_edge("draft_digest", END)
+    return g
+
+
+def gather_topology() -> dict:
+    """The topology as data, for the dashboard — built with stubs, never run."""
+    return build_gather_graph(
+        github_fn=lambda: {"gh_text": "", "gh_open_prs": 0, "gh_open_issues": 0},
+        web_fn=lambda: "",
+        calendar_fn=lambda: {"cal_text": "", "cal_event_count": 0},
+        memory_fn=lambda: "",
+        synth_fn=lambda s: "",
+        draft_fn=lambda s: "",
+    ).describe()

--- a/waku/graph/workflows/triage.py
+++ b/waku/graph/workflows/triage.py
@@ -1,0 +1,125 @@
+"""The triage graph workflow — every message's front door when the flag is on.
+
+The retrieval gate asked one narrow question with a small model ("does this
+message need memory?"). Triage generalizes that idea from one gate to a
+structure: two things happen AT THE SAME TIME (a small model classifies the
+message; today's calendar loads from disk), then a code router picks the path:
+
+    START ── classify ──────┐
+         └── check_calendar ┴─► route:  quick → quick_reply (small model) → END
+                                        full  → full_agent (THE loop)     → END
+
+"thanks!" never wakes the big model. "schedule a swim Saturday" runs the exact
+same loop as always — as one node. The user never chooses a mode; this graph
+IS the choice. And every seam fails open: a broken classifier, a broken
+engine, anything → the plain loop answers, same as if the flag were off.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from datetime import datetime
+from pathlib import Path
+
+from waku.graph.engine import END, START, Graph, Node
+from waku.graph.nodes import key_router
+
+TRIAGE_PROMPT = """\
+You are a triage gate for a personal assistant. Given the user's message,
+decide which brain should answer it.
+
+Reply with ONLY this JSON, nothing else:
+{{"route": "quick" or "full", "reason": "<5 words>"}}
+
+quick — greetings, thanks, acknowledgements, pure small talk: nothing to do,
+        nothing to look up.
+full  — anything mentioning tasks, schedules, people, notes, memory, or that
+        needs a tool. When unsure, choose full.
+
+User message: {message}"""
+
+QUICK_REPLY_PROMPT = """\
+You are Waku, a warm, concise personal assistant. The user's message needs no
+tools or memory — reply in one or two short, natural sentences. If today's
+calendar (below) is clearly relevant, you may mention it; otherwise ignore it.
+
+Today's calendar: {calendar}
+
+User message: {message}"""
+
+
+def classify_message(client, small_model: str, message: str) -> tuple[str, str]:
+    """Returns (route, reason). Fails open to "full": a broken triage must
+    cost latency, never capability — mirror of retrieval_gate.should_retrieve."""
+    try:
+        response = client.messages.create(
+            model=small_model,
+            max_tokens=600,  # reasoning models think before the JSON
+            messages=[{"role": "user", "content": TRIAGE_PROMPT.format(message=message)}],
+        )
+        text = "".join(b.text for b in response.content if b.type == "text")
+        if "{" not in text:
+            return "full", "no JSON — failing open"
+        decision = json.loads(text[text.index("{") : text.rindex("}") + 1])
+        route = decision.get("route")
+        if route not in ("quick", "full"):
+            return "full", f"bad route '{route}' — failing open"
+        return route, decision.get("reason", "")
+    except Exception as exc:
+        return "full", f"triage failed open ({type(exc).__name__})"
+
+
+def todays_events(home: Path) -> str:
+    """Today's events straight from calendar.ics — a local file read, which is
+    exactly why it can run in parallel with the classifier's network call."""
+    ics = home / "calendar.ics"
+    if not ics.exists():
+        return "(no calendar)"
+    today = datetime.now().strftime("%Y%m%d")
+    lines, title = [], ""
+    for line in ics.read_text(encoding="utf-8").splitlines():
+        if line.startswith("SUMMARY:"):
+            title = line[len("SUMMARY:"):]
+        elif line.startswith("DTSTART") and today in line and title:
+            lines.append(title)
+    return "; ".join(lines) or "(nothing today)"
+
+
+def build_triage_graph(*, classify_fn: Callable[[str], tuple[str, str]],
+                       calendar_fn: Callable[[], str],
+                       quick_fn: Callable[[dict], str],
+                       full_fn: Callable[[dict], object]) -> Graph:
+    """Callables injected so evals script them, the dashboard builds it with
+    stubs just to describe(), and app.py binds the real client/loop."""
+    g = Graph("triage")
+
+    def classify(state: dict) -> dict:
+        route, reason = classify_fn(state["message"])
+        notify = state.get("_notify")
+        if notify:  # the human-readable "why" — traced, and shown on the turn card
+            notify("triage", {"route": route, "reason": reason})
+        return {"route": route, "triage_reason": reason}
+
+    g.add_node(Node("classify", classify, kind="llm"))
+    g.add_node(Node("check_calendar", lambda s: {"calendar": calendar_fn()}, kind="tool"))
+    g.add_node(Node("quick_reply", lambda s: {"reply": quick_fn(s)}, kind="llm"))
+    g.add_node(Node("full_agent", lambda s: {"result": full_fn(s)}, kind="agent"))
+    g.add_edge(START, "classify")
+    g.add_edge(START, "check_calendar")
+    # the router waits on BOTH parallel branches before deciding
+    g.add_node(Node("gather", lambda s: {}, kind="fn"))
+    g.add_edge("classify", "gather")
+    g.add_edge("check_calendar", "gather")
+    g.add_router("gather", key_router("route", default="full"),
+                 {"quick": "quick_reply", "full": "full_agent"})
+    g.add_edge("quick_reply", END)
+    g.add_edge("full_agent", END)
+    return g
+
+
+def triage_topology() -> dict:
+    """The topology as data, for the dashboard — built with stubs, never run."""
+    noop = lambda *a, **k: ""  # noqa: E731
+    return build_triage_graph(classify_fn=lambda m: ("full", ""), calendar_fn=noop,
+                              quick_fn=noop, full_fn=noop).describe()

--- a/waku/ops/dashboard.py
+++ b/waku/ops/dashboard.py
@@ -80,7 +80,7 @@ def chat_stream(message: str, emit) -> None:
     events: list[dict] = []
 
     def observer(kind, ev):
-        if kind in ("gate", "consolidation"):
+        if kind in ("gate", "consolidation", "route", "triage"):
             events.append({"kind": kind, **ev})
         emit(kind, ev)
 
@@ -93,16 +93,23 @@ def chat_stream(message: str, emit) -> None:
 
     gate = next((e for e in events if e["kind"] == "gate"), None)
     cons = next((e for e in events if e["kind"] == "consolidation"), None)
+    route = next((e for e in events if e["kind"] == "route"), None)
+    triage = next((e for e in events if e["kind"] == "triage"), None)
+    quick = bool(route) and route.get("target") == "quick_reply"
     emit("done", {
         "reply": result.reply,
         "gate": {"decision": gate["decision"], "reason": gate.get("reason")} if gate else None,
+        "graph": ({"workflow": route.get("workflow", "triage"),
+                   "route": "quick" if quick else "full",
+                   "reason": (triage or {}).get("reason", "")} if route else None),
         "tools": [{"tool": c["tool"], "args": c["args"], "output": c["output"],
                    "status": _tool_status(c["output"]),
                    "summary": (c["output"] or "").split(". ")[0][:120]} for c in result.tool_calls],
         "consolidation": {"new_facts": cons["new_facts"]} if cons else None,
         "iterations": result.iterations,
         "latency_ms": latency_ms,
-        "model": agent.settings.model,   # which brain answered — shown per card
+        # which brain answered — shown per card; a quick graph turn was the small model
+        "model": agent.settings.small_model if quick else agent.settings.model,
     })
 
 

--- a/waku/ops/dashboard.py
+++ b/waku/ops/dashboard.py
@@ -217,6 +217,12 @@ def collect() -> dict:
         elif current is not None:
             if kind == "gate":
                 current["gate"] = ev
+            elif kind == "route":
+                current["graph"] = {"workflow": ev.get("workflow"),
+                                    "route": "quick" if ev.get("target") == "quick_reply" else "full",
+                                    "reason": (current.get("graph") or {}).get("reason", "")}
+            elif kind == "triage":
+                current.setdefault("graph", {})["reason"] = ev.get("reason", "")
             elif kind == "llm":
                 current["llm_calls"].append(ev)
             elif kind == "tool":
@@ -310,6 +316,11 @@ def collect() -> dict:
     # pay for an agent nobody has chatted with yet.
     live = browser_agent.current()
 
+    # --- graph workflows: topology straight from the engine (never hand-drawn,
+    # so the picture can't drift) + quick/full split from the trace events
+    from waku.graph.workflows.triage import triage_topology
+    graph_routes = [e.get("target") for e in events if e.get("type") == "route"]
+
     return {
         "generated_at": datetime.now(UTC).isoformat(timespec="seconds"),
         "home": str(home.resolve()),
@@ -352,6 +363,12 @@ def collect() -> dict:
         "skills": skills,
         "eval_report": eval_report,
         "eval_history": eval_history,
+        "graph": {
+            "enabled": settings.graph_workflows,
+            "workflows": [triage_topology()],
+            "stats": {"quick": sum(1 for t in graph_routes if t == "quick_reply"),
+                      "full": sum(1 for t in graph_routes if t == "full_agent")},
+        },
         "db": db_info,
         "settings": settings_info(),
         "tools": tools_info(),

--- a/waku/ops/gather.py
+++ b/waku/ops/gather.py
@@ -1,0 +1,181 @@
+"""`python -m waku gather` — the morning briefing, run as a graph.
+
+    30 7 * * *  cd ~/waku-agent && make gather
+
+This is the ONE place where real callables meet the pure workflow in
+waku/graph/workflows/gather.py. Both the CLI and the dashboard's
+/api/graph/stream come through build_bound_graph, so there is exactly one
+definition of what a gather is allowed to touch — and a reviewer only has to
+read one function to know.
+
+Compare `brief.py` next door, which is the same job done as a LOOP: one prompt
+in, the model decides which tools to call, four sequential round trips. Both
+ship. Reading them side by side is the point.
+
+Nothing here can act. The scans are reads, the synthesis is one model call with
+no tools, and the only write is a markdown file in the outbox. See rule 1 in
+the workflow's docstring.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+from rich.console import Console
+
+from waku.app import Waku
+from waku.graph import run_graph
+from waku.graph.workflows.gather import DIGEST_PROMPT, build_gather_graph
+
+DEFAULT_TOPICS = "AI agent harness loop memory eval"
+
+
+def _github(settings) -> dict:
+    """Open PRs and issues. Calls waku/tools/github.py as a LIBRARY, not through
+    the registry — so a gather works with WAKU_GH_TOOL off. That flag decides
+    whether the MODEL can reach GitHub; this is our own code asking."""
+    from waku.tools import github
+
+    repo = getattr(settings, "gh_repo", "")
+    ok_p, prs = github.list_prs(repo, 20)
+    ok_i, issues = github.list_issues(repo, 20)
+    prs = prs if ok_p and isinstance(prs, list) else []
+    issues = issues if ok_i and isinstance(issues, list) else []
+    lines = []
+    if ok_p:
+        lines.append("Open PRs:\n" + (github._format(prs) if prs else "(none)"))
+    else:
+        lines.append(f"Open PRs: unavailable — {prs}")
+    if ok_i:
+        lines.append("Open issues:\n" + (github._format(issues) if issues else "(none)"))
+    else:
+        lines.append(f"Open issues: unavailable — {issues}")
+    return {"gh_text": "\n\n".join(lines),
+            "gh_open_prs": len(prs), "gh_open_issues": len(issues)}
+
+
+def _web(settings) -> str:
+    from waku.tools import search
+
+    topics = getattr(settings, "gh_repo", "") or DEFAULT_TOPICS
+    return search.make_tool().fn(query=f"{topics} {DEFAULT_TOPICS} this week")
+
+
+def _calendar(settings) -> dict:
+    """Reuses triage's .ics reader rather than re-implementing it — one parser
+    for "what is on today" means the two workflows can never disagree."""
+    from waku.graph.workflows.triage import todays_events
+
+    text = todays_events(settings.home)
+    empty = text.startswith("(")          # "(no calendar)" / "(nothing today)"
+    return {"cal_text": text, "cal_event_count": 0 if empty else text.count(";") + 1}
+
+
+def _memory(settings) -> str:
+    """Straight fact search, deliberately NOT gated_retrieve: the gate spends a
+    small-model call deciding whether memory is relevant, and for a briefing we
+    already know the answer is yes.
+
+    Opens its OWN sqlite connection rather than reusing waku.memory's. A
+    connection belongs to the thread that made it, and this scan runs in a pool
+    thread — the first live gather returned "local DB threading error" for
+    exactly that reason, with _safe absorbing it so the digest still shipped
+    minus a source. Passing check_same_thread=False on the shared handle would
+    also have silenced it, and would have been the wrong fix: parallel nodes
+    sharing a mutable handle is the hazard, not the thread check that reports
+    it. A short-lived read-only connection is honest and costs microseconds.
+    """
+    import sqlite3
+
+    from waku.db import connect
+    from waku.memory.semantic.store import SqliteFactStore
+
+    conn = None
+    try:
+        conn = connect(settings.home)
+        found = SqliteFactStore(conn).search("project repo contributors release", 8)
+        return "\n".join(found) or "(nothing relevant)"
+    except sqlite3.Error as exc:
+        return f"(memory unavailable: {exc})"
+    finally:
+        if conn is not None:
+            conn.close()
+
+
+def _synthesize(waku, state: dict) -> str:
+    """One model call, NO tools parameter. That absence is the propose-never-act
+    guarantee — a model with no tool schemas cannot call a tool."""
+    prompt = DIGEST_PROMPT.format(
+        gh_text=state.get("gh_text", ""), web_text=state.get("web_text", ""),
+        cal_text=state.get("cal_text", ""), mem_text=state.get("mem_text", ""))
+    resp = waku.client.messages.create(
+        model=waku.settings.model, max_tokens=1500,
+        messages=[{"role": "user", "content": prompt}])
+    return "".join(b.text for b in resp.content if getattr(b, "type", "") == "text")
+
+
+def _draft(home: Path, state: dict) -> str:
+    """Write the digest where a human will find it. Resolves the path and checks
+    it is inside the outbox before writing — same posture as messages.py, which
+    drafts and never sends."""
+    outbox = (home / "outbox").resolve()
+    outbox.mkdir(parents=True, exist_ok=True)
+    dest = (outbox / f"gather-{date.today().isoformat()}.md").resolve()
+    if outbox not in dest.parents:
+        return "refused: draft path escaped the outbox"
+    dest.write_text(state.get("digest", "") + "\n", encoding="utf-8")
+    return str(dest)
+
+
+def build_bound_graph(waku: Waku):
+    """The pure workflow, wired to this machine."""
+    s = waku.settings
+    return build_gather_graph(
+        github_fn=lambda: _github(s),
+        web_fn=lambda: _web(s),
+        calendar_fn=lambda: _calendar(s),
+        memory_fn=lambda: _memory(s),
+        synth_fn=lambda state: _synthesize(waku, state),
+        draft_fn=lambda state: _draft(s.home, state),
+    )
+
+
+def run_gather(waku: Waku | None = None, observer=None) -> dict:
+    """Run one gather to completion. Returns the final state; never raises.
+
+    The observer is composed with the tracer so a gather lands in
+    traces/*.jsonl like any turn — which means the dashboard's existing
+    /api/events poller animates the topology chart for free.
+    """
+    own = waku is None
+    waku = waku or Waku()
+    try:
+        def notify(kind: str, ev: dict) -> None:
+            waku.tracer.event(kind, ev)
+            if observer:
+                observer(kind, ev)
+
+        return run_graph(build_bound_graph(waku), {}, observer=notify)
+    finally:
+        if own:
+            waku.close()
+
+
+def main() -> None:
+    console = Console()
+    waku = Waku()
+    try:
+        console.print("[dim]gathering — github, web, calendar and memory, together…[/dim]")
+        state = run_gather(waku)
+        console.print(state.get("digest") or "(no digest — every source was empty)")
+        if state.get("draft_path"):
+            console.print(f"[dim]saved to {state['draft_path']}[/dim]")
+        for node, err in (state.get("errors") or {}).items():
+            console.print(f"[dim]{node}: {err}[/dim]")
+    finally:
+        waku.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/waku/ops/settings_api.py
+++ b/waku/ops/settings_api.py
@@ -93,6 +93,9 @@ def settings_info() -> dict:
         # a toggle here, the sidebar chat could never delegate. See settings_save.
         "experimental": s.experimental,
         "pi_installed": bool(shutil.which("pi")),
+        # graph workflows (triage-first turns) — same toggle contract as
+        # experimental: the UI renders it, settings_save writes it.
+        "graph_workflows": s.graph_workflows,
         # optional web-search key (Tavily) — same BYOK treatment as provider keys
         "search_key_env": "TAVILY_API_KEY",
         "search_key_set": bool(os.getenv("TAVILY_API_KEY")),
@@ -123,7 +126,7 @@ def apply_settings(payload: dict) -> dict:
               "model": os.getenv("WAKU_MODEL", ""),
               "small_model": os.getenv("WAKU_SMALL_MODEL", "")}
     writable = ({"WAKU_PROVIDER", "WAKU_MODEL", "WAKU_SMALL_MODEL", "TAVILY_API_KEY",
-                 "WAKU_EPISODIC_STORE", "WAKU_EXPERIMENTAL",
+                 "WAKU_EPISODIC_STORE", "WAKU_EXPERIMENTAL", "WAKU_GRAPH_WORKFLOWS",
                  "NOTION_TOKEN", "NOTION_EPISODES_DATABASE_ID"}
                 | {p.key_env for p in PROVIDERS.values()})
     env_path = find_dotenv(usecwd=True) or ".env"
@@ -138,6 +141,9 @@ def apply_settings(payload: dict) -> dict:
     experimental = payload.get("experimental")
     if experimental is not None:
         updates["WAKU_EXPERIMENTAL"] = "1" if str(experimental).strip() else ""
+    graph_workflows = payload.get("graph_workflows")  # same is-not-None rule
+    if graph_workflows is not None:
+        updates["WAKU_GRAPH_WORKFLOWS"] = "1" if str(graph_workflows).strip() else ""
     # Changing provider never carries a model across endpoints (live bug:
     # kimi->gemini kept gate model kimi-k3 and every turn 404'd on Gemini). But
     # if the user didn't newly type a model, use THIS provider's default (their

--- a/waku/ops/static/README.md
+++ b/waku/ops/static/README.md
@@ -22,6 +22,7 @@ runs the bootstrap and must load last**.
 | `models.js`  | `applyModel` (the one `/api/settings` writer), model picker / catalog / pins |
 | `render.js`  | formatters + chat card renderers (`stagesRow`/`teleFooter`) + chatlog + streaming + `sendChat` |
 | `diagram.js` | `archSVG` (the architecture chart) **and** its live animation (`STAGE`/`hot`/`pollEvents`) |
+| `graph.js`   | graph workflows: data-driven topology chart (`graphSVG` from `d.graph.workflows`), the Overview panel (`graphPanel`), and `animateGraphStage` for `graph_*`/`route` events |
 | `views.js`   | subtab/db helpers, SQL console, Memory/Tools sub-views, the `VIEWS` router object |
 | `compare.js` | the Model arena (`Arena` tab; internals keep the `compare` name) — race one message through several models at once |
 | `dock.js`    | chat sessions/history (`loadThreadInto`), model chip, stats toggle |
@@ -41,6 +42,11 @@ Data flows one way: `refresh()` (main.js) fetches `/api/data` into the global
   `data-node="…"`/`data-edge="…"` ids that the `STAGE` map (same file) drives the
   live animation from. If you ever change a node/edge id, change it in both
   places. (Both are in `diagram.js` precisely so they stay together.)
+- **The graph chart is data-driven — never hand-edit a topology.** `graphSVG`
+  renders `Graph.describe()` served in `/api/data`, so the picture is provably
+  what the engine runs (`test_graph_topology_payload.py` pins it). To change the
+  chart's shape, change the workflow in `waku/graph/workflows/`. Graph ids are
+  namespaced `g-<node>` / `g-<src>-<dst>` so they can never collide with archSVG's.
 - **No build step / no framework / no new dependencies.** If you reach for one,
   stop — the whole point is that this reads and runs with nothing installed.
 - **No emojis in UI** (project rule). Known pre-existing exception: the `★`/`☆`

--- a/waku/ops/static/index.html
+++ b/waku/ops/static/index.html
@@ -9,6 +9,7 @@
   <a href="#overview" data-v="overview">Overview</a>
   <a href="#gateway" data-v="gateway">Gateway <span class="n" id="n-gw"></span></a>
   <a href="#loop" data-v="loop">Loop <span class="n" id="n-loop"></span></a>
+  <a href="#graph" data-v="graph">Graph <span class="n" id="n-graph"></span></a>
   <a href="#memory" data-v="memory">Memory <span class="n" id="n-mem"></span></a>
   <a href="#tools" data-v="tools">Tools <span class="n" id="n-tools"></span></a>
   <a href="#database" data-v="database">Database <span class="n" id="n-db"></span></a>
@@ -54,6 +55,7 @@
 <script src="/static/js/models.js"></script>
 <script src="/static/js/render.js"></script>
 <script src="/static/js/diagram.js"></script>
+<script src="/static/js/graph.js"></script>
 <script src="/static/js/views.js"></script>
 <script src="/static/js/compare.js"></script>
 <script src="/static/js/dock.js"></script>

--- a/waku/ops/static/js/diagram.js
+++ b/waku/ops/static/js/diagram.js
@@ -119,6 +119,7 @@ function hot(sel, cls, ms){
   });
 }
 function animateStage(ev){
+  if (GRAPH_KINDS.has(ev.type)) return animateGraphStage(ev);   // graph.js owns these
   const spec = STAGE[ev.type];
   if (!spec || !document.querySelector(".arch")) return;
   document.querySelectorAll(".arch-status").forEach(st => st.innerHTML = `<span class="live-dot"></span>${spec.label}`);

--- a/waku/ops/static/js/graph.js
+++ b/waku/ops/static/js/graph.js
@@ -1,0 +1,108 @@
+// waku dashboard — graph workflows: the topology chart + its live animation.
+// Split out: classic <script>, shared global scope. Load order: static/README.md.
+//
+// The chart is DATA-DRIVEN: it renders Graph.describe() served in /api/data
+// (d.graph.workflows), so the picture is provably the topology the engine
+// runs — the anti-drift lesson learned from archSVG's byte-freeze. Never
+// hand-edit a workflow's shape here; change the workflow and this follows.
+// Ids are namespaced "g-" so they can never collide with archSVG's ids.
+
+// --- layered layout: START at the left, each node one column after its
+// furthest predecessor. Small graphs only (triage is 5 nodes) — no library.
+function graphLayout(wf){
+  const names = ["START", ...wf.nodes.map(n => n.name), "END"];
+  const layer = {START: 0};
+  for (let pass = 0; pass < names.length; pass++)     // relax until stable
+    wf.edges.forEach(e => {
+      const src = layer[e.src] ?? 0;
+      layer[e.dst] = Math.max(layer[e.dst] ?? 0, src + 1);
+    });
+  const cols = [];
+  names.forEach(n => {
+    if (layer[n] == null) layer[n] = 0;
+    (cols[layer[n]] = cols[layer[n]] || []).push(n);
+  });
+  return {layer, cols: cols.filter(c => c && c.length)};
+}
+
+function graphSVG(wf, opts = {}){
+  const {cols} = graphLayout(wf);
+  const kinds = Object.fromEntries(wf.nodes.map(n => [n.name, n.kind]));
+  const W = 168, H = 52, GX = 74, GY = 22, PAD = 14;
+  const height = Math.max(...cols.map(c => c.length)) * (H + GY) - GY + PAD * 2;
+  const width = cols.length * (W + GX) - GX + PAD * 2;
+  const pos = {};
+  cols.forEach((col, ci) => col.forEach((n, ri) => {
+    const colH = col.length * (H + GY) - GY;
+    pos[n] = {x: PAD + ci * (W + GX), y: PAD + (height - PAD * 2 - colH) / 2 + ri * (H + GY)};
+  }));
+  const SUB = {llm: "small model", agent: "THE loop, as a node", tool: "local read", fn: ""};
+  const nodeBox = n => {
+    const p = pos[n];
+    if (n === "START" || n === "END")
+      return `<g class="node" data-node="g-${n}">
+        <rect class="bx" x="${p.x + W/2 - 34}" y="${p.y + H/2 - 15}" width="68" height="30" rx="15"/>
+        <text class="nt" x="${p.x + W/2}" y="${p.y + H/2 + 5}" text-anchor="middle" style="font-size:12px">${n}</text></g>`;
+    const sub = SUB[kinds[n]] || "";
+    return `<g class="node" data-node="g-${n}">
+      <rect class="bx" x="${p.x}" y="${p.y}" width="${W}" height="${H}" rx="9"/>
+      <text class="nt" x="${p.x + 12}" y="${p.y + 22}">${esc(n)}</text>
+      ${sub ? `<text class="ns" x="${p.x + 12}" y="${p.y + 39}">${sub}</text>` : ""}</g>`;
+  };
+  const edgeLine = e => {
+    const a = pos[e.src], b = pos[e.dst];
+    const x1 = a.x + (e.src === "START" ? W/2 + 34 : W), y1 = a.y + H/2;
+    const x2 = b.x + (e.dst === "END" ? W/2 - 34 : 0), y2 = b.y + H/2;
+    const mx = (x1 + x2) / 2;
+    return `<path class="flow${e.conditional ? " dash" : ""}" data-edge="g-${e.src}-${e.dst}"
+      d="M${x1} ${y1} C${mx} ${y1} ${mx} ${y2} ${x2} ${y2}" marker-end="url(#garr)"/>`;
+  };
+  return `<div style="overflow-x:auto"><svg viewBox="0 0 ${width} ${height}" class="arch graphchart"
+      style="max-width:${width}px" role="img">
+    <defs><marker id="garr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7"
+      orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" class="head"/></marker></defs>
+    ${wf.edges.map(edgeLine).join("")}
+    ${["START", ...wf.nodes.map(n => n.name), "END"].map(nodeBox).join("")}
+  </svg></div>`;
+}
+
+// --- the compact Overview panel: the harness auto-decides, this reflects it.
+function graphPanel(d){
+  const g = d.graph || {enabled: false, workflows: [], stats: {quick: 0, full: 0}};
+  const wf = g.workflows[0];
+  const tot = g.stats.quick + g.stats.full;
+  const seg = (cls, n, label, pct) =>
+    `<div class="${cls}" style="width:${pct}%">${pct >= 14 ? `${n} ${label}` : ""}</div>`;
+  const split = !tot
+    ? `<div class="meta" style="margin:6px 0 10px">no graph turns yet — every message will route here once it's on</div>`
+    : `<div class="splitbar">
+        ${seg("seg-skip", g.stats.quick, "quick", Math.round(g.stats.quick / tot * 100))}
+        ${seg("seg-ret", g.stats.full, "full", 100 - Math.round(g.stats.quick / tot * 100))}
+      </div><div class="meta" style="margin:6px 0 10px">${g.stats.quick} answered by the small model alone — the loop never woke</div>`;
+  if (!g.enabled)
+    return `<div class="card"><div class="meta">Off — every turn runs the classic loop above. Switch on
+      <b>graph workflows</b> in <a class="reveal" onclick="location.hash='settings'">Settings</a> and every message
+      is triaged first: trivial ones get a fast small-model reply, real tasks run the same loop as a graph node.
+      You never pick a mode — the harness decides, this chart just shows which door each turn took.</div></div>`;
+  return `<div class="card" style="cursor:pointer" onclick="location.hash='graph'">
+    ${split}${wf ? graphSVG(wf) : ""}
+    <div class="meta" style="margin-top:8px">live — nodes light up as a turn flows through · click for the full story</div></div>`;
+}
+
+// --- live animation: same machinery as the loop's STAGE map. hot() lights
+// every copy on the page, so the Overview panel and the Graph tab glow together.
+const GRAPH_KINDS = new Set(["graph_start", "node_start", "node_end", "route", "graph_end"]);
+function animateGraphStage(ev){
+  if (!document.querySelector(".graphchart")) return;
+  const status = t => document.querySelectorAll(".arch-status").forEach(
+    st => st.innerHTML = `<span class="live-dot"></span>${t}`);
+  if (ev.type === "graph_start"){ status("graph workflow starts"); hot(`[data-node="g-START"]`, "hot", 1000); }
+  else if (ev.type === "node_start") status(`graph · ${ev.node}`);
+  else if (ev.type === "node_end") hot(`[data-node="g-${ev.node}"]`, "hot", 1000);
+  else if (ev.type === "route"){
+    status(`route → ${ev.target}`);
+    hot(`[data-edge="g-${ev.router}-${ev.target}"]`, "live", 1400);
+    hot(`[data-node="g-${ev.target}"]`, "hot", 1400);
+  }
+  else if (ev.type === "graph_end") hot(`[data-node="g-END"]`, "hot", 1000);
+}

--- a/waku/ops/static/js/main.js
+++ b/waku/ops/static/js/main.js
@@ -4,6 +4,7 @@
 
 let activeView = null, activeSub = null;
 const TITLES = {chat:"Chat & watch", ops:"LLM Ops",
+                graph:"Graph workflows — structure around the loop",
                 compare:"Arena — race models through the real loop",
                 database:"Database — everything Waku stores (state.db)"};
 function render(){
@@ -14,9 +15,9 @@ function render(){
   const subChanged = sub !== activeSub || view !== activeView;
   document.querySelectorAll("nav a").forEach(a=>a.classList.toggle("on", a.dataset.v===view));
   document.getElementById("title").textContent = TITLES[view] || view[0].toUpperCase()+view.slice(1);
-  if (view === "overview"){
+  if (view === "overview" || view === "graph"){
     // don't rebuild mid-animation or the glowing SVG gets wiped
-    if (activeView !== "overview" || !animating){ document.getElementById("view").innerHTML = VIEWS.overview(D); }
+    if (activeView !== view || !animating){ document.getElementById("view").innerHTML = VIEWS[view](D); }
   } else if ((view === "memory" || view === "settings" || view === "database" || view === "compare") && editing && !subChanged){
     // don't wipe an in-progress edit on the 5s refresh — but DO switch sub-tabs
   } else {
@@ -34,6 +35,8 @@ function render(){
   document.getElementById("model").textContent = `${D.provider} · ${D.model}`;
   document.getElementById("n-gw").textContent = (D.chat_log||[]).length;
   document.getElementById("n-loop").textContent = D.stats.turns;
+  document.getElementById("n-graph").textContent =
+    (D.graph && (D.graph.stats.quick + D.graph.stats.full)) || "";
   document.getElementById("n-mem").textContent = D.facts.length + D.episodes.length;
   document.getElementById("n-tools").textContent = D.calendar.length + D.outbox.length;
   document.getElementById("n-db").textContent = (D.db && D.db.all_tables.length) || "";

--- a/waku/ops/static/js/models.js
+++ b/waku/ops/static/js/models.js
@@ -7,8 +7,8 @@
 // releases the edit lock — else the render guard keeps showing the OLD state
 // (live bug: "Current:" card stayed on kimi after switching) — clears the stale
 // catalog, and re-fetches. Returns the response so callers show their own status.
-async function applyModel({provider, model, small_model, episodic_store, experimental, keys = {}}){
-  const r = await postJSON("/api/settings", {provider, model, small_model, episodic_store, experimental, keys});
+async function applyModel({provider, model, small_model, episodic_store, experimental, graph_workflows, keys = {}}){
+  const r = await postJSON("/api/settings", {provider, model, small_model, episodic_store, experimental, graph_workflows, keys});
   if (!r.error){ editing = false; modelCatalog = null; await refresh(); }
   return r;
 }
@@ -18,10 +18,11 @@ async function saveSettings(){
   const small_model = (document.getElementById("set-small-model")?.value || "").trim();
   const episodic_store = document.getElementById("set-episodic-store")?.value;
   const experimental = document.getElementById("set-experimental")?.value;
+  const graph_workflows = document.getElementById("set-graph-workflows")?.value;
   const keys = {};
   document.querySelectorAll("[data-key]").forEach(i => { if(i.value.trim()) keys[i.dataset.key] = i.value.trim(); });
   document.getElementById("set-msg").textContent = "switching…";
-  const r = await applyModel({provider, model, small_model, episodic_store, experimental, keys});
+  const r = await applyModel({provider, model, small_model, episodic_store, experimental, graph_workflows, keys});
   document.getElementById("set-msg").textContent = r.error ? ("Error: "+r.error) : "Switched to "+r.provider+" — live now.";
 }
 function markEditing(){ editing = true; }

--- a/waku/ops/static/js/render.js
+++ b/waku/ops/static/js/render.js
@@ -25,6 +25,7 @@ const toolRow = x => `<div class="tool ${x.status||"ok"}">
 function histItem(m){
   if (m.role === "user") return {role:"user", text:m.content};
   if (m.meta) return {role:"waku", reply:m.content, gate:m.meta.gate,
+                      graph:m.meta.graph,
                       tools:m.meta.tools, iterations:m.meta.iterations,
                       latency_ms:m.meta.latency_ms, model:m.meta.model};
   return {role:"waku", reply:m.content, historical:true};
@@ -69,17 +70,22 @@ function stagesRow(t, live){
   const gateCls = live ? (t.gate ? "done" : "on") : "done";
   const replyCls = live ? (t.stream ? "on" : "") : "done";
   const tools = (t.tools||[]).map(x => toolChip(x.tool)).join("");
+  // graph chip first — the front door. A quick graph turn has NO gate stage
+  // (memory retrieval never ran), so the gate chip is honest and disappears.
+  const graph = (t.graph && t.graph.route)
+    ? `<span class="stage done">graph · ${esc(t.graph.route)}</span>` : "";
+  const gate = (t.graph && t.graph.route === "quick") ? ""
+    : `<span class="stage ${gateCls}">gate${t.gate?` · ${esc(t.gate.decision)}`:""}</span>`;
   return `<div class="stages${live?"":" tele"}">`
-    + `<span class="stage ${gateCls}">gate${t.gate?` · ${esc(t.gate.decision)}`:""}</span>`
-    + tools + `<span class="stage ${replyCls}">reply</span></div>`;
+    + graph + gate + tools + `<span class="stage ${replyCls}">reply</span></div>`;
 }
 // The per-turn telemetry footer: seconds · iterations · model · consolidation.
 const teleFooter = t => `<div class="meta tele">${secs(t.latency_ms)} · ${t.iterations??"?"} iter${
   t.model?` · ${esc(t.model)}`:""}${t.consolidation?` · consolidated ${t.consolidation.new_facts} fact(s)`:""}</div>`;
 
 const chatTurnCard = t => `<div class="card">
-  ${t.gate?`${stagesRow(t, false)}
-    <div class="meta tele" style="margin:0 0 6px">${esc(t.gate.reason||"")}</div>`:""}
+  ${(t.gate||t.graph)?`${stagesRow(t, false)}
+    <div class="meta tele" style="margin:0 0 6px">${esc((t.gate&&t.gate.reason)||(t.graph&&t.graph.reason)||"")}</div>`:""}
   ${(t.tools||[]).length?`<div class="tele">${(t.tools||[]).map(toolRow).join("")}</div>`:""}
   <div class="r" style="margin-top:8px">${renderMarkdown(t.reply)}</div>
   ${teleFooter(t)}
@@ -126,6 +132,10 @@ function syncChatLogs(){
 // One streamed harness event updates the live card in place.
 function applyStreamEvent(pending, ev){
   if (ev.kind === "gate") pending.gate = {decision: ev.decision, reason: ev.reason};
+  else if (ev.kind === "route")
+    pending.graph = {route: ev.target === "quick_reply" ? "quick" : "full",
+                     reason: (pending.graph || {}).reason};
+  else if (ev.kind === "triage") (pending.graph = pending.graph || {}).reason = ev.reason;
   else if (ev.kind === "text") pending.stream = (pending.stream || "") + (ev.delta || "");
   else if (ev.kind === "tool"){
     (pending.tools = pending.tools || []).push({

--- a/waku/ops/static/js/views.js
+++ b/waku/ops/static/js/views.js
@@ -237,10 +237,52 @@ const VIEWS = {
     <h2>Retrieval gate — the hero decision</h2>${gateSplit(s)}
     <h2 style="margin-top:26px">Architecture — click any box <span class="arch-status"></span></h2>
     ${archSVG(d)}
+    <h2>Graph workflows — when a turn needs shape</h2>
+    ${graphPanel(d)}
     <h2>Latest turn</h2>${d.turns.length?turnCard(d.turns[0]):'<div class="card empty">no turns yet — talk to Waku first</div>'}`;
   },
   loop(d){
     return d.turns.length ? d.turns.map(turnCard).join("") : `<div class="card empty">no turns yet</div>`;
+  },
+  // Graph workflows: the loop's sibling. The chart is rendered from the
+  // engine's own describe() (served in d.graph.workflows) so it can never
+  // show a shape the engine doesn't run. Nothing here is a mode switch —
+  // the harness routes every message itself; this tab just tells the story.
+  graph(d){
+    const g = d.graph || {enabled:false, workflows:[], stats:{quick:0, full:0}};
+    const wf = g.workflows[0];
+    let h = `<div class="meta" style="margin-bottom:14px">The loop is one agent turn: the model picks tools until
+      it stops. Some work has <b>shape</b> — steps that can run at the same time, and explicit "if this, go
+      there" routing. A <b>graph workflow</b> makes that shape first-class: nodes (each does one job) connected
+      by edges (what happens next). The loop did not change one line — the <code>full_agent</code> node below
+      IS the same loop, running as one step. You never pick a mode: the harness triages every message itself
+      and this page just shows which door each turn took.</div>`;
+    if (!g.enabled)
+      h += `<div class="card"><b>Off</b> — every turn currently runs the classic loop.
+        <div class="meta" style="margin-top:6px">Switch on <b>graph workflows</b> in
+        <a class="reveal" onclick="location.hash='settings'">Settings</a>, or set
+        <code>WAKU_GRAPH_WORKFLOWS=1</code> in <code>.env</code>. Any failure anywhere fails open to the
+        plain loop — this can never lose a reply, only save time and tokens.</div></div>`;
+    if (wf){
+      h += `<h2>${esc(wf.name)} — live topology <span class="arch-status"></span></h2>`;
+      const tot = g.stats.quick + g.stats.full;
+      h += `<div class="card">${graphSVG(wf)}
+        <div class="meta" style="margin-top:8px">solid arrows = always · dashed = the router's choice ·
+        ${tot ? `${g.stats.quick} quick / ${g.stats.full} full so far` : "no graph turns on tape yet"} ·
+        drawn from the engine's own <code>describe()</code>, so this picture cannot drift from the code</div></div>`;
+    }
+    const gturns = (d.turns||[]).filter(t => t.graph && t.graph.route);
+    h += `<h2>Graph turns</h2>`;
+    h += gturns.length
+      ? gturns.slice(0,20).map(t => `<div class="card">
+          <div class="u">${esc(t.user_message)}</div>
+          <div class="meta" style="margin-top:4px"><span class="badge ${t.graph.route==="quick"?"":"retrieve"}">graph · ${esc(t.graph.route)}</span>
+            <span class="meta" style="margin:0">${esc(t.graph.reason||"")}</span></div>
+          <div class="r">${renderMarkdown(t.reply||"")}</div></div>`).join("")
+      : `<div class="card empty">no graph turns yet — ${g.enabled
+          ? 'say "thanks!" in the chat and watch it take the quick door'
+          : "switch the flag on first"}</div>`;
+    return h;
   },
   memory(d, sub){
     sub = sub || "overview";
@@ -290,6 +332,20 @@ const VIEWS = {
       ${st.pi_installed
         ? `<div class="meta"><span class="srcpill" style="background:var(--good-soft);color:var(--good)">pi found</span> on this machine</div>`
         : `<div class="meta"><span class="srcpill apple">pi not installed</span> — <code>npm install -g --ignore-scripts @earendil-works/pi-coding-agent</code></div>`}
+      <div style="margin-top:12px"><button class="save" onclick="saveSettings()">Save &amp; switch</button>
+        <span class="meta" style="margin-left:10px">rebuilds the agent in-process — no restart</span></div>
+    </div>
+    <h2>Graph workflows</h2><div class="card">
+      <div class="meta" style="margin-bottom:8px">Off by default. When on, <b>every</b> message is triaged
+        through a graph first: a small model classifies it while today's calendar loads in parallel — trivial
+        messages get a fast small-model reply, real tasks run the exact same loop as a node. You never pick a
+        mode; any failure fails open to the plain loop. Watch it live on the
+        <a class="reveal" onclick="location.hash='graph'">Graph</a> tab.</div>
+      <label class="fld">Triage-first turns
+        <select id="set-graph-workflows" onfocus="markEditing()">
+          <option value="" ${!st.graph_workflows?"selected":""}>off — every turn runs the classic loop (default)</option>
+          <option value="1" ${st.graph_workflows?"selected":""}>on — triage graph routes each message</option>
+        </select></label>
       <div style="margin-top:12px"><button class="save" onclick="saveSettings()">Save &amp; switch</button>
         <span class="meta" style="margin-left:10px">rebuilds the agent in-process — no restart</span></div>
     </div>


### PR DESCRIPTION
## What this adds

A stdlib graph engine (`waku/graph/`, 433 lines), two workflows, and a dashboard Graph tab.

**The distinction it teaches:** a loop *discovers* what to do next; a graph *pre-determines* what happens next. Both ship, side by side, so you can read them against each other.

- `waku brief` — morning briefing as a **LOOP**: one prompt, the model works out which tools to call, four sequential round trips.
- `waku gather` — the same job as a **GRAPH**: four sources fetched together, then one digest.

## Why it is being merged now

This branch sat parked because its only workflow (`triage`) was a weak example — its two "parallel" branches were one LLM call and a 40ms file read, and the router never read the value it fetched. The bar for merging was a workflow that genuinely earns the shape.

`gather` is that workflow. Measured on the first live run against this repo:

```
node_start  scan_github  scan_web  scan_calendar  scan_memory
node_end    scan_github    1500ms
node_end    scan_web        515ms
node_end    scan_calendar     5ms
node_end    scan_memory       6ms
```

Four starts before a single finish. The wave costs its slowest branch (1500ms) rather than the sum (2026ms) — before counting the model round trip a loop needs between each tool call.

## Safety

The graph front door is **off by default** (`WAKU_GRAPH_WORKFLOWS`), and any failure anywhere falls open to the plain loop, so it cannot make Waku worse.

`gather` **proposes and never acts**: no `agent_node`, no `run_loop`, no `ToolRegistry`, and its single model call passes **no `tools` parameter** — a model handed no tool schemas cannot call a tool. The only write is a markdown file in the outbox. A source-level eval fails CI if that ever changes.

## Verification

**374 deterministic tests, ruff clean.** Verified live in the CLI and the dashboard. The live run also surfaced a real SQLite threading bug in the memory scan that the offline tests could not — `_safe` absorbed it and the digest shipped one source short, which is the failure mode that wrapper exists for, working as designed.