### PR TITLE
fix: find the user's .env from where they ARE, and say so when we cannot

### DIFF
--- a/evals/deterministic/test_dotenv_discovery.py
+++ b/evals/deterministic/test_dotenv_discovery.py
@@ -1,0 +1,112 @@
+"""DETERMINISTIC EVAL — finding the user's .env, and saying so when we cannot.
+
+Reported 2026-07-31 from a clean install: standing in the waku-agent folder,
+with a .env holding a valid ANTHROPIC_API_KEY, `waku brief` answered
+
+    No API key for provider 'anthropic'. Set ANTHROPIC_API_KEY in .env
+    (see .env.example).
+
+Both halves of that sentence were wrong. The .env was right there, and
+.env.example does not exist unless you cloned the repo.
+
+The cause: bare `load_dotenv()` searches upward from the FILE THAT CALLED IT,
+not from the working directory. In a git checkout config.py sits inside the
+project, so walking up from it lands on the project's .env by luck. Installed
+from PyPI it walks up from site-packages, hits /, and finds nothing.
+
+That is why no test caught it: every test runs from the checkout, where the
+broken behaviour and the correct behaviour are indistinguishable. These tests
+therefore assert on the RULE (usecwd) rather than on the outcome in this repo,
+because the outcome in this repo is green either way.
+"""
+
+from __future__ import annotations
+
+import inspect
+import subprocess
+import sys
+import textwrap
+
+from waku import config
+from waku.loop import models
+
+
+def test_dotenv_is_found_from_the_working_directory():
+    """THE regression. `find_dotenv()` without usecwd resolves relative to
+    waku's own source; the user is standing somewhere else entirely."""
+    src = inspect.getsource(config._load_env)
+    assert "usecwd=True" in src, (
+        "load_dotenv is searching from waku's install location again — an "
+        "installed Waku will ignore the user's .env and claim it has no key"
+    )
+
+
+def test_the_loaded_path_is_recorded():
+    """A user with three .env files needs to know which one won. Recording the
+    path is also what lets the error message say where to add the line."""
+    assert hasattr(config, "DOTENV_PATH")
+    assert isinstance(config.DOTENV_PATH, str)
+
+
+def test_a_subdirectory_still_finds_the_project_env(tmp_path):
+    """The upward walk is kept deliberately: running `waku` from a subfolder of
+    your project should find the .env at its root, the rule git and pytest
+    already taught everyone. Only the STARTING POINT changes."""
+    root = tmp_path / "proj"
+    (root / "deep" / "nested").mkdir(parents=True)
+    (root / ".env").write_text("ANTHROPIC_API_KEY=from-project-root\n", encoding="utf-8")
+    # A clean environment on purpose. load_dotenv does NOT override a variable
+    # that is already exported — correct behaviour (a real exported key should
+    # beat a file) but it means this suite, which runs with ANTHROPIC_API_KEY
+    # blanked, would otherwise measure the blank instead of the .env.
+    import os
+
+    env = {k: v for k, v in os.environ.items() if k != "ANTHROPIC_API_KEY"}
+    out = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent("""
+            from dotenv import find_dotenv, load_dotenv
+            import os
+            load_dotenv(find_dotenv(usecwd=True))
+            print(os.getenv("ANTHROPIC_API_KEY", ""))
+        """)],
+        cwd=root / "deep" / "nested", env=env,
+        capture_output=True, text=True, check=False)
+    assert out.stdout.strip() == "from-project-root", out
+
+
+def test_the_error_never_points_at_a_file_pip_users_do_not_have():
+    """.env.example ships only in the git checkout. Telling someone who ran
+    `pip install waku-agent` to 'see .env.example' is a dead end, and it was
+    the ONLY instruction the old message gave."""
+    msg = models._no_key_message("anthropic", "ANTHROPIC_API_KEY")
+    assert ".env.example" not in msg
+
+
+def test_the_error_says_how_to_get_a_key():
+    msg = models._no_key_message("anthropic", "ANTHROPIC_API_KEY")
+    assert "https://" in msg, "no URL — the reader has to go and search"
+    assert "ANTHROPIC_API_KEY" in msg
+
+
+def test_the_error_names_the_env_file_in_play():
+    """'Set it in .env' is ambiguous the moment more than one .env exists. Say
+    which file was loaded, or say plainly that none was found and where to
+    create one."""
+    msg = models._no_key_message("anthropic", "ANTHROPIC_API_KEY")
+    assert (config.DOTENV_PATH and config.DOTENV_PATH in msg) or "No .env found" in msg
+
+
+def test_the_error_mentions_the_other_providers():
+    """Waku speaks to eleven providers. Naming one made it look like a
+    single-vendor tool to anyone who hit this on their first run — which is
+    everyone who hits it."""
+    msg = models._no_key_message("anthropic", "ANTHROPIC_API_KEY")
+    for other in ("openai", "gemini", "openrouter"):
+        assert other in msg
+    assert "WAKU_PROVIDER" in msg
+
+
+def test_every_provider_has_somewhere_to_get_a_key():
+    """A provider in the table with no URL is a dead end for whoever picks it."""
+    missing = sorted(set(models.PROVIDERS) - set(models.KEY_URLS))
+    assert missing == [], f"no key URL for: {missing}"

