### PR TITLE
feat: add LiteLLM proxy as a provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # ── Provider ────────────────────────────────────────────────────────────────
 # Pick ONE provider and paste its key below. That's the whole setup.
-#   anthropic (default) · openai · gemini · deepseek · minimax · kimi · glm · openrouter · opencode_zen · opencode_go
+#   anthropic (default) · openai · gemini · deepseek · minimax · kimi · glm · openrouter · opencode_zen · opencode_go · litellm
 # No paid key? openrouter's default models are $0 ":free" ids (rate-limited).
 WAKU_PROVIDER=anthropic
 
@@ -28,6 +28,9 @@ XAI_API_KEY=
 OPENCODE_ZEN_API_KEY=
 # opencode go → https://opencode.ai/zen/go/v1
 OPENCODE_GO_API_KEY=
+# litellm (self-hosted proxy, one endpoint for 100+ providers) → https://docs.litellm.ai/docs/simple_proxy
+# set WAKU_MODEL to a model your proxy serves; WAKU_BASE_URL overrides the default http://localhost:4000/v1
+LITELLM_API_KEY=
 
 # ── Models (optional) ───────────────────────────────────────────────────────
 # Each provider has sensible defaults (see waku/loop/models.py PROVIDERS):

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ laptop. Set `TELEGRAM_BOT_TOKEN` and it starts your bot too. (`make dashboard` w
 file: `.waku/state.db`.
 
 **Use the model you already pay for.** Anthropic (default), OpenAI, Gemini, DeepSeek, MiniMax,
-Kimi, GLM, OpenRouter (one key, hundreds of hosted models), OpenCode Zen, or OpenCode Go —
+Kimi, GLM, OpenRouter (one key, hundreds of hosted models), OpenCode Zen, OpenCode Go, or a
+self-hosted LiteLLM proxy (one endpoint in front of 100+ providers) —
 set `WAKU_PROVIDER=`, paste the key, done. One dialect in the loop;
 a [~60-line adapter](waku/loop/models.py) handles the rest.
 

--- a/waku/loop/models.py
+++ b/waku/loop/models.py
@@ -4,10 +4,12 @@ The loop speaks one dialect: Anthropic's Messages shape (system/messages/tools
 in, content blocks out). Providers plug in two ways:
 
   anthropic wire format (native)     → Anthropic, Kimi/Moonshot, GLM/Z.ai, MiniMax
-  openai wire format (thin adapter)  → OpenAI, Google Gemini, DeepSeek, OpenRouter
+  openai wire format (thin adapter)  → OpenAI, Google Gemini, DeepSeek, OpenRouter, LiteLLM
 
-Pick with WAKU_PROVIDER=anthropic|openai|gemini|deepseek|minimax|kimi|glm|openrouter
-and set that provider's API key in .env. Override the model ids with WAKU_MODEL /
+Pick with WAKU_PROVIDER=anthropic|openai|gemini|deepseek|minimax|kimi|glm|openrouter|litellm
+and set that provider's API key in .env. litellm points at a self-hosted LiteLLM
+proxy (one OpenAI-compatible endpoint fronting 100+ providers); set WAKU_MODEL to a
+model your proxy serves. Override the model ids with WAKU_MODEL /
 WAKU_SMALL_MODEL if the defaults below age out — they're just strings. This
 matters most for openrouter: it's a single key in front of hundreds of models,
 so WAKU_MODEL=<vendor>/<model> (e.g. "google/gemini-3.5-flash") picks whichever
@@ -106,6 +108,14 @@ PROVIDERS: dict[str, Provider] = {
     "opencode_go":  Provider("openai", "OPENCODE_GO_API_KEY",
                                "https://opencode.ai/zen/go/v1",
                                "deepseek-v4-flash", "deepseek-v4-flash"),
+    # LiteLLM proxy — one OpenAI-compatible endpoint in front of 100+ providers
+    # (OpenAI, Anthropic, Bedrock, Vertex, Azure, Gemini, Groq, ...). base_url is
+    # your self-hosted proxy (default port 4000); LITELLM_API_KEY is the proxy's
+    # virtual/master key. Model ids are whatever your proxy config names them, so
+    # the defaults below are just starting points — set WAKU_MODEL to a model on
+    # your proxy, and the Settings picker lists its live catalog ({base_url}/models).
+    "litellm":   Provider("openai", "LITELLM_API_KEY", "http://localhost:4000/v1",
+                          "gpt-4o", "gpt-4o-mini"),
 }
 
 
@@ -125,6 +135,7 @@ KEY_URLS = {
     "xai": "https://console.x.ai",
     "opencode_zen": "https://opencode.ai/zen",
     "opencode_go": "https://opencode.ai/zen",
+    "litellm": "https://docs.litellm.ai/docs/proxy/virtual_keys",
 }
 
 

--- a/waku/ops/pricing.py
+++ b/waku/ops/pricing.py
@@ -37,6 +37,10 @@ PRICING = {
     # (rough mid-catalog guess). ":free" ids and catalog-priced models never
     # hit this: see price_for().
     "openrouter": (1.0, 3.0),
+    # litellm proxy fronts many providers, so the real rate depends on the routed
+    # model; this is only a rough fallback when neither the proxy catalog nor a
+    # MODEL_PRICING id resolves.
+    "litellm": (1.0, 3.0),
 }
 
 # model id -> exact ($/M in, $/M out), filled from the live catalog fetch in


### PR DESCRIPTION
**What this does, and why**

One openai-wire `PROVIDERS` row (base_url `http://localhost:4000/v1`, `LITELLM_API_KEY`) so a self-hosted LiteLLM proxy fronting 100+ providers works with the existing OpenAI-compatible adapter and `{base_url}/models` picker. Survives the deterministic provider suite (43 provider checks, 417 total) and a live turn through a real proxy.

**Which issue does it close?** No related issue.

---

- [x] **Tested it, not just written it.** See below.
- [x] **A deterministic eval** in `evals/deterministic/` covers the behavior. `test_providers.py` is parametrized over every `PROVIDERS` entry, so it now covers `litellm`: right wire client, default model ids filled, exits with the key name when the key is missing, and present in the dashboard `PRICING` fallback.
- [x] `make gate` and `make lint` pass locally.
- [x] Any heavy or optional dependency is **behind an extra**, not in the default install. (No new dependency; reuses the `openai` SDK already in core.)
- [x] No hidden network calls, no reading secrets or `.env`, nothing runs at install time. (Just a `PROVIDERS` row plus `KEY_URLS` / `PRICING` entries.)

**How you tested it** — commands, and what you saw:

```
$ .venv/bin/python -m pytest -q evals/deterministic/test_providers.py
43 passed

$ make gate
=== deterministic ===
417 passed, 11 skipped
(judge suite skipped: no API key)
GATE OPEN — safe to release.

$ make lint
All checks passed!

# Live turn through a real LiteLLM proxy (get_client -> OpenAICompatClient ->
# LiteLLM proxy -> a non-Anthropic model), no tools:
litellm in PROVIDERS: True
provider: openai LITELLM_API_KEY http://localhost:4000/v1 | default model: gpt-4o
client type: OpenAICompatClient
response text: '4'
stop_reason: end_turn
usage: in=19 out=5
```
