### PR TITLE
feat(dashboard): show the wave happening, not just its shape

### DIFF
--- a/evals/deterministic/test_dashboard_routes.py
+++ b/evals/deterministic/test_dashboard_routes.py
@@ -49,7 +49,8 @@ GET_PATHS = {
 
 # Streaming endpoints. These are what the dashboard actually uses for chat and
 # racing; the browser reads them as SSE, so they are handled before the router.
-STREAM_ROUTES = {"/api/chat/stream", "/api/compare/stream", "/api/voice"}
+STREAM_ROUTES = {"/api/chat/stream", "/api/compare/stream", "/api/voice",
+                 "/api/graph/stream"}
 
 
 def _source() -> str:
@@ -77,7 +78,7 @@ def test_streaming_routes_survive():
 
 
 def test_the_handlers_behind_the_routes_exist_and_are_callable():
-    for name in ("collect", "chat", "chat_stream", "compare_stream", "memory_action",
+    for name in ("collect", "chat", "chat_stream", "compare_stream", "graph_stream", "memory_action",
                  "apply_settings", "run_query", "session_action", "pin_action",
                  "list_models", "events_since", "reveal_path", "settings_info",
                  "tools_info", "compare_clear", "compare_regrade", "compare_delete_run"):

--- a/evals/deterministic/test_graph_stream.py
+++ b/evals/deterministic/test_graph_stream.py
@@ -1,0 +1,149 @@
+"""DETERMINISTIC EVAL — /api/graph/stream, the socket behind the wave cards.
+
+The cards in the Graph tab are only as honest as the events reaching them, and
+three ways to break that are invisible until a live run:
+
+  * a workflow name arriving from the browser gets imported and called
+  * a value that json.dumps cannot encode kills the stream mid-frame, so the
+    browser sees a half-finished run and no error
+  * a node raises and the whole response dies instead of reporting
+
+None of that needs a model, a network or a real workflow — a scripted graph and
+a fake emit are enough. Offline, sub-second.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from waku.graph import END, START, Graph, Node
+from waku.ops import dashboard
+
+
+def _emitter():
+    out: list[tuple[str, dict]] = []
+    return out, lambda kind, ev: out.append((kind, ev))
+
+
+def test_an_unknown_workflow_is_refused_without_importing_anything():
+    """The runner table is a dict for exactly this reason. 'run the workflow the
+    client named' is one careless refactor from 'import whatever string
+    arrives', so the refusal is pinned."""
+    out, emit = _emitter()
+    for name in ("", "nope", "waku.ops.gather", "os:system", "../../etc/passwd"):
+        out.clear()
+        dashboard.graph_stream({"workflow": name}, emit)
+        assert len(out) == 1 and out[0][0] == "done"
+        assert "unknown workflow" in out[0][1]["error"], out
+
+
+def test_the_runner_table_maps_names_to_known_targets():
+    assert dashboard.WORKFLOW_RUNNERS == {"gather": "waku.ops.gather:run_gather"}
+    for target in dashboard.WORKFLOW_RUNNERS.values():
+        module, _, fn = target.partition(":")
+        assert module.startswith("waku.") and fn
+
+
+@pytest.fixture
+def scripted(monkeypatch):
+    """Swap the gather runner for a tiny scripted graph — same engine, same
+    events, no model and no network."""
+    def fake_run(observer=None, **kw):
+        g = Graph("gather")
+        g.add_node(Node("a", lambda s: {"x": 1}, kind="tool"))
+        g.add_node(Node("b", lambda s: {"y": 2}, kind="tool"))
+        g.add_node(Node("c", lambda s: {"digest": "D"}, kind="llm"))
+        for n in ("a", "b"):
+            g.add_edge(START, n)
+            g.add_edge(n, "c")
+        g.add_edge("c", END)
+        from waku.graph import run_graph
+
+        return run_graph(g, {}, observer=observer)
+
+    import waku.ops.gather as gather_mod
+
+    monkeypatch.setattr(gather_mod, "run_gather", fake_run)
+    return fake_run
+
+
+def test_the_fan_out_is_visible_in_the_event_order(scripted):
+    """Both parallel nodes must START before either ENDS. That ordering is the
+    only thing the cards use to group a wave, so if it stops holding the UI
+    silently draws two waves of one instead of one wave of two."""
+    out, emit = _emitter()
+    dashboard.graph_stream({"workflow": "gather"}, emit)
+    kinds = [(k, ev.get("node")) for k, ev in out]
+    starts = [i for i, (k, n) in enumerate(kinds) if k == "node_start" and n in ("a", "b")]
+    first_end = next(i for i, (k, n) in enumerate(kinds) if k == "node_end")
+    assert len(starts) == 2 and max(starts) < first_end, kinds
+
+
+def test_every_event_survives_json_dumps(scripted):
+    """The endpoint writes `data: {json}` per frame. One unencodable value —
+    a Path, a LoopResult — and the socket dies mid-stream with a traceback the
+    browser never sees, leaving the cards frozen and blameless."""
+    out, emit = _emitter()
+    dashboard.graph_stream({"workflow": "gather"}, emit)
+    assert out
+    for kind, ev in out:
+        json.dumps({"kind": kind, **ev}, default=str)
+
+
+def test_node_output_never_rides_along(scripted):
+    """Cards need names and timings, not payloads. node_end carrying a digest
+    would put the whole briefing into every frame."""
+    for kind, ev in [(k, e) for k, e in _run(scripted) if k == "node_end"]:
+        assert set(ev) <= {"workflow", "node", "ms", "keys", "error"}, ev
+
+
+def _run(_):
+    out, emit = _emitter()
+    dashboard.graph_stream({"workflow": "gather"}, emit)
+    return out
+
+
+def test_the_run_ends_with_a_done_carrying_the_digest(scripted):
+    out = _run(scripted)
+    assert out[-1][0] == "done"
+    assert out[-1][1]["digest"] == "D"
+    assert out[-1][1]["workflow"] == "gather"
+
+
+def test_a_raising_node_still_finishes_the_stream(monkeypatch):
+    """A dead node must not strand the browser. graph_end and done both still
+    arrive, so the cards settle instead of spinning forever."""
+    def fake_run(observer=None, **kw):
+        g = Graph("gather")
+
+        def boom(_s):
+            raise RuntimeError("scan died")
+
+        g.add_node(Node("a", boom, kind="tool"))
+        g.add_edge(START, "a")
+        g.add_edge("a", END)
+        from waku.graph import run_graph
+
+        return run_graph(g, {}, observer=observer)
+
+    import waku.ops.gather as gather_mod
+
+    monkeypatch.setattr(gather_mod, "run_gather", fake_run)
+    out = _run(None)
+    assert any(k == "graph_end" for k, _ in out)
+    assert out[-1][0] == "done"
+
+
+def test_a_runner_that_explodes_reports_instead_of_500ing(monkeypatch):
+    """GraphStateCollision is raised OUT of run_graph, unlike node errors. It
+    must surface in the card rather than drop the socket."""
+    def boom(**kw):
+        raise RuntimeError("collision")
+
+    import waku.ops.gather as gather_mod
+
+    monkeypatch.setattr(gather_mod, "run_gather", boom)
+    out = _run(None)
+    assert out[-1][0] == "done" and "collision" in out[-1][1]["error"]

--- a/waku/ops/dashboard.py
+++ b/waku/ops/dashboard.py
@@ -113,6 +113,44 @@ def chat_stream(message: str, emit) -> None:
     })
 
 
