### PR TITLE
feat: call a graph workflow by name — /gather, and any workflow you add

### DIFF
--- a/evals/deterministic/test_graph_stream.py
+++ b/evals/deterministic/test_graph_stream.py
@@ -40,8 +40,10 @@ def test_an_unknown_workflow_is_refused_without_importing_anything():
 
 
 def test_the_runner_table_maps_names_to_known_targets():
-    assert dashboard.WORKFLOW_RUNNERS == {"gather": "waku.ops.gather:run_gather"}
-    for target in dashboard.WORKFLOW_RUNNERS.values():
+    """Discovered rather than hand-listed since slash commands shipped — a
+    hardcoded table beside a command list is two registries of one fact."""
+    assert dashboard.WORKFLOW_RUNNERS()["gather"] == "waku.ops.gather:run_gather"
+    for target in dashboard.WORKFLOW_RUNNERS().values():
         module, _, fn = target.partition(":")
         assert module.startswith("waku.") and fn
 

--- a/evals/deterministic/test_slash_commands.py
+++ b/evals/deterministic/test_slash_commands.py
@@ -1,0 +1,98 @@
+"""DETERMINISTIC EVAL — calling a graph workflow by name.
+
+Two kinds of graph ship here and conflating them made the UI state something
+false. `triage` is a ROUTER — it runs itself on every message and you should
+never think about it. `gather` is a PROCEDURE — a named shape you ask for. The
+dashboard claimed "you never pick a mode" in two places, which was true right
+up until the second kind existed.
+
+A graph is a pre-determined workflow, so naming it is the natural interface.
+These tests pin the discovery rule that makes that automatic, and the parser
+that decides what counts as a command — because the failure mode of a loose
+parser is that an ordinary message mentioning a path silently runs something.
+"""
+
+from __future__ import annotations
+
+from waku.ops import commands
+
+
+def test_gather_is_discovered():
+    assert "gather" in commands.discover()
+
+
+def test_triage_is_not_a_command():
+    """The rule with teeth. triage is bound inside app.py as the per-message
+    door and has no waku/ops/triage.py, so it cannot be called by name — which
+    is correct: a router you invoke manually is just a slower loop."""
+    assert "triage" not in commands.discover()
+
+
+def test_discovery_requires_both_halves():
+    """A workflow module is the PURE graph — injected callables, nothing bound
+    to this machine, deliberately unrunnable on its own. The binder in
+    waku/ops/ is what makes it runnable, so that is what earns the command."""
+    import pkgutil
+
+    import waku.graph.workflows as pkg
+
+    modules = {m.name for m in pkgutil.iter_modules(pkg.__path__) if not m.name.startswith("_")}
+    assert modules >= {"triage", "gather"}
+    for name, target in commands.discover().items():
+        assert name in modules, f"/{name} has no workflow module"
+        assert target == f"waku.ops.{name}:run_{name}"
+
+
+def test_the_runner_table_and_the_commands_cannot_drift():
+    """/api/graph/stream and the slash commands are two doors to one set of
+    workflows. Two hand-maintained lists of the same fact drift; one function
+    cannot."""
+    from waku.ops import dashboard
+
+    assert dashboard.WORKFLOW_RUNNERS() == commands.discover()
+
+
+# --- the parser --------------------------------------------------------------
+
+def test_a_leading_slash_is_a_command():
+    assert commands.parse("/gather") == ("gather", "")
+    assert commands.parse("  /graphs  ") == ("graphs", "")
+    assert commands.parse("/gather since friday") == ("gather", "since friday")
+
+
+def test_ordinary_messages_are_not_commands():
+    """The expensive failure is the other direction: a message that merely
+    mentions a path must never fire a workflow."""
+    for text in ("hello", "look in /tmp/x", "what is 3/4", "", "   ",
+                 "/ gather", "the file is at /etc/hosts"):
+        assert commands.parse(text) is None, text
+
+
+def test_an_unknown_command_explains_itself():
+    msg = commands.unknown_reply("nope")
+    assert "/nope" in msg
+    assert "/gather" in msg, "must list what DOES exist"
+    assert "/graphs" in msg
+
+
+def test_the_listing_names_every_runnable_workflow():
+    text = commands.describe()
+    for name in commands.discover():
+        assert f"/{name}" in text
+    assert "triage" in text, "should say why the router has no command"
+
+
+def test_running_an_unknown_name_returns_none_rather_than_raising():
+    assert commands.run("definitely-not-a-workflow", lambda *a: None) is None
+
+
+# --- the UI must stop claiming you cannot choose ------------------------------
+
+def test_the_dashboard_no_longer_says_you_never_pick_a_mode():
+    """That sentence was true when triage was the only workflow. It became
+    false the moment a workflow you must invoke yourself shipped alongside it,
+    and a UI that contradicts the feature is worse than no copy at all."""
+    import pathlib
+
+    js = pathlib.Path(__file__).resolve().parents[2] / "waku/ops/static/js/views.js"
+    assert "never pick a mode" not in js.read_text()

