### PR TITLE
feat: /triage <message> — give the router a front door too

### DIFF
--- a/evals/deterministic/test_slash_commands.py
+++ b/evals/deterministic/test_slash_commands.py
@@ -21,11 +21,19 @@ def test_gather_is_discovered():
     assert "gather" in commands.discover()
 
 
-def test_triage_is_not_a_command():
-    """The rule with teeth. triage is bound inside app.py as the per-message
-    door and has no waku/ops/triage.py, so it cannot be called by name — which
-    is correct: a router you invoke manually is just a slower loop."""
-    assert "triage" not in commands.discover()
+def test_triage_is_a_command_and_takes_a_message():
+    """The router got a front door too. It still runs itself on every message
+    when the flag is on — calling it by name just lets you watch ONE message
+    choose a branch, with the flag off and nothing else changed.
+
+    It is the one runner that needs an argument: a router with nothing to route
+    has nothing to decide."""
+    import importlib
+    import inspect
+
+    assert "triage" in commands.discover()
+    fn = importlib.import_module("waku.ops.triage").run_triage
+    assert "message" in inspect.signature(fn).parameters
 
 
 def test_discovery_requires_both_halves():
@@ -79,7 +87,7 @@ def test_the_listing_names_every_runnable_workflow():
     text = commands.describe()
     for name in commands.discover():
         assert f"/{name}" in text
-    assert "triage" in text, "should say why the router has no command"
+    assert "triage" in text, "should explain how the router differs"
 
 
 def test_running_an_unknown_name_returns_none_rather_than_raising():
@@ -96,3 +104,26 @@ def test_the_dashboard_no_longer_says_you_never_pick_a_mode():
 
     js = pathlib.Path(__file__).resolve().parents[2] / "waku/ops/static/js/views.js"
     assert "never pick a mode" not in js.read_text()
+
+
+def test_a_runner_without_a_message_parameter_is_not_given_one():
+    """gather takes no input — always the same four sources, which is what
+    makes it a fixed shape. Passing it an argument would be a TypeError, so the
+    dispatcher inspects rather than assumes."""
+    import importlib
+    import inspect
+
+    fn = importlib.import_module("waku.ops.gather").run_gather
+    assert "message" not in inspect.signature(fn).parameters
+
+
+def test_triage_without_a_message_explains_itself_instead_of_running():
+    """A bare /triage has nothing to route. Say so, and show the two commands
+    worth comparing, rather than routing an empty string."""
+    state = commands.run("triage", lambda *a: None, "")
+    assert state is not None
+    assert "/triage thanks!" in state["digest"]
+
+
+def test_the_listing_no_longer_says_triage_has_no_command():
+    assert "no command" not in commands.describe()

--- a/waku/ops/commands.py
+++ b/waku/ops/commands.py
@@ -22,13 +22,18 @@ where real callables meet the pure shape.
 So the rule is: `waku/graph/workflows/<name>.py` plus `waku/ops/<name>.py`
 exposing `run_<name>` gives you `/<name>`. Drop in both halves and the command
 appears; ship only the pure half and it stays a shape the dashboard can draw
-but nobody can invoke. triage has no binder — it is bound inside app.py as the
-per-message door — so it correctly never becomes a command.
+but nobody can invoke.
+
+A runner that declares a `message` parameter receives whatever followed the
+command. `gather` takes none — it always fetches the same four things, which is
+what makes it a fixed shape. `triage` needs one, because a router with nothing
+to route has nothing to decide.
 """
 
 from __future__ import annotations
 
 import importlib
+import inspect
 import pkgutil
 
 
@@ -69,9 +74,10 @@ def describe() -> str:
         lines.append(f"`/{name}` — {summary}" if summary else f"`/{name}`")
     lines += [
         "",
-        ("These are workflows you *call*. `triage` is different — it is a router "
-         "that runs itself on every message when graph workflows are on, which "
-         "is why it has no command."),
+        ("`triage` is the ROUTER — it also runs itself on every message when "
+         "graph workflows are on, so calling it by name just lets you watch one "
+         "message choose a door. The others are procedures: they only run when "
+         "you ask."),
     ]
     return "\n".join(lines)
 
@@ -89,8 +95,14 @@ def parse(message: str) -> tuple[str, str] | None:
     return head.strip().lower(), rest.strip()
 
 
-def run(name: str, emit) -> dict | None:
+def run(name: str, emit, arg: str = "") -> dict | None:
     """Run a workflow by name, streaming its node events through `emit`.
+
+    `arg` is whatever followed the command. It is passed only to runners that
+    declare a `message` parameter — a gather takes no input (the whole point is
+    that it always fetches the same four things), while a router needs
+    something to route. Inspecting the signature keeps that a property of each
+    binder rather than a second table someone has to remember to update.
 
     Returns the final state, or None if the name is unknown. Never raises: a
     bad command must answer in the chat, not kill the stream.
@@ -100,6 +112,8 @@ def run(name: str, emit) -> dict | None:
         return None
     module_name, _, fn_name = target.partition(":")
     fn = getattr(importlib.import_module(module_name), fn_name)