+# A NAME -> runner table, never a dynamic import of whatever the browser sent.
+# "run the workflow the client named" is one careless refactor away from "import
+# and call whatever string arrives", so the indirection is a dict on purpose.
+WORKFLOW_RUNNERS = {"gather": "waku.ops.gather:run_gather"}
+
+
+def graph_stream(payload: dict, emit) -> None:
+    """Run a graph workflow, streaming its node events as SSE.
+
+    Only the engine's own events go out — graph_start / node_start / node_end /
+    route / graph_end. They already carry `workflow` and `node`, which is all a
+    card needs, and they carry no node OUTPUT, so a digest can never leak into
+    a frame. Unlike the Arena this needs no lock of its own: run_graph already
+    serialises notify() behind one (engine.py), so events arrive whole.
+    """
+    name = (payload.get("workflow") or "").strip()
+    target = WORKFLOW_RUNNERS.get(name)
+    if target is None:
+        emit("done", {"error": f"unknown workflow '{name}'"})
+        return
+    module_name, _, fn_name = target.partition(":")
+    try:
+        import importlib
+
+        run = getattr(importlib.import_module(module_name), fn_name)
+        state = run(observer=lambda kind, ev: emit(kind, ev))
+        emit("done", {
+            "workflow": name,
+            "digest": (state.get("digest") or "")[:4000],
+            "draft_path": state.get("draft_path", ""),
+            "errors": state.get("errors") or {},
+        })
+    except Exception as exc:
+        # Includes GraphStateCollision, which run_graph raises OUT (unlike node
+        # errors) — better shown in the card than dropped on the floor.
+        emit("done", {"error": f"{type(exc).__name__}: {exc}"})
+
+
 def _parse_ts(ts: str):
     try:
         return datetime.fromisoformat(ts)
