### PR TITLE
fix: a FactStore contract, so a backend can't silently answer wrong (#83)

### DIFF
--- a/evals/deterministic/test_fact_store_conformance.py
+++ b/evals/deterministic/test_fact_store_conformance.py
@@ -1,0 +1,153 @@
+"""DETERMINISTIC EVAL — every semantic-memory backend, held to the same contract.
+
+This suite exists because the contract was never written down, so the second
+backend silently didn't meet it. `SqliteFactStore` had six methods,
+`SupabaseFactStore` had two, and `WAKU_SEMANTIC_STORE=supabase` therefore
+broke the dashboard's memory page, the manage_memory tool's update and delete
+— and worst of all made `search_with_ids` return `[]` through a
+`hasattr(...) else []` guard, so the agent told users a fact didn't exist while
+it sat in the database.
+
+So the shape of this file matters more than any single assertion: it is
+parametrized over BACKENDS, and every backend runs every test. Adding a store
+is not "write a class"; it is "write a class that passes this". That is the
+whole point of waku/memory/semantic/base.py.
+
+The first test is the one that would have caught the original bug on the day it
+shipped, and it is one line: `isinstance(store, FactStore)`. A runtime
+checkable Protocol verifies the methods are PRESENT — which is exactly the
+failure we had. It cannot check signatures or behaviour, so the rest of the
+file does that by exercising them.
+
+Offline by default: SQLite in tmp_path, no keys, no network. Supabase joins the
+parametrization only when you opt in explicitly (see `_supabase_store`), because
+its `add()` calls OpenAI for embeddings and costs real money — `make gate` must
+stay green for a contributor with no accounts.
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+
+import pytest
+
+from waku.db import connect
+from waku.memory.semantic.base import FactStore
+from waku.memory.semantic.store import SqliteFactStore
+
+
+def _sqlite_store(tmp_path):
+    return SqliteFactStore(connect(tmp_path))
+
+
+def _supabase_store(tmp_path):
+    """Opt-in only. Needs a Supabase project AND an OpenAI key (embeddings are
+    billed per call), so it is gated on an explicit env var rather than on the
+    credentials happening to be present — a maintainer with a populated .env
+    should not start paying for embeddings by running the test suite."""
+    if os.getenv("WAKU_TEST_SUPABASE") != "1":
+        pytest.skip("set WAKU_TEST_SUPABASE=1 (plus SUPABASE_* and OPENAI_API_KEY) to include it")
+    from waku.config import Settings
+    from waku.memory.semantic.supabase_store import SupabaseFactStore
+
+    return SupabaseFactStore(Settings(home=tmp_path))
+
+
+BACKENDS = {"sqlite": _sqlite_store, "supabase": _supabase_store}
+
+
+@pytest.fixture(params=list(BACKENDS), ids=list(BACKENDS))
+def store(request, tmp_path):
+    return BACKENDS[request.param](tmp_path)
+
+
+def test_the_backend_declares_every_method_the_contract_requires(store):
+    """THE regression. `SupabaseFactStore` shipped missing four of the six and
+    nothing anywhere noticed until a user switched backends."""
+    assert isinstance(store, FactStore), (
+        f"{type(store).__name__} does not satisfy the FactStore protocol — missing: "
+        + ", ".join(m for m in _protocol_methods() if not hasattr(store, m))
+    )
+
+
+def test_add_then_search_round_trips(store):
+    store.add("jensen", "Jensen always wears a leather jacket")
+    assert any("leather jacket" in hit for hit in store.search("jensen leather jacket"))
+
+
+def test_a_miss_returns_empty_rather_than_raising(store):
+    """A memory backend that throws takes the whole turn down with it."""
+    assert store.search("nothing here matches this at all") == []
+
+
+def test_search_with_ids_returns_ids_that_update_accepts(store):
+    """The lookup step of every correction. When this returns [] on failure
+    instead of raising, the agent reports the memory does not exist — which is
+    precisely what the `hasattr` guard in manage_memory used to cause."""
+    store.add("elon", "The launch is in March")
+    rows = store.search_with_ids("elon launch")
+    assert rows, "search_with_ids found nothing it just stored"
+    assert "id" in rows[0] and "content" in rows[0]
+    assert store.update(rows[0]["id"], "The launch is in June") is True
+
+
+def test_update_changes_what_search_returns(store):
+    store.add("elon", "The launch is in March")
+    rid = store.search_with_ids("elon launch")[0]["id"]
+    store.update(rid, "The launch is in June")
+    assert any("June" in hit for hit in store.search("elon launch"))
+
+
+def test_delete_removes_the_fact(store):
+    store.add("tom", "Tom Holland cannot keep a secret")
+    rid = store.search_with_ids("tom holland secret")[0]["id"]
+    assert store.delete(rid) is True
+    assert not any("secret" in hit for hit in store.search("tom holland secret"))
+
+
+@pytest.mark.parametrize("method", ["update", "delete"])
+def test_an_unknown_id_is_false_not_an_exception(store, method):
+    """False means "no such row". Raising here would turn a stale id in the
+    dashboard into a 500."""
+    assert getattr(store, method)(*( (999_999, "x") if method == "update" else (999_999,) )) is False
+
+
+def test_list_returns_what_was_added(store):
+    store.add("pikachu", "Pikachu is coming to the dinner party")
+    rows = store.list(50)
+    assert any("Pikachu" in r["content"] for r in rows)
+    assert all({"id", "subject", "content"} <= set(r) for r in rows)
+
+
+def test_non_ascii_round_trips_on_every_backend(store):
+    """The 2026-08-05 bug (see test_memory_search.py) was one backend's query
+    builder dropping non-ASCII. Pinning it HERE means a new backend cannot
+    reintroduce it — the failure mode was users silently receiving somebody
+    else's memories, which no amount of English test coverage would catch."""
+    store.add("сергей", "Сергей любит плавать")
+    assert store.search("Сергей") != [], "a Cyrillic fact stored but not findable"
+
+
+# --- the suite keeps itself honest -------------------------------------------
+
+def _protocol_methods() -> list[str]:
+    """The contract's own method names, read off the class.
+
+    NOT `FactStore.__protocol_attrs__` — that is a CPython implementation
+    detail of typing.Protocol, absent on 3.11 and free to change. Reading
+    `vars()` is stable, and it also stays in declaration order, which makes the
+    failure message below read in the same order as base.py."""
+    return [n for n, v in vars(FactStore).items() if callable(v) and not n.startswith("_")]
+
+
+def test_every_method_on_the_contract_is_actually_exercised_here():
+    """A Protocol only helps if the suite grows with it. Add a method to
+    FactStore without testing it and this fails — otherwise the contract
+    silently widens and we are back to trusting that backends implement it,
+    which is the exact assumption that broke."""
+    source = inspect.getsource(inspect.getmodule(test_add_then_search_round_trips))
+    body = source.split("# --- the suite keeps itself honest", 1)[0]
+    untested = [m for m in _protocol_methods() if f"store.{m}(" not in body
+                and f'"{m}"' not in body]
+    assert untested == [], f"FactStore methods with no test in this file: {untested}"

