### PR TITLE
fix: show the workflow that is running, and light nodes while they work

### DIFF
--- a/waku/ops/commands.py
+++ b/waku/ops/commands.py
@@ -114,7 +114,13 @@ def run(name: str, emit, arg: str = "") -> dict | None:
     fn = getattr(importlib.import_module(module_name), fn_name)
     if "message" in inspect.signature(fn).parameters:
         return fn(observer=emit, message=arg)
-    return fn(observer=emit)
+    state = fn(observer=emit)
+    if arg and isinstance(state, dict):
+        # Silently swallowing input is worse than not accepting it: `/gather
+        # what's up with the repo` looked like it had been understood, and the
+        # digest that came back was the same one it always produces.
+        state["ignored_argument"] = arg
+    return state
 
 
 def unknown_reply(name: str) -> str:

--- a/waku/ops/dashboard.py
+++ b/waku/ops/dashboard.py
@@ -187,6 +187,10 @@ def _run_command(command: tuple[str, str], emit) -> None:
                       "iterations": 0, "latency_ms": 0, "gate": None})
         return
     reply = state.get("digest") or "(the workflow produced no text)"
+    if state.get("ignored_argument"):
+        reply = (f"*`/{name}` takes no input, so \u201c{state['ignored_argument']}\u201d "
+                 f"was not used — a fixed shape always fetches the same sources. "
+                 f"Ask a normal question to use the loop instead.*\n\n") + reply
     if state.get("draft_path"):
         reply += f"\n\n*saved to `{state['draft_path']}`*"
     for node, err in (state.get("errors") or {}).items():

