### PR TITLE
release: 0.1.1 — agent graphs, and a tag that matches what shipped

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "waku-agent"
-version = "0.1.0"
+version = "0.1.1"
 description = "A minimal, transparent, local-first Waku: harness + loop + memory + eval, in code you can read in an afternoon."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Two reasons for a version bump rather than moving a tag.

The substantive one: this is the first release with waku/graph/ — the graph
engine, the triage front door, and `waku gather`. Worth its own number.

The housekeeping one: the v0.1.0 git tag points at 4aaa98c, from 2026-07-26 —
five days before the packaging fix in #44. So checking out v0.1.0 gives code
whose wheel ships NO skills, while PyPI's 0.1.0 was built from a later main.
The two disagree about what 0.1.0 means.

Force-moving a published tag would fix the disagreement by rewriting history
someone may already have fetched. Cutting 0.1.1 from the current tree costs one
version number and leaves the record honest: v0.1.0 stays where it was, and
v0.1.1 points at code that actually matches its wheel.

374 deterministic tests pass, ruff clean.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