--- a/waku/ops/commands.py
+++ b/waku/ops/commands.py
@@ -1,0 +1,109 @@
+"""Slash commands — call a graph workflow by name.
+
+    /gather      run the morning gather
+    /graphs      list what is available
+
+Two kinds of graph ship in Waku and conflating them made the UI say something
+false. `triage` is a ROUTER: it runs itself on every message and you should
+never think about it. `gather` is a PROCEDURE: a named shape you ask for. The
+dashboard used to claim "you never pick a mode", which was true until the
+second kind existed.
+
+A graph is a pre-determined workflow. If the shape is known in advance, being
+able to name it is the natural interface — so anything with a binder gets a
+slash command, automatically.
+
+DISCOVERY, and why it is shaped this way: a module in waku/graph/workflows/ is
+the PURE graph — injected callables, no client, no filesystem, nothing bound to
+this machine. It cannot be run on its own, by design, because that is what
+makes it testable. What makes a workflow runnable is its BINDER in waku/ops/,
+where real callables meet the pure shape.
+
+So the rule is: `waku/graph/workflows/<name>.py` plus `waku/ops/<name>.py`
+exposing `run_<name>` gives you `/<name>`. Drop in both halves and the command
+appears; ship only the pure half and it stays a shape the dashboard can draw
+but nobody can invoke. triage has no binder — it is bound inside app.py as the
+per-message door — so it correctly never becomes a command.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+
+
+def discover() -> dict[str, str]:
+    """{command name: "module:function"} for every runnable workflow.
+
+    Import errors are swallowed per workflow: one broken optional workflow must
+    not take out the whole command list (and with it the chat box).
+    """
+    import waku.graph.workflows as pkg
+
+    found: dict[str, str] = {}
+    for mod in pkgutil.iter_modules(pkg.__path__):
+        name = mod.name
+        if name.startswith("_"):
+            continue
+        binder = f"waku.ops.{name}"
+        try:
+            module = importlib.import_module(binder)
+        except Exception:  # noqa: S112 — one broken optional workflow must not
+            continue       # empty the command list, and with it the chat box
+        if callable(getattr(module, f"run_{name}", None)):
+            found[name] = f"{binder}:run_{name}"
+    return found
+
+
+def describe() -> str:
+    """The /graphs reply. Reads the binder's docstring first line so a new
+    workflow describes itself instead of needing a second registration."""
+    lines = ["**Graph workflows you can run by name**", ""]
+    for name, target in sorted(discover().items()):
+        module_name, _, _ = target.partition(":")
+        try:
+            doc = (importlib.import_module(module_name).__doc__ or "").strip()
+            summary = doc.splitlines()[0] if doc else ""
+        except Exception:
+            summary = ""
+        lines.append(f"`/{name}` — {summary}" if summary else f"`/{name}`")
+    lines += [
+        "",
+        ("These are workflows you *call*. `triage` is different — it is a router "
+         "that runs itself on every message when graph workflows are on, which "
+         "is why it has no command."),
+    ]
+    return "\n".join(lines)
+
+
+def parse(message: str) -> tuple[str, str] | None:
+    """('graphs', '') / ('gather', 'rest of line') / None if not a command.
+
+    A leading slash only counts at the very start and with no space after it,
+    so a message that merely mentions a path is still a message.
+    """
+    text = (message or "").strip()
+    if not text.startswith("/") or text.startswith("/ "):
+        return None
+    head, _, rest = text[1:].partition(" ")
+    return head.strip().lower(), rest.strip()
+
+
+def run(name: str, emit) -> dict | None:
+    """Run a workflow by name, streaming its node events through `emit`.
+
+    Returns the final state, or None if the name is unknown. Never raises: a
+    bad command must answer in the chat, not kill the stream.
+    """
+    target = discover().get(name)
+    if target is None:
+        return None
+    module_name, _, fn_name = target.partition(":")
+    fn = getattr(importlib.import_module(module_name), fn_name)
+    return fn(observer=emit)
+
+
+def unknown_reply(name: str) -> str:
+    known = sorted(discover())
+    listed = ", ".join(f"`/{k}`" for k in known) or "(none installed)"
+    return f"No workflow called `/{name}`.\n\nAvailable: {listed} · `/graphs` for details."

--- a/waku/ops/dashboard.py
+++ b/waku/ops/dashboard.py
@@ -31,7 +31,7 @@ from pathlib import Path
 
 from waku.config import load_settings
 from waku.db import connect
-from waku.ops import browser_agent, compare_history
+from waku.ops import browser_agent, commands, compare_history
 from waku.ops.arena import (
     compare_clear,
     compare_delete_run,
@@ -76,7 +76,16 @@ def chat_stream(message: str, emit) -> None:
     """Run one turn, calling emit(kind, event) for every harness event AS it
     happens — gate decision, tool calls, and the reply text token by token —
     so the browser can show thinking stream in (like the CLI/voice do). Ends