--- a/waku/config.py
+++ b/waku/config.py
@@ -10,9 +10,35 @@ import os
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from dotenv import load_dotenv
+from dotenv import find_dotenv, load_dotenv
 
-load_dotenv()  # reads .env in the current directory, if present
+
+def _load_env() -> str:
+    """Find the user's .env the way the user expects: from where they ARE.
+
+    Bare `load_dotenv()` searches upward from the file that called it, not from
+    the working directory. Inside a git checkout that is invisible — config.py
+    lives in the project, so walking up from it lands on the project's .env and
+    everything works. Installed from PyPI it walks up from site-packages,
+    reaches the filesystem root, and finds nothing: the user stands in a folder
+    holding a perfectly good .env and Waku reports "No API key". Reported from
+    a clean install on 2026-07-31, from inside the repo folder itself.
+
+    usecwd=True is the whole fix. The walk upward is kept on purpose, so
+    running `waku` from a subdirectory of your project still finds the .env at
+    its root — the same rule git, npm and pytest already taught everyone.
+
+    Returns the path that was loaded (empty string if none) so `waku doctor`
+    and the first-run error can say WHICH file was read, rather than leaving
+    people guessing between three .env files.
+    """
+    path = find_dotenv(usecwd=True)
+    if path:
+        load_dotenv(path)
+    return path
+
+
+DOTENV_PATH = _load_env()
 
 
 @dataclass

--- a/waku/loop/models.py
+++ b/waku/loop/models.py
@@ -109,6 +109,53 @@ PROVIDERS: dict[str, Provider] = {
 }
 
 
