### PR TITLE
fix: stop the chart flicking back, and show graph nodes in the chat card

### DIFF
--- a/waku/ops/static/js/graph.js
+++ b/waku/ops/static/js/graph.js
@@ -81,6 +81,13 @@ function graphSVG(wf, opts = {}){
 // chart that is on screen, nothing lit up either. One wrong chart caused both
 // bugs: you saw the old shape, and you saw it stay dark.
 let GRAPH_LIVE = null;
+// The workflow to keep showing once a run ENDS. Without it the panel fell back
+// to d.graph.runs[0] the instant graph_end fired — and that payload is only
+// refreshed by the /api/data poll, so for one beat it still named the PREVIOUS
+// run. Observed as: swap to gather, flick back to triage, then back to gather
+// when the poll caught up. Remembering locally means the panel never shows a
+// workflow older than the one it just watched.
+let GRAPH_SHOWN = null;
 
 // --- the compact Overview panel: the harness auto-decides, this reflects it.
 function graphPanel(d){
@@ -92,7 +99,7 @@ function graphPanel(d){
   // as leftovers rather than as news.
   // A run in flight wins over the last finished one — during a gather you want
   // to watch the gather, not read about the triage that came before it.
-  const showing = GRAPH_LIVE || ((g.runs || [])[0] || {}).workflow;
+  const showing = GRAPH_LIVE || GRAPH_SHOWN || ((g.runs || [])[0] || {}).workflow;
   const last = (g.runs || [])[0];
   const wf = (g.workflows || []).find(w => w && w.name === showing)
              || (g.workflows || [])[0];
@@ -172,6 +179,7 @@ function animateGraphStage(ev){
 // starts rather than at the next poll.
 function graphLive(name){
   if (GRAPH_LIVE === name) return;
+  if (name) GRAPH_SHOWN = name;   // sticky: outlives the run, so no flick-back
   GRAPH_LIVE = name;
   if (typeof render === "function") render();
 }

--- a/waku/ops/static/js/render.js
+++ b/waku/ops/static/js/render.js
@@ -86,6 +86,7 @@ const teleFooter = t => `<div class="meta tele">${secs(t.latency_ms)} · ${t.ite
 const chatTurnCard = t => `<div class="card">
   ${(t.gate||t.graph)?`${stagesRow(t, false)}
     <div class="meta tele" style="margin:0 0 6px">${esc((t.gate&&t.gate.reason)||(t.graph&&t.graph.reason)||"")}</div>`:""}
+  ${nodesRow(t)}
   ${(t.tools||[]).length?`<div class="tele">${(t.tools||[]).map(toolRow).join("")}</div>`:""}
   <div class="r" style="margin-top:8px">${renderMarkdown(t.reply)}</div>
   ${teleFooter(t)}
@@ -93,8 +94,22 @@ const chatTurnCard = t => `<div class="card">
 
 // While a turn runs we stream it live: stages light up as the harness reaches
 // them, and the reply text appears token by token (with a blinking caret).
+// Graph nodes as chips: lit while running, with their measured time once done.
+// Several lit at once IS the fan-out, which no amount of "thinking…" conveys.
+const nodesRow = m => {
+  const names = Object.keys(m.nodes || {});
+  if (!names.length) return "";
+  return `<div class="cmp-stats" style="margin:0 0 6px">` + names.map(n => {
+    const s = m.nodes[n];
+    const cls = s.status === "running" ? "chip live" : s.status === "error" ? "chip err" : "chip";
+    const suffix = s.status === "running" ? "" : s.ms != null ? ` ${s.ms}ms` : "";
+    return `<span class="${cls}">${esc(n)}${suffix}</span>`;
+  }).join("") + `</div>`;
+};
+
 const streamingCard = m => `<div class="card">
   ${stagesRow(m, true)}
+  ${nodesRow(m)}
   ${m.gate&&m.gate.reason?`<div class="meta" style="margin:0 0 6px">${esc(m.gate.reason)}</div>`:""}
   ${(m.tools||[]).map(toolRow).join("")}
   ${m.stream
@@ -137,6 +152,16 @@ function applyStreamEvent(pending, ev){
   // the Overview panel swaps to the running workflow the moment you hit send.
   if (ev.kind === "graph_start" && typeof graphLive === "function") graphLive(ev.workflow);
   else if (ev.kind === "graph_end" && typeof graphLive === "function") graphLive(null);
+  // Graph nodes are not ToolRegistry tools, so none of them ever reached the
+  // tool chips — a /gather ran for thirteen seconds showing nothing but
+  // "thinking…". Track them separately and render them the same way, because
+  // "which four things are happening right now" is the entire point of a wave.
+  if (ev.kind === "node_start"){
+    (pending.nodes = pending.nodes || {})[ev.node] = {status: "running"};
+  } else if (ev.kind === "node_end"){
+    (pending.nodes = pending.nodes || {})[ev.node] =
+      {status: ev.error ? "error" : "done", ms: ev.ms};
+  }
   if (ev.kind === "gate") pending.gate = {decision: ev.decision, reason: ev.reason};
   else if (ev.kind === "route")
     pending.graph = {route: ev.target === "quick_reply" ? "quick" : "full",

--- a/waku/ops/static/style.css
+++ b/waku/ops/static/style.css
@@ -337,6 +337,11 @@
   .cmp-stats{display:flex;flex-wrap:wrap;gap:5px;align-items:center}
   .chip{font-size:11px;color:var(--ink2);border:1px solid var(--line2);border-radius:99px;padding:1px 8px}
   .chip.money{color:var(--good);border-color:var(--good)}
+  /* A graph node's chip while it WORKS, and after. Several .live at once is
+     the fan-out made visible in the chat card — the pending state used to say
+     only "thinking…" for the whole thirteen seconds of a gather. */
+  .chip.live{color:var(--accent);border-color:var(--accent);background:var(--accent-soft)}
+  .chip.err{color:var(--bad);border-color:var(--bad)}
   .chip.sorted{color:var(--accent);border-color:var(--accent);background:var(--accent-soft);font-weight:600}
   .cmp-reply{margin-top:2px;font-size:13px;max-height:340px;overflow-y:auto}
   .cmp-race{padding:5px 14px;font-size:12.5px}


### PR DESCRIPTION
Two more from the same live /gather.

1. THE CHART FLICKED BACK TO TRIAGE, THEN FORWARD AGAIN.

Reported exactly: swaps to gather immediately, drops back to triage once the
digest lands, then returns to gather a moment later.

graph_end cleared GRAPH_LIVE, and the panel then fell back to
d.graph.runs[0] — which comes from /api/data and is only refreshed on the
poll. For one beat that payload still named the PREVIOUS run. So the panel
correctly showed gather, then honestly reported stale state, then corrected
itself. Three truthful frames, one wrong impression.

GRAPH_SHOWN now remembers the last workflow this browser actually watched, and
the panel prefers it over the server's list. The panel can no longer display a
workflow older than the one it just animated.

2. NO CHIPS DURING A GATHER — THIRTEEN SECONDS OF "THINKING...".

Graph nodes are not ToolRegistry tools. The chat card only ever rendered
pending.tools, populated from `tool` events, and a graph emits node_start /
node_end instead. Nothing was broken; the card simply had no idea those events
existed. So the one moment worth watching — four sources being fetched at once
— was the moment the UI had least to say.

Nodes are now tracked separately and rendered as chips: lit while running, with
their measured duration once done. Several lit at once IS the fan-out, and it
appears in the chat rather than only on the Graph tab, so /gather from the
message box shows its work.

Verified by replaying a real wave through the actual render code rather than by
eye: four chips live mid-wave, then one still live while three carry 1506ms /
2ms / 1ms, then one live again for synthesize in the next wave.

395 deterministic tests pass, ruff clean, both changed JS files parse.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