-    with a 'done' event carrying the final structured result."""
+    with a 'done' event carrying the final structured result.
+
+    A leading slash calls a graph workflow BY NAME instead of running a turn.
+    Both doors end in the same 'done' event, so the chat renders the answer the
+    same way whether the harness routed it or you named the shape yourself."""
+    command = commands.parse(message)
+    if command is not None:
+        _run_command(command, emit)
+        return
+
     events: list[dict] = []
 
     def observer(kind, ev):
@@ -116,7 +125,10 @@ def chat_stream(message: str, emit) -> None:
 # A NAME -> runner table, never a dynamic import of whatever the browser sent.
 # "run the workflow the client named" is one careless refactor away from "import
 # and call whatever string arrives", so the indirection is a dict on purpose.
-WORKFLOW_RUNNERS = {"gather": "waku.ops.gather:run_gather"}
+def WORKFLOW_RUNNERS() -> dict[str, str]:  # noqa: N802 — reads as a table
+    """Discovered, not hand-listed. A hardcoded table and a slash-command list
+    are two registries of the same fact, and they drift."""
+    return commands.discover()
 
 
 def graph_stream(payload: dict, emit) -> None:
@@ -129,7 +141,7 @@ def graph_stream(payload: dict, emit) -> None:
     serialises notify() behind one (engine.py), so events arrive whole.
     """
     name = (payload.get("workflow") or "").strip()
-    target = WORKFLOW_RUNNERS.get(name)
+    target = WORKFLOW_RUNNERS().get(name)
     if target is None:
         emit("done", {"error": f"unknown workflow '{name}'"})
         return
@@ -149,6 +161,42 @@ def graph_stream(payload: dict, emit) -> None:
         # Includes GraphStateCollision, which run_graph raises OUT (unlike node
         # errors) — better shown in the card than dropped on the floor.
         emit("done", {"error": f"{type(exc).__name__}: {exc}"})
+
+
+def _run_command(command: tuple[str, str], emit) -> None:
+    """Handle `/name` from the chat box.
+
+    The node events go out exactly as the engine emits them, so the topology
+    chart animates from the same trace poll that animates a normal turn — a
+    named workflow lights the picture as readily as a routed one.
+    """
+    name, _rest = command
+    start = datetime.now(UTC)
+    if name in ("graphs", "help", "?"):
+        emit("done", {"reply": commands.describe(), "tools": [], "iterations": 0,
+                      "latency_ms": 0, "gate": None})
+        return
+    try:
+        state = commands.run(name, emit)
+    except Exception as exc:
+        emit("done", {"reply": f"`/{name}` failed: {type(exc).__name__}: {exc}",
+                      "tools": [], "iterations": 0, "latency_ms": 0, "gate": None})
+        return
+    if state is None:
+        emit("done", {"reply": commands.unknown_reply(name), "tools": [],
+                      "iterations": 0, "latency_ms": 0, "gate": None})
+        return
+    reply = state.get("digest") or "(the workflow produced no text)"
+    if state.get("draft_path"):
+        reply += f"\n\n*saved to `{state['draft_path']}`*"
+    for node, err in (state.get("errors") or {}).items():
+        reply += f"\n\n*{node}: {err}*"
+    emit("done", {
+        "reply": reply, "tools": [], "gate": None, "consolidation": None,
+        "iterations": 0,
+        "latency_ms": int((datetime.now(UTC) - start).total_seconds() * 1000),
+        "workflow": name,
+    })
 
 
 def _parse_ts(ts: str):

--- a/waku/ops/static/js/views.js
+++ b/waku/ops/static/js/views.js
@@ -254,8 +254,8 @@ const VIEWS = {
       it stops. Some work has <b>shape</b> — steps that can run at the same time, and explicit "if this, go
       there" routing. A <b>graph workflow</b> makes that shape first-class: nodes (each does one job) connected
       by edges (what happens next). The loop did not change one line — the <code>full_agent</code> node below
-      IS the same loop, running as one step. You never pick a mode: the harness triages every message itself
-      and this page just shows which door each turn took.</div>`;
+      IS the same loop, running as one step. The harness routes every message itself — and workflows you
+      can also call BY NAME from the chat box: type <code>/graphs</code> to see them.</div>`;
     if (!g.enabled)
       h += `<div class="card"><b>Off</b> — every turn currently runs the classic loop.
         <div class="meta" style="margin-top:6px">Switch on <b>graph workflows</b> in
@@ -352,8 +352,9 @@ const VIEWS = {
     <h2>Graph workflows</h2><div class="card">
       <div class="meta" style="margin-bottom:8px">Off by default. When on, <b>every</b> message is triaged
         through a graph first: a small model classifies it while today's calendar loads in parallel — trivial
-        messages get a fast small-model reply, real tasks run the exact same loop as a node. You never pick a
-        mode; any failure fails open to the plain loop. Watch it live on the
+        messages get a fast small-model reply, real tasks run the exact same loop as a node. This flag governs
+        the AUTOMATIC door only — workflows you call by name (<code>/gather</code>) run either way. Any
+        failure fails open to the plain loop. Watch it live on the
         <a class="reveal" onclick="location.hash='graph'">Graph</a> tab.</div>
       <label class="fld">Triage-first turns
         <select id="set-graph-workflows" onfocus="markEditing()">


### PR DESCRIPTION
Two kinds of graph ship here, and conflating them made the dashboard state
something false. `triage` is a ROUTER: it runs itself on every message and you
should never think about it. `gather` is a PROCEDURE: a named shape you ask
for. The UI said "you never pick a mode" in two places — true right up until
the second kind existed, and false ever since.

A graph is a pre-determined workflow. If the shape is known in advance, naming
it is the natural interface, so a leading slash in the chat box now calls one:

    /gather      run the morning gather
    /graphs      list what is available

REGISTRATION IS AUTOMATIC, and the rule self-documents. A module in
waku/graph/workflows/ is the PURE graph — injected callables, nothing bound to
this machine, deliberately unrunnable on its own because that is what makes it
testable. What makes a workflow runnable is its BINDER in waku/ops/. So:

    waku/graph/workflows/<name>.py + waku/ops/<name>.py::run_<name>  ->  /<name>

Drop in both halves and the command appears. Ship only the pure half and it
stays a shape the dashboard can draw but nobody can invoke. triage has no
binder — it is bound inside app.py as the per-message door — so it correctly
never becomes a command, which is right: a router you invoke by hand is just a
slower loop.

The old hardcoded WORKFLOW_RUNNERS table is now that same discovery call. A
table beside a command list is two registries of one fact, and they drift.

Node events stream out unchanged, so the topology chart animates from the same
trace poll that animates a routed turn — a named workflow lights the picture
as readily as an automatic one.

The parser is deliberately strict at the one end that matters. A slash only
counts at the very start with no space after it, so "look in /tmp/x" and
"what is 3/4" stay messages. The expensive failure is not an unrecognised
command; it is an ordinary sentence silently running a workflow.

Both false UI sentences are rewritten, and a test asserts the phrase cannot
come back.

15 new offline tests. 400 deterministic pass, ruff clean. Verified live:
/graphs lists gather and explains why triage is absent, /nope names what does
exist, and /gather streams all six node events and returns the digest.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
