### PR TITLE
feat(dashboard): show both graph workflows, and stop the node labels lying

### DIFF
--- a/waku/ops/dashboard.py
+++ b/waku/ops/dashboard.py
@@ -318,6 +318,7 @@ def collect() -> dict:
 
     # --- graph workflows: topology straight from the engine (never hand-drawn,
     # so the picture can't drift) + quick/full split from the trace events
+    from waku.graph.workflows.gather import gather_topology
     from waku.graph.workflows.triage import triage_topology
     graph_routes = [e.get("target") for e in events if e.get("type") == "route"]
 
@@ -365,7 +366,8 @@ def collect() -> dict:
         "eval_history": eval_history,
         "graph": {
             "enabled": settings.graph_workflows,
-            "workflows": [triage_topology()],
+            # triage stays index 0 — the Overview panel renders workflows[0].
+            "workflows": [triage_topology(), gather_topology()],
             "stats": {"quick": sum(1 for t in graph_routes if t == "quick_reply"),
                       "full": sum(1 for t in graph_routes if t == "full_agent")},
         },

--- a/waku/ops/static/js/graph.js
+++ b/waku/ops/static/js/graph.js
@@ -36,7 +36,15 @@ function graphSVG(wf, opts = {}){
     const colH = col.length * (H + GY) - GY;
     pos[n] = {x: PAD + ci * (W + GX), y: PAD + (height - PAD * 2 - colH) / 2 + ri * (H + GY)};
   }));
-  const SUB = {llm: "small model", agent: "THE loop, as a node", tool: "local read", fn: ""};
+  // "code, no model" not "local read": a tool node is anything deterministic —
+  // triage's calendar peek is a local file, but gather's scan_github shells out
+  // to gh and scan_web hits the network. What they share is that no model runs.
+  // Both labels used to overclaim. "local read" was true for triage's calendar
+  // peek and false for gather's scan_github (a subprocess) and scan_web (the
+  // network) — what tool nodes share is that NO MODEL RUNS. And "small model"
+  // was true of triage's classify and false of gather's synthesize, which uses
+  // the main one; the kind alone does not know which, so do not claim.
+  const SUB = {llm: "one model call", agent: "THE loop, as a node", tool: "code, no model", fn: ""};
   const nodeBox = n => {
     const p = pos[n];
     if (n === "START" || n === "END")

--- a/waku/ops/static/js/views.js
+++ b/waku/ops/static/js/views.js
@@ -250,7 +250,6 @@ const VIEWS = {
   // the harness routes every message itself; this tab just tells the story.
   graph(d){
     const g = d.graph || {enabled:false, workflows:[], stats:{quick:0, full:0}};
-    const wf = g.workflows[0];
     let h = `<div class="meta" style="margin-bottom:14px">The loop is one agent turn: the model picks tools until
       it stops. Some work has <b>shape</b> — steps that can run at the same time, and explicit "if this, go
       there" routing. A <b>graph workflow</b> makes that shape first-class: nodes (each does one job) connected
@@ -263,14 +262,23 @@ const VIEWS = {
         <a class="reveal" onclick="location.hash='settings'">Settings</a>, or set
         <code>WAKU_GRAPH_WORKFLOWS=1</code> in <code>.env</code>. Any failure anywhere fails open to the
         plain loop — this can never lose a reply, only save time and tokens.</div></div>`;
-    if (wf){
-      h += `<h2>${esc(wf.name)} — live topology <span class="arch-status"></span></h2>`;
+    const NOTE = {
+      triage: `solid arrows = always · dashed = the router's choice · every message comes through
+        this door, and <code>full_agent</code> is the ordinary loop running as one node`,
+      gather: `the four scans have no dependencies on each other, so the engine runs them in ONE WAVE —
+        together, not in turn. Run it with <code>make gather</code>. It proposes and never acts:
+        the digest lands in the outbox for you to read`,
+    };
+    (g.workflows || []).forEach(w => {
+      if (!w) return;
+      h += `<h2>${esc(w.name)} — live topology <span class="arch-status"></span></h2>`;
       const tot = g.stats.quick + g.stats.full;
-      h += `<div class="card">${graphSVG(wf)}
-        <div class="meta" style="margin-top:8px">solid arrows = always · dashed = the router's choice ·
-        ${tot ? `${g.stats.quick} quick / ${g.stats.full} full so far` : "no graph turns on tape yet"} ·
+      const extra = w.name === "triage" && tot
+        ? ` · ${g.stats.quick} quick / ${g.stats.full} full so far` : "";
+      h += `<div class="card">${graphSVG(w)}
+        <div class="meta" style="margin-top:8px">${NOTE[w.name] || ""}${extra} ·
         drawn from the engine's own <code>describe()</code>, so this picture cannot drift from the code</div></div>`;
-    }
+    });
     const gturns = (d.turns||[]).filter(t => t.graph && t.graph.route);
     h += `<h2>Graph turns</h2>`;
     h += gturns.length


### PR DESCRIPTION
The Graph tab rendered workflows[0] only, so `gather` — the workflow that makes
the parallel case — was invisible the moment it shipped. It now renders every
workflow the payload carries, each with a one-line note saying what its shape
is for. triage stays at index 0 because the Overview panel renders that one.

Two node subtitles were overclaiming, both dating from when triage was the only
workflow and the label happened to be true:

  "local read"  was right for triage's calendar peek and wrong for gather's
                scan_github (a gh subprocess) and scan_web (the network). What
                tool nodes actually share is that NO MODEL RUNS -> "code, no
                model".

  "small model" was right for triage's classify and wrong for gather's
                synthesize, which uses the main model. The node kind does not
                know which model a node picked, so it should not claim one ->
                "one model call".

Both were visible on screen, next to a chart whose whole selling point is that
it is generated from the engine and therefore cannot drift. A caption that
drifts is the same bug wearing different clothes.

Verified in the browser: both topologies render, gather shows its four-way
fan-out and the dashed conditional edges out of synthesize, zero console errors.
374 deterministic tests pass, ruff clean.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