--- a/waku/memory/semantic/base.py
+++ b/waku/memory/semantic/base.py
@@ -1,0 +1,92 @@
+"""The contract every semantic-memory backend has to honour.
+
+Waku is meant to be indifferent to *where* facts live — SQLite on your laptop,
+pgvector in Supabase, a hosted memory API. Everything upstream just says "store
+this" and "find that". That indifference only works if every backend can do the
+same six things, and until this file existed, nothing checked.
+
+It didn't check, so it broke. `SqliteFactStore` implemented six methods;
+`SupabaseFactStore` implemented two. Switching backends then produced three
+different failures, and the first one is the kind Waku keeps shipping:
+
+  * `list()`      → AttributeError, dashboard memory page 500s
+  * `update()`
+    `delete()`    → AttributeError, from both the dashboard and manage_memory
+  * `search_with_ids()` → worse. The call site guarded it with
+    `hasattr(...) else []`, so the agent received an empty list and told the
+    user "no matching facts" — while the facts sat in the database. No error,
+    no trace, no way to notice. A guard around a missing method doesn't prevent
+    a bug; it converts a loud one into a silent lie.
+
+That is the third silent failure in this codebase in two weeks (see
+consolidation.py's max_tokens note and store.py's `_fts_query` docstring for
+the other two). The pattern is always the same shape: a fallback that looks
+defensive and quietly answers wrong. A Protocol is how you stop writing them —
+the conformance suite in evals/deterministic/test_fact_store_conformance.py
+runs against *every* backend, so a store that can't do the job fails in CI
+instead of in front of a user.
+
+Ids are `int | str` on purpose. SQLite rows are integers, but the Supabase
+table is keyed by a `chunk_id` string (`fact-a1b2c3…`) inherited from
+launch-rag, and a hosted API will hand back whatever it likes. The episodic
+side already settled this — `memory_admin.py` coerces by shape — so the
+semantic side matches rather than inventing a second convention.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+# A row id as its backend chose to express it: sqlite counts, Supabase and
+# hosted APIs hand out opaque strings. Never parse it — pass it back verbatim.
+FactId = int | str
+
+
+@runtime_checkable
+class FactStore(Protocol):
+    """Durable facts about the user, their people, projects and preferences.
+
+    Six methods, split by who calls them:
+
+      add / search              — the agent, every turn
+      list / search_with_ids
+      update / delete           — humans in the dashboard, and the agent's
+                                  manage_memory tool when a fact goes stale
+
+    Implementations must never raise on a miss. Return an empty list or False;
+    a memory backend that throws takes the whole turn down with it.
+    """
+
+    def add(self, subject: str, content: str, source: str = "user") -> None:
+        """Store one fact. `subject` is the who/what it is about and is
+        lowercased by convention; `source` records who claimed it ("user",
+        "consolidation") so the dashboard can show provenance."""
+        ...
+
+    def search(self, query: str, top_k: int = 4) -> list[str]:
+        """Facts relevant to `query`, best first, formatted for the prompt as
+        `[subject] content`. Returns [] when nothing matches — and [] must mean
+        "nothing matched", never "I couldn't run the search"."""
+        ...
+
+    def list(self, limit: int = 200) -> list[dict]:
+        """Recent facts, newest first, for the dashboard. Each dict carries at
+        least `id`, `subject` and `content`."""
+        ...
+
+    def search_with_ids(self, query: str, top_k: int = 8) -> list[dict]:
+        """Like `search`, but each dict carries the `id` needed to `update` or
+        `delete` it. This is the lookup step of every correction, which is why
+        returning [] on failure instead of raising is so damaging: the agent
+        reports the memory does not exist and moves on."""
+        ...
+
+    def update(self, fact_id: FactId, content: str, subject: str | None = None) -> bool:
+        """Replace a fact's text. True if a row changed, False if `fact_id` is
+        unknown. `subject=None` leaves the subject alone."""
+        ...
+
+    def delete(self, fact_id: FactId) -> bool:
+        """Forget a fact. True if a row went away, False if `fact_id` is
+        unknown."""
+        ...

--- a/waku/memory/semantic/supabase_store.py
+++ b/waku/memory/semantic/supabase_store.py
@@ -56,3 +56,105 @@ class SupabaseFactStore:
             {"query_embedding": self._embed(query), "match_count": top_k},
         ).execute()
         return [f"[{row['source']}] {row['text']}" for row in (result.data or [])]
+
+    # --- CRUD ----------------------------------------------------------------
+    # These four went missing until 2026-08-08 and nothing noticed, because
+    # nothing described what a fact store owes its callers. See
+    # semantic/base.py: the dashboard's memory page and manage_memory's
+    # update/delete raised AttributeError here, and search_with_ids was worse —
+    # a `hasattr` guard upstream turned it into "no matching facts" while the
+    # facts sat in this table.
+    #
+    # Two schema notes, both inherited from launch-rag and neither obvious:
+    #
+    #   * `source` is the SUBJECT here, not provenance. SqliteFactStore keeps
+    #     them apart (subject="alex", source="consolidation"); rag_chunks has
+    #     one column and add() puts the subject in it. So `list()` below cannot
+    #     report who claimed a fact. The protocol only promises id/subject/
+    #     content, so this is honest rather than broken — but it is why the
+    #     dashboard's provenance column is blank on this backend.
+    #   * ids: rag_chunks has BOTH `id BIGSERIAL` and `chunk_id TEXT`. We expose
+    #     the integer, because dashboard.py does `int(payload["id"])` and would
+    #     reject a string outright. Strings are still accepted on the way back
+    #     in (matched against chunk_id) the same way memory_admin coerces
+    #     Notion's page ids — by shape, not by parsing.
+
+    def _column_for(self, fact_id: int | str) -> str:
+        return "id" if isinstance(fact_id, int) or str(fact_id).isdigit() else "chunk_id"
+
+    def list(self, limit: int = 200) -> list[dict]:
+        rows = (
+            self.supabase.table("rag_chunks")
+            .select("id, source, text, created_at")
+            .order("id", desc=True)
+            .limit(limit)
+            .execute()
+        )
+        return [
+            {"id": r["id"], "subject": r["source"], "content": r["text"],
+             "source": "", "created_at": r.get("created_at")}
+            for r in (rows.data or [])
+        ]
+
+    def search_with_ids(self, query: str, top_k: int = 8) -> list[dict]:
+        """Semantic search that also returns the ids update/delete need.
+
+        match_chunks() returns chunk_id but not id, so this is two round trips:
+        rank first, then resolve. Changing the SQL function would be one trip,
+        but it ships in launch-rag and anyone who followed those videos already
+        has it — silently requiring them to re-run a migration is a worse trade
+        than an extra select on a query that already paid for an embedding."""
+        ranked = self.supabase.rpc(
+            "match_chunks",
+            {"query_embedding": self._embed(query), "match_count": top_k},
+        ).execute()
+        chunk_ids = [r["chunk_id"] for r in (ranked.data or [])]
+        if not chunk_ids:
+            return []
+        rows = (
+            self.supabase.table("rag_chunks")
+            .select("id, chunk_id, source, text")
+            .in_("chunk_id", chunk_ids)
+            .execute()
+        )
+        by_chunk = {r["chunk_id"]: r for r in (rows.data or [])}
+        # re-impose the RPC's similarity order; the `in_` select does not keep it
+        return [
+            {"id": by_chunk[c]["id"], "subject": by_chunk[c]["source"],
+             "content": by_chunk[c]["text"]}
+            for c in chunk_ids
+            if c in by_chunk
+        ]
+
+    def update(self, fact_id: int | str, content: str, subject: str | None = None) -> bool:
+        """Re-embeds. A vector store where update() rewrote the text but left
+        the old embedding would keep answering the old question correctly and
+        the new one not at all — the silent-wrong-answer failure this whole
+        file is a reaction to."""
+        column = self._column_for(fact_id)
+        current = (
+            self.supabase.table("rag_chunks").select("source").eq(column, fact_id).execute()
+        )
+        if not current.data:
+            return False
+        new_subject = (subject or current.data[0]["source"]).lower().strip()
+        result = (
+            self.supabase.table("rag_chunks")
+            .update({
+                "source": new_subject,
+                "text": content,
+                "embedding": self._embed(f"{new_subject}: {content}"),
+            })
+            .eq(column, fact_id)
+            .execute()
+        )
+        return bool(result.data)
+
+    def delete(self, fact_id: int | str) -> bool:
+        result = (
+            self.supabase.table("rag_chunks")
+            .delete()
+            .eq(self._column_for(fact_id), fact_id)
+            .execute()
+        )
+        return bool(result.data)

--- a/waku/tools/memory_admin.py
+++ b/waku/tools/memory_admin.py
@@ -35,7 +35,15 @@ def make_manage_memory_tool(memory) -> Tool:
                 if query:
                     rows = [r for r in rows if query.lower() in r["summary"].lower()]
                 return "\n".join(f"#{r['id']} ({r['happened_at']}) {r['summary']}" for r in rows[:8]) or "no episodes"
-            rows = facts.search_with_ids(query, 8) if hasattr(facts, "search_with_ids") else []
+            # No hasattr guard. It used to read
+            #   facts.search_with_ids(...) if hasattr(...) else []
+            # which looked defensive and was the opposite: on a backend missing
+            # the method, the agent got [] and told the user "no matching
+            # facts" while the facts sat in the database. Every FactStore now
+            # has to declare this method (semantic/base.py) and prove it
+            # (test_fact_store_conformance.py), so a real absence should be a
+            # loud AttributeError, not a confident wrong answer.
+            rows = facts.search_with_ids(query, 8)
             return "\n".join(f"#{r['id']} [{r['subject']}] {r['content']}" for r in rows) or "no matching facts"
         if action == "update":
             if kind != "fact":


### PR DESCRIPTION
Waku is meant to be indifferent to where facts live. That only works if
every backend can do the same six things, and nothing checked — so
SupabaseFactStore shipped with two of them.

With WAKU_SEMANTIC_STORE=supabase, four call sites were broken:
list() 500'd the dashboard memory page; update() and delete() raised
AttributeError from both the dashboard and manage_memory; and
search_with_ids() was the bad one — a `hasattr(...) else []` guard
upstream turned a missing method into the agent telling the user "no
matching facts" while the facts sat in the table. No error, no trace.

That is the third silent failure here in two weeks (consolidation.py's
max_tokens truncation, _fts_query dropping non-ASCII). Always the same
shape: a fallback that looks defensive and quietly answers wrong.

WHAT LANDS

- semantic/base.py — the FactStore Protocol. Six methods, each with its
  return contract, and the rule that a miss returns empty/False rather
  than raising. FactId is `int | str`: rag_chunks carries both an
  `id BIGSERIAL` and a `chunk_id TEXT`, and the episodic side already
  coerces by shape rather than parsing.
- test_fact_store_conformance.py — one suite, parametrized over every
  backend. Adding a store is now "write a class that passes this". The
  first assertion is `isinstance(store, FactStore)`, which is the single
  line that would have caught this on the day it shipped. Includes a
  Cyrillic round-trip so the 2026-08-05 non-ASCII bug cannot come back
  through a new backend, and a meta-test that fails if the Protocol
  grows a method this file doesn't exercise.
- supabase_store.py — the four missing methods. update() re-embeds:
  rewriting the text while leaving the stale vector would answer the old
  question correctly and the new one not at all, which is the exact
  failure mode this commit exists to stop. search_with_ids() takes two
  round trips rather than changing match_chunks(), because that function
  ships in launch-agentic-rag and quietly requiring a migration is the
  worse trade.
- memory_admin.py — the hasattr guard is gone. A real absence should be
  a loud AttributeError now that the contract is declared and tested.

WHAT IT SURVIVED

523 deterministic evals pass (was 507), ruff clean. The conformance
check was proven to bite: against the unfixed store it reports exactly
['list', 'search_with_ids', 'update', 'delete'] missing, and an object
with only add/search fails isinstance.

NOT verified against a live Supabase project — the suite covers it but
skips without WAKU_TEST_SUPABASE=1 plus credentials, since add() bills
OpenAI for embeddings and `make gate` has to stay green for a
contributor with no accounts.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