@@ -321,6 +359,15 @@ def collect() -> dict:
     from waku.graph.workflows.gather import gather_topology
     from waku.graph.workflows.triage import triage_topology
     graph_routes = [e.get("target") for e in events if e.get("type") == "route"]
+    # The last few completed runs, newest first. Overview needs this because the
+    # two workflows are two different JOBS with different triggers — triage runs
+    # itself on every message, gather runs when you ask — so "which chart is
+    # relevant right now" is a question only the trace can answer. Rendering a
+    # fixed workflow there showed triage forever, seconds after a gather ran.
+    graph_runs = [{"workflow": e.get("workflow"), "ms": e.get("ms"),
+                   "at": e.get("ts"), "steps": e.get("steps"),
+                   "path": e.get("path") or [], "error": e.get("error")}
+                  for e in events if e.get("type") == "graph_end"][-8:][::-1]
 
     return {
         "generated_at": datetime.now(UTC).isoformat(timespec="seconds"),
@@ -365,9 +412,12 @@ def collect() -> dict:
         "eval_report": eval_report,
         "eval_history": eval_history,
         "graph": {
+            # NOTE: `enabled` gates TRIAGE ONLY — the per-message front door.
+            # `waku gather` is a routine you run yourself and ignores this flag
+            # entirely, so the UI must not say "off = no graphs run".
             "enabled": settings.graph_workflows,
-            # triage stays index 0 — the Overview panel renders workflows[0].
             "workflows": [triage_topology(), gather_topology()],
+            "runs": graph_runs,
             "stats": {"quick": sum(1 for t in graph_routes if t == "quick_reply"),
                       "full": sum(1 for t in graph_routes if t == "full_agent")},
         },
@@ -859,6 +909,21 @@ class Handler(BaseHTTPRequestHandler):
                                judge_spec=(payload.get("judge_model") or ""), apple=bool(payload.get("apple")))
             except Exception as exc:
                 emit("done", {"error": f"{type(exc).__name__}: {exc}"})
+            return
+        if self.path == "/api/graph/stream":
+            payload = json.loads(self.rfile.read(length) or "{}")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Cache-Control", "no-cache")
+            self.end_headers()
+
+            def emit(kind, ev):
+                try:
+                    self.wfile.write(f"data: {json.dumps({'kind': kind, **ev}, default=str)}\n\n".encode())
+                    self.wfile.flush()
+                except (BrokenPipeError, ConnectionResetError):
+                    pass
+            graph_stream(payload, emit)
             return
         routes = {"/api/chat": None, "/api/memory": memory_action, "/api/settings": apply_settings,
                   "/api/query": run_query, "/api/session": session_action, "/api/pin": pin_action,

--- a/waku/ops/static/js/graph.js
+++ b/waku/ops/static/js/graph.js
@@ -36,9 +36,10 @@ function graphSVG(wf, opts = {}){
     const colH = col.length * (H + GY) - GY;
     pos[n] = {x: PAD + ci * (W + GX), y: PAD + (height - PAD * 2 - colH) / 2 + ri * (H + GY)};
   }));
