### PR TITLE
fix: escape quotes in esc(), so model output cannot break out of an attribute

### DIFF
--- a/evals/deterministic/test_html_escaping.py
+++ b/evals/deterministic/test_html_escaping.py
@@ -1,0 +1,80 @@
+"""DETERMINISTIC EVAL — esc() must survive being used in an HTML attribute.
+
+`esc()` escaped `&`, `<` and `>` and nothing else. For text nodes that is
+enough, and for a long time nothing put model output inside an ATTRIBUTE, so
+the gap could not bite.
+
+The copy buttons added in #58 are the first place it happens:
+
+    <button class="msg-copy" data-text="${esc(t.reply)}">
+
+A reply containing one double quote closes that attribute and everything after
+it becomes markup. Measured before the fix:
+
+    data-text="hi" onmouseover="alert(1)" x=""
+
+That is a real path, not a theoretical one. The model's output is not entirely
+ours — `search_web` and `browse_web` pull text off the open web and the model
+can echo it — and this dashboard holds the memory, the traces and the settings.
+
+CI has no browser, so this asserts on the escaper itself rather than on
+rendering. That is the right level anyway: the fix belongs in the helper, so
+every future caller inherits it instead of having to remember.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+JS = Path(__file__).resolve().parents[2] / "waku/ops/static/js/util.js"
+
+
+def _esc_source() -> str:
+    src = JS.read_text(encoding="utf-8")
+    m = re.search(r"^const esc = .*?;$", src, re.MULTILINE | re.DOTALL)
+    assert m, "esc() not found in util.js"
+    return m.group(0)
+
+
+def test_esc_escapes_both_quote_characters():
+    """THE regression. Without these two, any model reply containing a quote can
+    break out of an attribute and attach its own event handler."""
+    src = _esc_source()
+    for ch, entity in (('"', "&quot;"), ("'", "&#39;")):
+        assert entity in src, (
+            f"esc() no longer escapes {ch!r} — a reply containing it can escape "
+            "an HTML attribute. See waku/ops/static/js/render.js's copy buttons."
+        )
+
+
+def test_esc_still_escapes_the_original_three():
+    src = _esc_source()
+    for entity in ("&amp;", "&lt;", "&gt;"):
+        assert entity in src
+
+
+def test_the_character_class_covers_everything_it_maps():
+    """A map entry with no matching character in the regex is a silent no-op —
+    the code reads as if it escapes the character and does not."""
+    src = _esc_source()
+    cls = re.search(r"replace\(/\[([^\]]+)\]/g", src)
+    assert cls, f"could not read esc()'s character class from: {src}"
+    chars = cls.group(1).replace("\\", "")
+    for ch in ("&", "<", ">", '"', "'"):
+        assert ch in chars, f"{ch!r} is mapped but not matched by the regex"
+
+
+def test_model_output_in_an_attribute_is_escaped_at_the_helper():
+    """The copy buttons put a whole reply into data-text=. Pin that the file
+    doing it relies on esc() rather than hand-rolling its own escaping, so this
+    test keeps covering it."""
+    render = (JS.parent / "render.js").read_text(encoding="utf-8")
+    for attr in ('data-text="${esc(', 'data-text="${esc('):
+        if attr in render:
+            return
+    raise AssertionError(
+        "the copy buttons no longer pass their text through esc() — either they "
+        "were removed, or something is escaping by hand and this test has "
+        "stopped protecting it"
+    )

--- a/waku/ops/static/js/util.js
+++ b/waku/ops/static/js/util.js
@@ -2,7 +2,15 @@
 // Split out of app.js: classic <script>, shared global scope (no build
 // step, no modules). Load order + rules: static/README.md.
 
-const esc = s => (s??"").toString().replace(/[&<>]/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;"}[c]));
+// Escapes quotes too, not just &<>. Text nodes never needed it, and for a long
+// time nothing put model output inside an ATTRIBUTE — so the gap was invisible.
+// The copy buttons (#58) are the first place that happens, and a reply
+// containing one double quote was enough to close data-text="..." and attach
+// its own event handler. The model's output is not fully ours: search_web and
+// browse_web pull text off the open web, and this dashboard holds the memory,
+// the traces and the settings. Escape at the helper, once, for every caller.
+const esc = s => (s??"").toString().replace(/[&<>"']/g,
+  c => ({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[c]));
 
 // --- tiny markdown renderer for chat replies (no dependency, XSS-safe: we
 // escape first, then apply a small set of transforms the LLM actually uses:


### PR DESCRIPTION
Follow-up to #58, which is good work and is why this was found.

esc() escaped &, < and > and nothing else. For text nodes that is enough, and
for a long time nothing put model output inside an ATTRIBUTE, so the gap could
not bite. The copy buttons are the first place it happens:

    <button class="msg-copy" data-text="${esc(t.reply)}">

One double quote in a reply closes that attribute and the rest becomes markup.
Measured on the branch before the fix:

    data-text="hi" onmouseover="alert(1)" x=""

Not theoretical. The model's output is not entirely ours — search_web and
browse_web pull text off the open web and the model can echo it back — and this
dashboard holds the memory, the traces and the settings.

The fenced code blocks in the same PR are safe, for the record: renderMarkdown
calls esc() on the whole reply before parsing, so a <script> inside a fence came
out as &lt;script&gt;. Only the attribute was exposed.

Fixed at the helper rather than at the two call sites, so every future caller
inherits it instead of having to remember. Tests assert on esc() itself — CI has
no browser, and the helper is the right level anyway — including that every
character the map escapes is actually matched by the regex, since a map entry
with no matching character reads as protection and is a no-op.

411 deterministic tests pass, ruff clean, util.js parses.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