+# Where each provider's key actually comes from. Pointing at ".env.example"
+# was useless advice for anyone who installed from PyPI — that file only exists
+# in a git checkout, so the one instruction the message gave could not be
+# followed by the people most likely to need it.
+KEY_URLS = {
+    "anthropic": "https://console.anthropic.com/settings/keys",
+    "openai": "https://platform.openai.com/api-keys",
+    "gemini": "https://aistudio.google.com/apikey",
+    "deepseek": "https://platform.deepseek.com/api_keys",
+    "openrouter": "https://openrouter.ai/keys",
+    "kimi": "https://platform.moonshot.ai/console/api-keys",
+    "glm": "https://z.ai/manage-apikey/apikey-list",
+    "minimax": "https://platform.minimaxi.com/user-center/basic-information",
+    "xai": "https://console.x.ai",
+    "opencode_zen": "https://opencode.ai/zen",
+    "opencode_go": "https://opencode.ai/zen",
+}
+
+
+def _no_key_message(name: str, key_env: str) -> str:
+    """Say what to set, where to get it, and WHICH file we read.
+
+    The old message named one env var and pointed at a file that does not exist
+    off a git checkout. Three things were missing and each one cost a search:
+    the URL to get a key, the absolute path of the .env actually in play, and
+    the fact that Waku speaks to eleven providers, not one.
+    """
+    from waku.config import DOTENV_PATH
+
+    # Name the variable in BOTH branches. "add the line there" without saying
+    # which line is the same dead end as pointing at .env.example was.
+    where = (f"Add it to {DOTENV_PATH}:\n"
+             f"    {key_env}=your-key-here"
+             if DOTENV_PATH else
+             f"No .env found from {os.getcwd()} upward — create one here:\n"
+             f"    echo '{key_env}=your-key-here' >> .env")
+    url = KEY_URLS.get(name)
+    return (
+        f"No API key for provider '{name}'.\n\n"
+        f"  1. Get a key: {url}\n" if url else f"No API key for provider '{name}'.\n\n"
+    ) + (
+        f"  2. {where}\n\n"
+        f"Other providers: {', '.join(sorted(PROVIDERS))}\n"
+        f"Switch with WAKU_PROVIDER=<name> and that provider's key."
+    )
+
+
 def get_client(settings: Settings):
     """Build the client for settings.provider and fill in default model ids.
     Returns anything with .messages.create(...) in the Anthropic shape."""
@@ -121,10 +168,7 @@ def get_client(settings: Settings):
     # auth header (headers are latin-1; a stray non-ASCII char errors cryptically).
     api_key = (settings.api_key or os.getenv(provider.key_env, "")).strip()
     if not api_key:
-        raise SystemExit(
-            f"No API key for provider '{settings.provider}'. "
-            f"Set {provider.key_env} in .env (see .env.example)."
-        )
+        raise SystemExit(_no_key_message(settings.provider, provider.key_env))
     try:
         api_key.encode("latin-1")
     except UnicodeEncodeError:


### PR DESCRIPTION
Reported from a clean install: standing in the waku-agent folder, with a .env
holding a valid ANTHROPIC_API_KEY, `waku brief` answered

    No API key for provider 'anthropic'. Set ANTHROPIC_API_KEY in .env
    (see .env.example).

Both halves of that sentence were wrong. The .env was right there, and
.env.example does not exist unless you cloned the repo.

Bare `load_dotenv()` searches upward from the FILE THAT CALLED IT, not from
the working directory. In a checkout config.py sits inside the project, so
walking up from it lands on the project's .env by luck and everything works.
Installed from PyPI it walks up from site-packages, reaches /, and finds
nothing — so an installed Waku ignores every .env a user will ever write.

    find_dotenv()              -> ''
    find_dotenv(usecwd=True)   -> /Users/.../waku-agent/.env

usecwd=True is the fix. The upward walk is kept deliberately, so running waku
from a subdirectory still finds the .env at the project root — the rule git,
npm and pytest already taught everyone. Only the starting point changes.

The error message was the second half of the failure, and it is worth naming
separately: the ONE instruction it gave — "see .env.example" — could not be
followed by exactly the people most likely to need it. It now gives the URL to
get a key, names the .env file actually in play (or says none was found and
where to create one), and mentions that Waku speaks to eleven providers rather
than reading as a single-vendor tool on someone's first run.

This is the third bug this week that was invisible from inside the repo and
broken for everyone outside it — after the wheel that shipped no skills and
the tag that pointed at the wrong tree. So the tests assert on the RULE
(usecwd appears in the source; no message may cite .env.example; every
provider has a key URL) rather than on behaviour in this checkout, where the
broken and the fixed versions are indistinguishable.

One of those tests found a real thing while being written: load_dotenv does
NOT override an already-exported variable. Correct — a real exported key
should beat a file — but it means a blank ANTHROPIC_API_KEY in the
environment silently defeats a perfectly good .env, so the test passes a
clean env and says why.

390 deterministic tests pass, ruff clean.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