-  // "code, no model" not "local read": a tool node is anything deterministic —
-  // triage's calendar peek is a local file, but gather's scan_github shells out
-  // to gh and scan_web hits the network. What they share is that no model runs.
+  // Ids carry the workflow name. START and END exist in EVERY workflow, so on a
+  // page showing two charts an un-namespaced `g-START` lit both of them at once
+  // — and hot() deliberately hits every match, so the bug looked like a feature.
+  const nid = n => `g-${wf.name}-${n}`;
   // Both labels used to overclaim. "local read" was true for triage's calendar
   // peek and false for gather's scan_github (a subprocess) and scan_web (the
   // network) — what tool nodes share is that NO MODEL RUNS. And "small model"
@@ -48,11 +49,11 @@ function graphSVG(wf, opts = {}){
   const nodeBox = n => {
     const p = pos[n];
     if (n === "START" || n === "END")
-      return `<g class="node" data-node="g-${n}">
+      return `<g class="node" data-node="${nid(n)}">
         <rect class="bx" x="${p.x + W/2 - 34}" y="${p.y + H/2 - 15}" width="68" height="30" rx="15"/>
         <text class="nt" x="${p.x + W/2}" y="${p.y + H/2 + 5}" text-anchor="middle" style="font-size:12px">${n}</text></g>`;
     const sub = SUB[kinds[n]] || "";
-    return `<g class="node" data-node="g-${n}">
+    return `<g class="node" data-node="${nid(n)}">
       <rect class="bx" x="${p.x}" y="${p.y}" width="${W}" height="${H}" rx="9"/>
       <text class="nt" x="${p.x + 12}" y="${p.y + 22}">${esc(n)}</text>
       ${sub ? `<text class="ns" x="${p.x + 12}" y="${p.y + 39}">${sub}</text>` : ""}</g>`;
@@ -62,7 +63,7 @@ function graphSVG(wf, opts = {}){
     const x1 = a.x + (e.src === "START" ? W/2 + 34 : W), y1 = a.y + H/2;
     const x2 = b.x + (e.dst === "END" ? W/2 - 34 : 0), y2 = b.y + H/2;
     const mx = (x1 + x2) / 2;
-    return `<path class="flow${e.conditional ? " dash" : ""}" data-edge="g-${e.src}-${e.dst}"
+    return `<path class="flow${e.conditional ? " dash" : ""}" data-edge="g-${wf.name}-${e.src}-${e.dst}"
       d="M${x1} ${y1} C${mx} ${y1} ${mx} ${y2} ${x2} ${y2}" marker-end="url(#garr)"/>`;
   };
   return `<div style="overflow-x:auto"><svg viewBox="0 0 ${width} ${height}" class="arch graphchart"
@@ -76,8 +77,15 @@ function graphSVG(wf, opts = {}){
 
 // --- the compact Overview panel: the harness auto-decides, this reflects it.
 function graphPanel(d){
-  const g = d.graph || {enabled: false, workflows: [], stats: {quick: 0, full: 0}};
-  const wf = g.workflows[0];
+  const g = d.graph || {enabled: false, workflows: [], runs: [], stats: {quick: 0, full: 0}};
+  // Overview is a STATUS surface — "what just happened" — while the Graph tab
+  // is a reference one: "what shapes exist". So this shows the workflow that
+  // most recently RAN, from the trace. Pinning it to workflows[0] meant Overview
+  // showed triage forever, seconds after a gather, which is why the panel read
+  // as leftovers rather than as news.
+  const last = (g.runs || [])[0];
+  const wf = (g.workflows || []).find(w => w && w.name === (last || {}).workflow)
+             || (g.workflows || [])[0];
   const tot = g.stats.quick + g.stats.full;
   const seg = (cls, n, label, pct) =>
     `<div class="${cls}" style="width:${pct}%">${pct >= 14 ? `${n} ${label}` : ""}</div>`;
@@ -87,14 +95,23 @@ function graphPanel(d){
         ${seg("seg-skip", g.stats.quick, "quick", Math.round(g.stats.quick / tot * 100))}
         ${seg("seg-ret", g.stats.full, "full", 100 - Math.round(g.stats.quick / tot * 100))}
       </div><div class="meta" style="margin:6px 0 10px">${g.stats.quick} answered by the small model alone — the loop never woke</div>`;
-  if (!g.enabled)
-    return `<div class="card"><div class="meta">Off — every turn runs the classic loop above. Switch on
-      <b>graph workflows</b> in <a class="reveal" onclick="location.hash='settings'">Settings</a> and every message
-      is triaged first: trivial ones get a fast small-model reply, real tasks run the same loop as a graph node.
-      You never pick a mode — the harness decides, this chart just shows which door each turn took.</div></div>`;
+  // The flag gates TRIAGE — the per-message door — and nothing else. `waku
+  // gather` is a routine you start yourself and runs regardless, so the old
+  // copy ("off = every turn runs the classic loop") was quietly false the
+  // moment a second workflow existed.
+  if (!g.enabled && !last)
+    return `<div class="card"><div class="meta">The per-message graph door is <b>off</b> — every chat turn
+      runs the classic loop above. Switch on <b>graph workflows</b> in
+      <a class="reveal" onclick="location.hash='settings'">Settings</a> to triage each message first.
+      Workflows you run yourself, like <code>make gather</code>, do not need the flag —
+      <a class="reveal" onclick="location.hash='graph'">see them here</a>.</div></div>`;
+  const when = last
+    ? `last run: <b>${esc(last.workflow || "")}</b>${last.ms ? ` · ${(last.ms/1000).toFixed(1)}s` : ""}${
+        last.steps ? ` · ${last.steps} nodes` : ""}`
+    : "live — nodes light up as a turn flows through";
   return `<div class="card" style="cursor:pointer" onclick="location.hash='graph'">
-    ${split}${wf ? graphSVG(wf) : ""}
-    <div class="meta" style="margin-top:8px">live — nodes light up as a turn flows through · click for the full story</div></div>`;
+    ${g.enabled ? split : ""}${wf ? graphSVG(wf) : ""}
+    <div class="meta" style="margin-top:8px">${when} · click for the full story</div></div>`;
 }
 
 // --- live animation: same machinery as the loop's STAGE map. hot() lights
@@ -104,13 +121,160 @@ function animateGraphStage(ev){
   if (!document.querySelector(".graphchart")) return;
   const status = t => document.querySelectorAll(".arch-status").forEach(
     st => st.innerHTML = `<span class="live-dot"></span>${t}`);
-  if (ev.type === "graph_start"){ status("graph workflow starts"); hot(`[data-node="g-START"]`, "hot", 1000); }
-  else if (ev.type === "node_start") status(`graph · ${ev.node}`);
-  else if (ev.type === "node_end") hot(`[data-node="g-${ev.node}"]`, "hot", 1000);
+  // Every graph event carries `workflow`, so the ids can be scoped to the chart
+  // that is actually running instead of lighting every chart on the page.
+  const w = ev.workflow || "";
+  if (ev.type === "graph_start"){ status(`${w} starts`); hot(`[data-node="g-${w}-START"]`, "hot", 1000); }
+  else if (ev.type === "node_start") status(`${w} · ${ev.node}`);
+  else if (ev.type === "node_end") hot(`[data-node="g-${w}-${ev.node}"]`, "hot", 1000);
   else if (ev.type === "route"){
     status(`route → ${ev.target}`);
-    hot(`[data-edge="g-${ev.router}-${ev.target}"]`, "live", 1400);
-    hot(`[data-node="g-${ev.target}"]`, "hot", 1400);
+    hot(`[data-edge="g-${w}-${ev.router}-${ev.target}"]`, "live", 1400);
+    hot(`[data-node="g-${w}-${ev.target}"]`, "hot", 1400);
   }
-  else if (ev.type === "graph_end") hot(`[data-node="g-END"]`, "hot", 1000);
+  else if (ev.type === "graph_end") hot(`[data-node="g-${w}-END"]`, "hot", 1000);
+}
+
+// ---------------------------------------------------------------------------
+// THE RUNNER — N nodes as a row of live cards.
+//
+// The topology chart above shows the SHAPE: "these four are independent". It
+// cannot show that they actually ran together, because a picture has no time
+// axis and a viewer cannot tell four boxes lit at once from four lit very fast
+// in sequence. So the cards carry the time: they start together, tick while
+// running, and finish out of order. Watching three settle while one spins is
+// the proof the chart can only promise.
+//
+// Same shape as the Arena, deliberately — arena.py tags every event with `spec`
+// and routes it to a card; the graph engine already tags every event with
+// `node`. Swap the key, reuse .cmp-grid/.cmp-col, and it reads as a sibling
+// because it is one.
+let graphRun = {running: false, workflow: "", nodes: {}, order: [], waves: [],
+                digest: "", draft: "", error: "", ticker: null};
+
+function graphResetRun(workflow){
+  graphRun = {running: true, workflow, nodes: {}, order: [], waves: [],
+              digest: "", draft: "", error: "", ticker: graphRun.ticker};
+}
+
+function graphApplyEvent(ev){
+  const R = graphRun;
+  const k = ev.kind;
+  if (k === "graph_start"){
+    R.order = ev.nodes || [];
+    R.order.forEach(n => R.nodes[n] = {status: "waiting"});
+  } else if (k === "node_start"){
+    // A wave is "the nodes that started before any of them finished". That is
+    // exactly what the engine means by a wave, and it is what the row groups by.
+    const open = R.waves[R.waves.length - 1];
+    if (open && !open.closed) open.nodes.push(ev.node);
+    else R.waves.push({nodes: [ev.node], closed: false});
+    R.nodes[ev.node] = {status: "running", startedAt: performance.now()};
+  } else if (k === "node_end"){
+    const w = R.waves[R.waves.length - 1];
+    if (w) w.closed = true;   // first finish closes the wave for new members
+    R.nodes[ev.node] = {status: ev.error ? "error" : "done", ms: ev.ms,
+                        keys: ev.keys || [], error: ev.error || ""};
+  } else if (k === "route"){
+    R.route = {target: ev.target, reason: ev.reason};
+  } else if (k === "graph_end"){
+    R.running = false; R.totalMs = ev.ms;
+  } else if (k === "done"){
+    R.running = false;
+    R.digest = ev.digest || ""; R.draft = ev.draft_path || ""; R.error = ev.error || "";
+  }
+}
+
+async function runGraph(workflow){
+  if (graphRun.running) return;
+  graphResetRun(workflow);
+  // Without a ticker the elapsed numbers freeze and the cards look identical to
+  // a sequential run — the one thing this view exists to disprove.
+  clearInterval(graphRun.ticker);
+  graphRun.ticker = setInterval(() => { if (graphRun.running) render(); }, 100);
+  render();
+  try {
+    const res = await fetch("/api/graph/stream", {
+      method: "POST", headers: {"Content-Type": "application/json"},
+      body: JSON.stringify({workflow}),
+    });
+    const reader = res.body.getReader();
+    const dec = new TextDecoder();
+    let buf = "";
+    for (;;){
+      const {value, done} = await reader.read();
+      if (done) break;
+      buf += dec.decode(value, {stream: true});
+      const parts = buf.split("\n\n");
+      buf = parts.pop();
+      for (const p of parts){
+        const line = p.trim();
+        if (!line.startsWith("data:")) continue;
+        try { graphApplyEvent(JSON.parse(line.slice(5))); } catch (e) { /* partial frame */ }
+        render();
+      }
+    }
+  } catch (e){
+    graphRun.error = String(e);
+  } finally {
+    graphRun.running = false;
+    clearInterval(graphRun.ticker);
+    render();
+  }
+}
+
+function graphCol(name){
+  const n = graphRun.nodes[name] || {status: "waiting"};
+  if (n.status === "waiting")
+    return `<div class="cmp-col" style="opacity:.5"><div class="cmp-h"><b>${esc(name)}</b></div>
+      <div class="meta">queued</div></div>`;
+  if (n.status === "running"){
+    const el = ((performance.now() - n.startedAt) / 1000).toFixed(1);
+    return `<div class="cmp-col"><div class="cmp-h"><b>${esc(name)}</b></div>
+      <div class="meta"><span class="live-dot"></span>${el}s</div></div>`;
+  }
+  if (n.status === "error")
+    return `<div class="cmp-col err"><div class="cmp-h"><b>${esc(name)}</b></div>
+      <div class="meta" style="color:var(--bad)">${esc(n.error)}</div></div>`;
+  // The bar is scaled to the SLOWEST node in this node's wave, and every faster
+  // node prints what it spent waiting at the barrier. That number is the honest
+  // cost of wave execution — printing it teaches more than hiding it would.
+  const wave = graphRun.waves.find(w => w.nodes.includes(name));
+  const peers = (wave ? wave.nodes : [name]).map(x => (graphRun.nodes[x] || {}).ms || 0);
+  const slowest = Math.max(...peers, 1);
+  const pct = Math.round((n.ms || 0) / slowest * 100);
+  const waited = slowest - (n.ms || 0);
+  return `<div class="cmp-col"><div class="cmp-h"><b>${esc(name)}</b>
+      <span class="chip">${n.ms}ms</span></div>
+    <div class="wavebar"><i style="width:${pct}%"></i></div>
+    <div class="meta">${waited > 20 && peers.length > 1
+      ? `waited ${(waited/1000).toFixed(1)}s at the barrier`
+      : (peers.length > 1 ? "set the pace for this wave" : "")}</div>
+    <div class="meta">${(n.keys || []).map(k => `<span class="chip">${esc(k)}</span>`).join(" ")}</div>
+  </div>`;
+}
+
+function graphRunPanel(){
+  const R = graphRun;
+  const btn = `<button class="btn" onclick="runGraph('gather')" ${R.running ? "disabled" : ""}>
+    ${R.running ? "running…" : "Run gather"}</button>`;
+  let h = `<h2>Run it — watch the wave <span class="meta" style="font-weight:400">
+    the chart shows the shape; these cards show it happening</span></h2>
+    <div class="card">${btn}
+    <span class="meta" style="margin-left:10px">fetches GitHub, the web, your calendar and your
+    memory — together. Proposes only: the digest lands in the outbox.</span>`;
+  if (R.error) h += `<div class="meta" style="color:var(--bad);margin-top:10px">${esc(R.error)}</div>`;
+  R.waves.forEach((w, i) => {
+    const done = w.nodes.filter(n => (R.nodes[n] || {}).ms != null);
+    const slowest = done.length ? Math.max(...done.map(n => R.nodes[n].ms)) : 0;
+    const sum = done.reduce((a, n) => a + R.nodes[n].ms, 0);
+    h += `<div class="meta" style="margin:14px 0 6px">wave ${i + 1} · ${w.nodes.length}
+      node${w.nodes.length > 1 ? "s" : ""}${slowest ? ` · ${(slowest/1000).toFixed(1)}s`
+      + (w.nodes.length > 1 ? ` (in sequence it would be ${(sum/1000).toFixed(1)}s)` : "") : ""}</div>
+      <div class="cmp-grid">${w.nodes.map(graphCol).join("")}</div>`;
+  });
+  if (R.totalMs) h += `<div class="meta" style="margin-top:12px">finished in
+    ${(R.totalMs/1000).toFixed(1)}s${R.draft ? ` · saved to <code>${esc(R.draft)}</code>` : ""}</div>`;
+  if (R.digest) h += `<div class="card" style="margin-top:10px">${renderMarkdown(R.digest)}</div>`;
+  return h + `</div>`;
 }

--- a/waku/ops/static/js/views.js
+++ b/waku/ops/static/js/views.js
@@ -262,12 +262,17 @@ const VIEWS = {
         <a class="reveal" onclick="location.hash='settings'">Settings</a>, or set
         <code>WAKU_GRAPH_WORKFLOWS=1</code> in <code>.env</code>. Any failure anywhere fails open to the
         plain loop — this can never lose a reply, only save time and tokens.</div></div>`;
+    // The two workflows are two different JOBS with different triggers, which is
+    // the thing the page has to make obvious — otherwise two stacked charts read
+    // like two options you pick between.
     const NOTE = {
-      triage: `solid arrows = always · dashed = the router's choice · every message comes through
-        this door, and <code>full_agent</code> is the ordinary loop running as one node`,
-      gather: `the four scans have no dependencies on each other, so the engine runs them in ONE WAVE —
-        together, not in turn. Run it with <code>make gather</code>. It proposes and never acts:
-        the digest lands in the outbox for you to read`,
+      triage: `<b>Runs itself, on every message.</b> Gated by the graph-workflows flag.
+        Solid arrows = always, dashed = the router's choice. <code>full_agent</code> is the
+        ordinary loop running as one node — a graph does not replace the loop, it arranges calls to it.`,
+      gather: `<b>Runs when you start it</b> — <code>make gather</code> or the button below — and
+        ignores the flag entirely. The four scans have no dependencies on each other, so the engine
+        runs them in ONE WAVE: together, not in turn. It proposes and never acts; the digest lands
+        in the outbox for you to read.`,
     };
     (g.workflows || []).forEach(w => {
       if (!w) return;
@@ -278,6 +283,7 @@ const VIEWS = {
       h += `<div class="card">${graphSVG(w)}
         <div class="meta" style="margin-top:8px">${NOTE[w.name] || ""}${extra} ·
         drawn from the engine's own <code>describe()</code>, so this picture cannot drift from the code</div></div>`;
+      if (w.name === "gather") h += graphRunPanel();
     });
     const gturns = (d.turns||[]).filter(t => t.graph && t.graph.route);
     h += `<h2>Graph turns</h2>`;

--- a/waku/ops/static/style.css
+++ b/waku/ops/static/style.css
@@ -324,6 +324,11 @@
   .cmp-col{background:var(--panel);border:1px solid var(--line);border-radius:12px;
        padding:12px 14px;display:flex;flex-direction:column;gap:8px}
   .cmp-col.err{border-color:var(--bad)}
+  /* One wave's nodes all start together, so every bar shares a left edge and
+     ends where that node finished. Four bars of different lengths from the same
+     origin IS the wave — the topology chart above can only promise it. */
+  .wavebar{height:6px;background:var(--line);border-radius:3px;overflow:hidden}
+  .wavebar i{display:block;height:100%;background:var(--accent);border-radius:3px}
   .cmp-h{display:flex;align-items:center;gap:6px;font-size:13px}
   .cmp-stats{display:flex;flex-wrap:wrap;gap:5px;align-items:center}
   .chip{font-size:11px;color:var(--ink2);border:1px solid var(--line2);border-radius:99px;padding:1px 8px}


### PR DESCRIPTION
The topology chart says "these four are independent". It cannot say they
actually ran together — a picture has no time axis, and nobody can tell four
boxes lit at once from four lit very fast in turn. So the parallelism was a
claim the UI asked you to take on faith.

The cards carry the time instead. One wave per row, bars sharing a left edge
because the nodes shared a start, each ending where that node finished:

    wave 1 · 4 nodes · 2.0s (in sequence it would be 3.5s)
      scan_github    1453ms  ████████░░░  waited 0.6s at the barrier
      scan_web       2029ms  ███████████  set the pace for this wave
      scan_calendar     1ms  ░░░░░░░░░░░  waited 2.0s at the barrier
      scan_memory       8ms  ░░░░░░░░░░░  waited 2.0s at the barrier

The barrier waits are printed rather than hidden. Wave execution costs its
slowest branch, and a reader who can see the 2.0s scan_calendar spent waiting
understands the trade better than one shown only the win.

Structurally this is the Arena: arena.py tags every event with `spec` and the
browser routes it to a card; the engine already tags every event with `node`.
Swap the key, reuse .cmp-grid/.cmp-col, and it reads as a sibling because it is
one. No second lock is needed — run_graph already serialises notify().

Three fixes that came out of putting two workflows on one page:

* SVG ids were not namespaced by workflow. START and END exist in EVERY
  workflow, and hot() deliberately lights every match, so `g-START` lit both
  charts at once — a bug that looked like a feature.

* The Overview panel rendered workflows[0], i.e. triage, forever. But the two
  workflows are two different JOBS: triage runs itself on every message, gather
  runs when you start it. Overview is a status surface, so it now shows the
  workflow that most recently RAN, read from graph_end events in the trace.
  That is why the panel read as leftovers — it was.

* "Off — every turn runs the classic loop" became false the moment a second
  workflow existed. WAKU_GRAPH_WORKFLOWS gates the per-message door ONLY;
  `make gather` ignores it. Both surfaces now say which is which.

/api/graph/stream mirrors the compare endpoint, with a name -> runner dict so
a workflow name from the browser can never become a dynamic import. Only engine
events go out — they carry no node output, so a digest cannot leak into a frame.

8 new offline tests: unknown names refused without importing, both fan-out
nodes starting before either ends, every event surviving json.dumps (one
unencodable value kills the socket mid-frame and the browser never learns why),
node output staying out of the frames, and a raising node still reaching
graph_end and done rather than stranding the cards.

382 deterministic pass, ruff clean. Verified in the browser against a real
gather: two charts, correct wave grouping, zero console errors.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