--- a/waku/ops/static/js/graph.js
+++ b/waku/ops/static/js/graph.js
@@ -75,6 +75,13 @@ function graphSVG(wf, opts = {}){
   </svg></div>`;
 }
 
+// Which workflow is running RIGHT NOW, set by graph_start and cleared by
+// graph_end. The Overview panel used to read the last COMPLETED run, so during
+// a gather it still showed triage — and since animateGraphStage only lights a
+// chart that is on screen, nothing lit up either. One wrong chart caused both
+// bugs: you saw the old shape, and you saw it stay dark.
+let GRAPH_LIVE = null;
+
 // --- the compact Overview panel: the harness auto-decides, this reflects it.
 function graphPanel(d){
   const g = d.graph || {enabled: false, workflows: [], runs: [], stats: {quick: 0, full: 0}};
@@ -83,8 +90,11 @@ function graphPanel(d){
   // most recently RAN, from the trace. Pinning it to workflows[0] meant Overview
   // showed triage forever, seconds after a gather, which is why the panel read
   // as leftovers rather than as news.
+  // A run in flight wins over the last finished one — during a gather you want
+  // to watch the gather, not read about the triage that came before it.
+  const showing = GRAPH_LIVE || ((g.runs || [])[0] || {}).workflow;
   const last = (g.runs || [])[0];
-  const wf = (g.workflows || []).find(w => w && w.name === (last || {}).workflow)
+  const wf = (g.workflows || []).find(w => w && w.name === showing)
              || (g.workflows || [])[0];
   const tot = g.stats.quick + g.stats.full;
   const seg = (cls, n, label, pct) =>
@@ -105,7 +115,9 @@ function graphPanel(d){
       <a class="reveal" onclick="location.hash='settings'">Settings</a> to triage each message first.
       Workflows you run yourself, like <code>make gather</code>, do not need the flag —
       <a class="reveal" onclick="location.hash='graph'">see them here</a>.</div></div>`;
-  const when = last
+  const when = GRAPH_LIVE
+    ? `<span class="live-dot"></span><b>${esc(GRAPH_LIVE)}</b> running now`
+    : last
     ? `last run: <b>${esc(last.workflow || "")}</b>${last.ms ? ` · ${(last.ms/1000).toFixed(1)}s` : ""}${
         last.steps ? ` · ${last.steps} nodes` : ""}`
     : "live — nodes light up as a turn flows through";
@@ -124,15 +136,44 @@ function animateGraphStage(ev){
   // Every graph event carries `workflow`, so the ids can be scoped to the chart
   // that is actually running instead of lighting every chart on the page.
   const w = ev.workflow || "";
-  if (ev.type === "graph_start"){ status(`${w} starts`); hot(`[data-node="g-${w}-START"]`, "hot", 1000); }
-  else if (ev.type === "node_start") status(`${w} · ${ev.node}`);
-  else if (ev.type === "node_end") hot(`[data-node="g-${w}-${ev.node}"]`, "hot", 1000);
+  if (ev.type === "graph_start"){
+    // Swap the Overview chart to this workflow before anything runs, so the
+    // nodes about to light up are the ones on screen.
+    graphLive(w);
+    status(`${w} starts`);
+    hot(`[data-node="g-${w}-START"]`, "hot", 1000);
+  }
+  else if (ev.type === "node_start"){
+    status(`${w} · ${ev.node}`);
+    // Held, not pulsed: a node is lit for as long as it is WORKING. Pulsing on
+    // node_end only ever showed you what had already finished, which is the
+    // opposite of watching it happen — and with four nodes in one wave it is
+    // the difference between seeing a fan-out and seeing four blinks.
+    document.querySelectorAll(`[data-node="g-${w}-${ev.node}"]`)
+      .forEach(el => el.classList.add("hot"));
+  }
+  else if (ev.type === "node_end"){
+    document.querySelectorAll(`[data-node="g-${w}-${ev.node}"]`)
+      .forEach(el => el.classList.remove("hot"));
+    hot(`[data-node="g-${w}-${ev.node}"]`, "done", 900);
+  }
   else if (ev.type === "route"){
     status(`route → ${ev.target}`);
     hot(`[data-edge="g-${w}-${ev.router}-${ev.target}"]`, "live", 1400);
     hot(`[data-node="g-${w}-${ev.target}"]`, "hot", 1400);
   }
-  else if (ev.type === "graph_end") hot(`[data-node="g-${w}-END"]`, "hot", 1000);
+  else if (ev.type === "graph_end"){
+    hot(`[data-node="g-${w}-END"]`, "hot", 1000);
+    graphLive(null);
+  }
+}
+
+// Setting the live workflow re-renders, so the panel swaps the moment a run
+// starts rather than at the next poll.
+function graphLive(name){
+  if (GRAPH_LIVE === name) return;
+  GRAPH_LIVE = name;
+  if (typeof render === "function") render();
 }
 
 // ---------------------------------------------------------------------------

--- a/waku/ops/static/js/render.js
+++ b/waku/ops/static/js/render.js
@@ -131,6 +131,12 @@ function syncChatLogs(){
 
 // One streamed harness event updates the live card in place.
 function applyStreamEvent(pending, ev){
+  // Graph events arrive here too when a workflow is called from the chat box.
+  // The trace poller animates the chart either way, but it runs every 450ms
+  // and stages play on a 620ms stagger — going straight to graphLive() means
+  // the Overview panel swaps to the running workflow the moment you hit send.
+  if (ev.kind === "graph_start" && typeof graphLive === "function") graphLive(ev.workflow);
+  else if (ev.kind === "graph_end" && typeof graphLive === "function") graphLive(null);
   if (ev.kind === "gate") pending.gate = {decision: ev.decision, reason: ev.reason};
   else if (ev.kind === "route")
     pending.graph = {route: ev.target === "quick_reply" ? "quick" : "full",

--- a/waku/ops/static/style.css
+++ b/waku/ops/static/style.css
@@ -144,6 +144,10 @@
      drop-shadow(var()) is unreliable on SVG, so we light the fill instead. */
   .arch .bx{transition:stroke .15s ease, fill .15s ease, stroke-width .15s ease}
   .arch .node.hot .bx{stroke:var(--accent) !important;stroke-width:2.6;fill:var(--accent-soft) !important}
+  /* A node holds .hot for as long as it is WORKING, then flashes .done. Held
+     rather than pulsed because four nodes in one wave lit together is the
+     thing worth seeing, and a pulse on completion shows the opposite. */
+  .arch .node.done .bx{stroke:var(--good) !important;stroke-width:2.2;fill:var(--good-soft) !important}
   .arch .gate{transition:stroke .15s ease, stroke-width .15s ease}
   .arch .gate.hot{stroke:var(--accent) !important;stroke-width:4}
   .arch .flow.live{stroke:var(--accent) !important;stroke-width:2.6;opacity:1;stroke-dasharray:6 5;


### PR DESCRIPTION
Three bugs from one live report of `/gather what's up with waku agent repo`.
The first two share a cause.

1. THE OVERVIEW PANEL SHOWED THE WRONG CHART DURING A RUN.

It rendered the last COMPLETED workflow, read from graph_end events in the
trace. So for the whole of a gather it still showed triage, and only switched
once the gather had finished — exactly backwards for a panel whose job is to
say what is happening.

2. NOTHING LIT UP.

Which follows directly: animateGraphStage only lights a chart that is on
screen, and the chart on screen was the wrong one. One wrong chart caused both
symptoms — you watched the old shape, and you watched it stay dark.

GRAPH_LIVE now tracks the workflow in flight, set on graph_start and cleared on
graph_end, and the panel prefers it over the last finished run. Setting it
re-renders, so the chart swaps as the run begins rather than at the next poll.
The SSE path sets it too: a workflow called from the chat box would otherwise
wait out the 450ms trace poll plus the 620ms stage stagger before the panel
caught up.

3. NODES ONLY FLASHED WHEN THEY FINISHED.

node_end pulsed .hot for a second; node_start did nothing but set a status
line. So the animation showed you what had ALREADY completed, which is the
opposite of watching work happen — and with four nodes in one wave it is the
difference between seeing a fan-out and seeing four unrelated blinks.

A node now HOLDS .hot from node_start until node_end, then flashes a green
.done. Four boxes lit at once for two seconds is the fan-out, visible.

Also: `/gather <anything>` silently discarded the argument. Worse than not
accepting it — the digest that came back was the same one gather always
produces, so it looked understood. A runner that takes no input now says so
and explains why: a fixed shape always fetches the same sources, and a question
belongs to the loop.

395 deterministic tests pass, ruff clean, all three changed JS files parse.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
