### PR TITLE
docs: a whiteboard belongs here only if it explains waku

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,9 +91,30 @@ Concretely, these get declined **even when the code is good**:
   time.** waku runs on people's own machines with their own keys.
 - **A "fix" that removes the thing it secures** — e.g. sandboxing a tool by
   making it not work.
+- **A rename.** The name is tied to the videos, the PyPI package and the
+  assistant's own identity. Fork it and rename freely — MIT only asks that you
+  keep the attribution line.
+- **A whiteboard that isn't about this codebase.** See below.
 
 None of this is about the quality of your code. It's about what everyone who
 installs waku has to carry.
+
+### Whiteboards: only the ones that explain waku
+
+`docs/whiteboards/` holds editable `.excalidraw` sources, and the bar for a new
+one is simple:
+
+> **A whiteboard belongs here if it explains THIS codebase. Everything else is
+> video production and stays on the maintainer's machine.**
+
+The reason is that the folder had drifted: five of its six charts were about
+*other* projects — Kimi K3, pi, Claude Code — and made up 1.8 MB of a 2 MB
+directory. Someone forking waku to build their own agent has no use for a chart
+about a model they aren't running, and the repo shouldn't ask them to clone it.
+
+Charts that explain waku's own architecture, its loop, or its graph engine are
+welcome and genuinely useful. Charts drawn for a video about something else are
+not part of the software.
 
 ## What you can expect from us
 


### PR DESCRIPTION
docs/whiteboards/ had drifted. Five of its six charts were about OTHER
projects — Kimi K3, pi, pi vs Claude Code — and they were 1.8 MB of a 2 MB
directory. Only waku-architecture.excalidraw is about the software people are
cloning.

Someone forking waku to build their own agent has no use for a chart about a
model they are not running, and the repo should not ask them to download it.
The existing charts stay; the rule applies from here.

Also adds a rename to the declined list. It came up as a real 180-file PR, and
the reason is worth stating once rather than in each reply: the name is tied to
the videos, the PyPI package and the assistant's own identity. Forking and
renaming is entirely fair — that is what MIT is for.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