+    if "message" in inspect.signature(fn).parameters:
+        return fn(observer=emit, message=arg)
     return fn(observer=emit)
 
 

--- a/waku/ops/dashboard.py
+++ b/waku/ops/dashboard.py
@@ -170,14 +170,14 @@ def _run_command(command: tuple[str, str], emit) -> None:
     chart animates from the same trace poll that animates a normal turn — a
     named workflow lights the picture as readily as a routed one.
     """
-    name, _rest = command
+    name, arg = command
     start = datetime.now(UTC)
     if name in ("graphs", "help", "?"):
         emit("done", {"reply": commands.describe(), "tools": [], "iterations": 0,
                       "latency_ms": 0, "gate": None})
         return
     try:
-        state = commands.run(name, emit)
+        state = commands.run(name, emit, arg)
     except Exception as exc:
         emit("done", {"reply": f"`/{name}` failed: {type(exc).__name__}: {exc}",
                       "tools": [], "iterations": 0, "latency_ms": 0, "gate": None})

--- a/waku/ops/triage.py
+++ b/waku/ops/triage.py
@@ -1,0 +1,67 @@
+"""`/triage <message>` — run the router on demand, and watch it choose.
+
+The triage graph is normally INVISIBLE: when graph workflows are on it runs
+itself on every message, and the whole point is that you never think about it.
+That is the right default and it stays the default.
+
+But a router you cannot watch is a router you have to take on faith. This
+binder gives it a front door, so you can send one message through the graph
+deliberately — with the flag off, without changing any setting, and see which
+branch it picks and why.
+
+    /triage thanks!                     -> quick door, small model, no gate
+    /triage what's on my calendar?      -> full door, gate fires, tools run
+
+That side-by-side is the clearest demonstration of a router there is: same
+harness, same message box, two paths. The automatic door is unaffected — this
+forces the graph for ONE message and changes nothing else.
+"""
+
+from __future__ import annotations
+
+from waku.ops.browser_agent import agent_lock, get_agent
+
+USAGE = (
+    "`/triage` needs a message to route.\n\n"
+    "Try `/triage thanks!` (takes the quick door) and then "
+    "`/triage what's on my calendar today?` (takes the full door), and compare."
+)
+
+
+def run_triage(observer=None, message: str = "") -> dict:
+    """Run ONE message through the triage graph, whatever the flag says.
+
+    Returns a state dict shaped like the other workflows so the chat renders it
+    the same way: `digest` is the reply, plus the route and the classifier's
+    reason, which are the parts worth seeing.
+    """
+    text = (message or "").strip()
+    if not text:
+        return {"digest": USAGE}
+
+    seen: dict = {}
+
+    def notify(kind: str, ev: dict) -> None:
+        if kind == "route":
+            seen["route"] = ev.get("target")
+        if kind == "triage":
+            seen["reason"] = ev.get("reason")
+        if observer:
+            observer(kind, ev)
+
+    with agent_lock:
+        agent = get_agent()
+        # _respond_via_graph is the same method the automatic door uses, so
+        # what you watch here IS what runs on every message when the flag is
+        # on — not a demo path that could drift from it.
+        result = agent._respond_via_graph(text, notify, stream=False)
+
+    if result is None:
+        return {"digest": ("The graph produced no answer, so a real turn would have "
+                           "fallen open to the plain loop — that is the fail-open rule "
+                           "working."), **seen}
+    door = "quick" if seen.get("route") == "quick_reply" else "full"
+    header = (f"**{door} door** — {seen.get('reason', '')}\n\n"
+              if seen.get("route") else "")
+    return {"digest": header + result.reply,
+            "route": seen.get("route"), "reason": seen.get("reason")}


### PR DESCRIPTION
Every workflow in graph/workflows now has a slash command. gather already did;
triage lacked a binder because it is bound inside app.py as the automatic
per-message door.

A router that runs itself is the right default and stays the default. But a
router you cannot watch is one you have to take on faith, and "the harness
decides" is a weak thing to assert on screen with nothing to point at. So:

    /triage thanks!                     -> quick door — Acknowledgement only
    /triage what is on my calendar?     -> full door  — Requires calendar lookup

Same message box, two paths, and the classifier's own reason printed above the
reply. It forces the graph for ONE message and changes nothing else — notably
it works with WAKU_GRAPH_WORKFLOWS off, so you can show routing without
flipping a setting first.

It calls agent._respond_via_graph, the same method the automatic door uses, so
what you watch here IS what runs on every message when the flag is on, not a
demo path free to drift from it.

Runners now receive the text after the command, but only if they declare a
`message` parameter. gather takes none — it always fetches the same four
sources, which is exactly what makes it a fixed shape — and passing it one
would be a TypeError. Inspecting the signature keeps that a property of each
binder instead of a second table to keep in sync.

Two pieces of copy that became false the moment this landed are fixed: the
module docstring claiming triage "correctly never becomes a command", and the
/graphs listing saying the same. The distinction that survives is the real one
— triage is a router that ALSO runs itself; the others only run when asked —
and a test pins that the old phrasing cannot return.

395 deterministic tests pass, ruff clean. Verified live through the chat path:
both doors, correct reasons, and a bare /triage explains itself instead of
routing an empty string.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
