### PR TITLE
release: 0.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "waku-agent"
-version = "0.1.1"
+version = "0.1.3"
 description = "A minimal, transparent, local-first Waku: harness + loop + memory + eval, in code you can read in an afternoon."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Cut from main after the work landed, not alongside it — the rule 0.1.1 taught
us when its tag ended up pointing two commits behind the dashboard changes it
was supposed to ship.

Fifteen commits since 0.1.1. The ones that matter to someone who installed
from PyPI:

  * an installed waku never read the user's .env. load_dotenv() searched from
    waku's own location instead of the user's, so every pip install ignored
    every .env its owner wrote, and said "No API key" while standing in a
    folder that had one. Invisible in a git checkout, broken everywhere else.
  * esc() did not escape quotes, so model output placed in an HTML attribute
    could close it and attach an event handler. The dashboard holds the memory
    and the settings, and search_web pulls text off the open web.
  * Google Calendar gained bundled-OAuth-client support, so connecting will not
    require building your own Google Cloud project (the client itself is still
    a placeholder).
  * graph workflows can be called by name from the chat box — /gather, /triage
    <message>, /graphs — and any workflow with a binder registers itself.
  * the dashboard renders fenced code blocks with copy buttons, shows which
    workflow is actually running, and lights nodes while they work rather than
    after they finish.

411 deterministic tests pass, ruff clean.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
