### PR TITLE
release: 0.1.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "waku-agent"
-version = "0.1.3"
+version = "0.1.4"
 description = "A minimal, transparent, local-first Waku: harness + loop + memory + eval, in code you can read in an afternoon."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
PyPI has been on 0.1.1 since 2026-07-31. 0.1.2 and 0.1.3 were tagged and built
and never uploaded, so 23 merged commits — including two bugs that silently
corrupt memory — have not reached anyone installing with pip. This bump draws
the line under them and is cut last, from the branch being published.

What an installing user has been missing:

MEMORY WAS SILENTLY WRONG FOR NON-ASCII USERS (#79). The FTS query builder used
[a-zA-Z0-9] against a unicode61 index. "Müller" became `ller` and matched
nothing; Cyrillic, Greek, Arabic, Hebrew and CJK reduced to "" — and an empty
query is not a no-op, because SqliteEpisodeStore.search() reads it as "give me
the recent ones". A Russian user asking about Сергей got an unrelated English
episode handed to the model under the heading "Relevant memory". Not missing
memory: confidently wrong memory.

MEMORY STOPPED GROWING ON REASONING MODELS (#74). Consolidation asked for 600
output tokens. A reasoning model spends a thinking block first, and that prompt
carries the whole unconsolidated log, so on a real backlog it returned zero text
blocks. The parse error was swallowed by a broad except and the log stayed
unconsolidated — identically, every turn, with nothing in the traces because
notify() only fires when facts are written.

Also in this release: the Connections registry and the Models/Connections pages
(#72), so integrations are configured in the browser instead of by hand-editing
.env; graph workflows callable by name (#60, #61); the live wave view (#50, #51,
#62, #63); an attribute-escaping fix in the dashboard (#69); .env discovery from
the working directory rather than site-packages (#56); and a guard that refuses
to publish a skill that is not tracked in git (#71).

Verified before tagging: 507 deterministic tests pass, ruff clean, twine check
passes on both artifacts, and the wheel installs into a clean venv OUTSIDE this
repo where `waku --help` runs, bundled_skill_dirs() resolves to site-packages
and finds all three skills, and _fts_query("Сергей") returns 'сергей' rather
than the empty string that caused the bug above.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
