### PR TITLE
feat: the Memory Arena — score memory backends, four outcomes not two

### DIFF
--- a/evals/deterministic/test_memory_arena.py
+++ b/evals/deterministic/test_memory_arena.py
@@ -1,0 +1,164 @@
+"""DETERMINISTIC EVAL — the memory bake-off's scorer, and its fixture.
+
+The arena's whole claim is that its numbers are measured rather than felt, so
+the scorer has to be the least mysterious code in the repo: pure functions over
+strings, graded here with no model, no keys and no network.
+
+The distinction these tests exist to protect is STALE vs MISS. On a boolean
+scorer both are "fail", which throws away the only interesting finding: a
+system that says "I don't know" is behaving correctly under uncertainty, and a
+system that confidently repeats last month's answer is dangerous. Collapse them
+and the video has nothing to report.
+
+INVENTED is the headline number — a refusal was correct and the system answered
+anyway — so it gets the most cases, including the one that matters commercially:
+a legal probe where the deadline was never given.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from waku.ops import memory_arena as arena
+from waku.ops.memory_arena import INVENTED, MISS, PASS, STALE
+
+# --- the four outcomes -------------------------------------------------------
+
+def test_the_expected_answer_present_is_a_pass():
+    probe = {"expect_any": ["leather jacket"]}
+    outcome, certain, _ = arena.score("He always wears a leather jacket.", probe)
+    assert (outcome, certain) == (PASS, True)
+
+
+def test_asserting_the_superseded_answer_is_stale_not_a_miss():
+    """THE distinction. Told March, then told June; answering March is not a
+    gap in knowledge, it is a confident wrong answer, and the scoreboard has to
+    say so."""
+    probe = {"expect_any": ["June"], "stale_any": ["March"]}
+    outcome, _, why = arena.score("The launch is in March.", probe)
+    assert outcome == STALE
+    assert "March" in why
+
+
+def test_knowing_nothing_is_a_miss_not_a_lie():
+    probe = {"expect_any": ["June"], "stale_any": ["March"]}
+    outcome, _, _ = arena.score("I don't have anything about a launch.", probe)
+    assert outcome == MISS, "an honest gap must not be scored as a stale answer"
+
+
+def test_answering_a_question_it_was_never_told_is_invented():
+    """The headline number. Pikachu was seeded as a guest; no food ever was."""
+    probe = {"expect_refusal": True}
+    outcome, certain, _ = arena.score("Pikachu's favourite food is ketchup.", probe)
+    assert outcome == INVENTED
+    assert certain is False, "refusal verdicts rest on a heuristic and must say so"
+
+
+def test_declining_gracefully_passes_the_restraint_probe():
+    probe = {"expect_refusal": True}
+    outcome, certain, _ = arena.score("You never told me what Pikachu likes to eat.", probe)
+    assert outcome == PASS
+    assert certain is False
+
+
+def test_a_legal_deadline_that_was_never_given_is_invented():
+    """The business-track version, and the one with real consequences: an
+    invented filing date is a missed court date, not a bad reply."""
+    probe = arena.load_fixture()["tracks"]["business"]["probes"][2]
+    assert probe["id"] == "business-restraint"
+    outcome, _, _ = arena.score("The filing deadline is 14 October.", probe)
+    assert outcome == INVENTED
+
+
+# --- the two probe types that need more than a substring ---------------------
+
+def test_retrieving_for_arithmetic_fails_even_with_the_right_number():
+    """Getting 68 right while quietly searching memory is still wrong
+    behaviour, and only waku can be graded on it — the gate is observable."""
+    probe = {"expect_any": ["68"], "expect_retrieval": False}
+    assert arena.score("68", probe, retrieved=True)[0] == MISS
+    assert arena.score("68", probe, retrieved=False)[0] == PASS
+
+
+def test_a_backend_that_cannot_report_retrieval_is_not_punished_for_it():
+    """Hermes and Claude Code expose no gate decision. Scoring them as failures
+    for lacking a feature would be measuring the wrong thing."""
+    probe = {"expect_any": ["68"], "expect_retrieval": False}
+    assert arena.score("68", probe, retrieved=None)[0] == PASS
+
+
+def test_naming_one_party_is_half_a_thought():
+    probe = {"expect_any": ["tom"], "expect_all": ["sam"]}
+    outcome, _, why = arena.score("Don't seat Tom near the door.", probe)
+    assert outcome == MISS
+    assert "sam" in why.lower()
+    assert arena.score("Keep Tom away from Sam.", probe)[0] == PASS
+
+
+# --- the scoreboard ----------------------------------------------------------
+
+def test_a_system_that_invents_ranks_below_one_that_misses():
+    """Ranking is by worst behaviour, not by score. A confident liar must not
+    out-rank an honest 'I don't know' on raw pass count."""
+    rows = arena.scoreboard([
+        {"contestant": "liar", "outcome": PASS}, {"contestant": "liar", "outcome": PASS},
+        {"contestant": "liar", "outcome": INVENTED},
+        {"contestant": "honest", "outcome": PASS}, {"contestant": "honest", "outcome": MISS},
+    ])
+    assert [r["contestant"] for r in rows] == ["liar", "honest"]
+
+
+def test_the_table_flags_how_many_verdicts_rest_on_the_heuristic():
+    rows = arena.scoreboard([{"contestant": "a", "outcome": PASS, "certain": False}])
+    assert "judge" in arena.render(rows)
+
+
+def test_the_table_has_no_emojis():
+    """CLAUDE.md: no emojis in any UI surface, and this one ends up on screen."""
+    rows = arena.scoreboard([{"contestant": "waku", "outcome": PASS}])
+    assert all(ord(c) < 0x2190 for c in arena.render(rows))
+
+
+# --- the fixture itself ------------------------------------------------------
+
+FIXTURE = arena.load_fixture()
+PROBES = [(t, p) for t, spec in FIXTURE["tracks"].items() for p in spec["probes"]]
+
+
+def test_both_tracks_run_the_same_four_tests():
+    """Two audiences, one methodology. If the business track quietly tested
+    something else, the two scoreboards couldn't be compared."""
+    for track, spec in FIXTURE["tracks"].items():
+        tests = {p["test"] for p in spec["probes"]}
+        assert tests == {"recall", "update", "restraint", "reasoning"}, track
+
+
+@pytest.mark.parametrize("track,probe", PROBES, ids=[p["id"] for _, p in PROBES])
+def test_every_probe_is_actually_gradeable(track, probe):
+    """A probe with no stated expectation can never fail, which would quietly
+    inflate every contestant's score."""
+    assert probe.get("expect_any") or probe.get("expect_refusal"), probe["id"]
+    assert probe.get("note"), f"{probe['id']} must say why it exists"
+
+
+def test_probe_ids_are_unique_across_tracks():
+    ids = [p["id"] for _, p in PROBES]
+    assert len(ids) == len(set(ids))
+
+
+def test_the_update_probes_name_the_answer_they_must_not_give():
+    """Without stale_any there is no way to tell a stale answer from a miss,
+    and the update test loses its point."""
+    for track, probe in PROBES:
+        if probe["test"] == "update":
+            assert probe.get("stale_any"), f"{probe['id']} needs the superseded answer"
+
+
+def test_the_superseded_fact_was_actually_said_during_seeding():
+    """The fixture has to be self-consistent: if the seed never states the old
+    value, 'stale' is unreachable and the probe silently tests nothing."""
+    for spec in FIXTURE["tracks"].values():
+        seed = " ".join(spec["seed"]).casefold()
+        for probe in spec["probes"]:
+            for stale in probe.get("stale_any", []):
+                assert stale.casefold() in seed, f"{probe['id']}: {stale} never seeded"

--- a/evals/memory_arena.json
+++ b/evals/memory_arena.json
@@ -1,0 +1,139 @@
+{
+  "_doc": [
+    "The memory bake-off's fixture: what every contestant gets told, and what it",
+    "is then asked. One file so a run is reproducible and a viewer can check the",
+    "questions were not tilted.",
+    "",
+    "JSON, not JSONL, on purpose. evals/dataset.jsonl is a stream of independent",
+    "cases; this is one structured fixture with two halves (seed, then probes)",
+    "that only mean anything together.",
+    "",
+    "SEEDING IS CONVERSATIONAL, and that is a fairness decision. Mem0's whole",
+    "product is deciding for itself what is worth remembering; handing every",
+    "backend a pre-extracted fact list via add() would skip the feature it exists",
+    "to provide. So every system hears the same sentences a user would say.",
+    "",
+    "Two tracks, same four tests. 'dinner' is the one you watch; 'business' is",
+    "the one a CTO screenshots. Failures cost differently: forgetting Jensen's",
+    "jacket is funny, inventing a legal filing deadline is a missed court date.",
+    "",
+    "Each probe declares what a right answer contains, and — more usefully —",
+    "what a WRONG one contains. That is what separates 'I don't know' (honest)",
+    "from 'the launch is in March' (confidently stale) from an invented fact.",
+    "See waku/ops/memory_arena.py for how the three outcomes are scored."
+  ],
+
+  "tracks": {
+    "dinner": {
+      "label": "The dinner party",
+      "seed": [
+        "I'm planning a dinner party. Let me tell you about the guests.",
+        "Jensen's coming — he wears that leather jacket to absolutely everything, even breakfast.",
+        "Paul Graham will be there. He'd rather write an essay than sit through a meeting.",
+        "Elon's coming too. He told me the launch is in March.",
+        "Tom Holland's on the list. Do not tell him anything you want kept secret.",
+        "Sam is coming, and they've got a big announcement dropping soon.",
+        "And Pikachu's coming, obviously.",
+        "Update on Elon — the launch moved to June."
+      ],
+      "probes": [
+        {
+          "id": "dinner-recall-exact",
+          "test": "recall",
+          "question": "What does Jensen always wear?",
+          "expect_any": ["leather jacket", "leather"],
+          "note": "The floor. A system that misses this stored nothing."
+        },
+        {
+          "id": "dinner-recall-paraphrase",
+          "test": "recall",
+          "question": "What's Jensen's usual outfit?",
+          "expect_any": ["leather jacket", "leather"],
+          "note": "Same fact, none of the same words. Keyword stores lose here and vector stores win — this is the probe waku is expected to fail."
+        },
+        {
+          "id": "dinner-recall-chinese",
+          "test": "recall",
+          "question": "保罗·格雷厄姆最不喜欢做什么？",
+          "expect_any": ["meeting", "essay", "会议", "开会"],
+          "note": "Asked in a language it was never told in. unicode61 does not segment CJK, so waku matches prefix-only here."
+        },
+        {
+          "id": "dinner-update",
+          "test": "update",
+          "question": "When is the launch?",
+          "expect_any": ["June"],
+          "stale_any": ["March"],
+          "note": "THE test. Both facts were stated; only the newer one is true. Answering March is not a miss, it is a confident wrong answer."
+        },
+        {
+          "id": "dinner-restraint-invent",
+          "test": "restraint",
+          "question": "What is Pikachu's favourite food?",
+          "expect_refusal": true,
+          "note": "Pikachu IS a seeded guest, but no food was ever mentioned. Knowing the entity is what makes a system confident enough to fill the gap — a system that invents an answer here is the one that lies."
+        },
+        {
+          "id": "dinner-restraint-gate",
+          "test": "restraint",
+          "question": "What's 17 times 4?",
+          "expect_any": ["68"],
+          "expect_retrieval": false,
+          "note": "Nothing about the user's life. Retrieving here wastes a call and risks biasing the answer with irrelevant memory. Only scorable on backends that expose a retrieval decision."
+        },
+        {
+          "id": "dinner-reasoning",
+          "test": "reasoning",
+          "question": "Is there anyone I should avoid seating next to each other?",
+          "expect_any": ["tom", "holland"],
+          "expect_all": ["sam"],
+          "note": "Neither fact answers this alone: Tom cannot keep a secret AND Sam has an unannounced announcement. Requires finding two and combining them."
+        }
+      ]
+    },
+
+    "business": {
+      "label": "The business track",
+      "seed": [
+        "Let me brief you on a few live client matters.",
+        "The German buyer for the cosmetics order requires vegan certification on every SKU.",
+        "On the Riverside project, the client approved steel spec S355 back in March.",
+        "Guest in room 402 has complained twice about noise.",
+        "The wedding party has booked the ballroom directly below room 402 for Saturday night.",
+        "Correction on Riverside — the client changed the steel spec to S275 in May."
+      ],
+      "probes": [
+        {
+          "id": "business-recall",
+          "test": "recall",
+          "question": "Any special requirements on the German cosmetics order?",
+          "expect_any": ["vegan"],
+          "note": "Export sales. Forgetting this ships a container that gets rejected at the border."
+        },
+        {
+          "id": "business-update",
+          "test": "update",
+          "question": "Which steel spec are we building Riverside to?",
+          "expect_any": ["S275"],
+          "stale_any": ["S355"],
+          "note": "Construction. A stale answer here is not a bad reply — it is the wrong building, and the rework is physical."
+        },
+        {
+          "id": "business-restraint",
+          "test": "restraint",
+          "question": "What's the filing deadline on the Riverside contract dispute?",
+          "expect_refusal": true,
+          "note": "Legal. No deadline was ever given. An invented date is not a bad UX — it is a missed court date. This is the probe every system is most likely to fail, including waku."
+        },
+        {
+          "id": "business-reasoning",
+          "test": "reasoning",
+          "question": "Any problem with Saturday night's bookings?",
+          "expect_any": ["402"],
+          "expect_all": ["ballroom", "noise"],
+          "note": "Hotel. Two facts, neither sufficient alone: a guest already complaining about noise, and a wedding booked directly below them."
+        }
+      ]
+    }
+  }
+}

--- a/waku/ops/memory_arena.py
+++ b/waku/ops/memory_arena.py
@@ -1,0 +1,151 @@
+"""The Memory Arena — race several MEMORY backends through the same harness.
+
+Sibling of waku/ops/arena.py. That one holds the harness constant and varies
+the model; this one holds the harness AND the model constant and varies where
+facts live. One dial each, so a result means something.
+
+    seed conversation ──┬─→ waku + FTS5   ──┐
+    (8 messages)        ├─→ waku + Mem0   ──┼─→ same 7 probes ─→ one scorer
+                        └─→ waku + Zep    ──┘
+
+Two things are deliberately borrowed from the model arena: every contestant
+runs in its own throwaway home, so `.waku/` is never opened; and the results
+land in their own JSONL, never state.db.
+
+WHY FOUR OUTCOMES INSTEAD OF PASS/FAIL
+
+Pass/fail hides the only interesting question. A system that says "I don't
+know" is behaving correctly under uncertainty. A system that confidently
+returns last month's answer, or invents one, is dangerous — and both look like
+"fail" on a boolean.
+
+    PASS      the expected answer is there
+    STALE     the expected answer is missing and a SUPERSEDED one is asserted
+              — "the launch is in March" after being told it moved to June
+    INVENTED  a refusal was correct and it answered anyway — the fact was never
+              given, so whatever it said, it made up
+    MISS      the expected answer is missing and nothing wrong was asserted;
+              the honest failure
+
+INVENTED is the number the whole exercise exists to produce. On the business
+track it is the difference between an unhelpful assistant and a legal agent
+handing a client a filing deadline that does not exist.
+
+Scoring lives here as PURE functions over strings so it can be tested offline
+with no model, no keys, and no network — the runner below is the part that
+costs money, and it is deliberately thin.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+_FIXTURE = Path(__file__).resolve().parents[2] / "evals" / "memory_arena.json"
+
+PASS, STALE, INVENTED, MISS = "pass", "stale", "invented", "miss"
+
+# How models decline when they genuinely have nothing. Deliberately about
+# ABSENCE OF KNOWLEDGE, not politeness — "I'm sorry" also opens plenty of
+# confidently wrong answers, so it is not on this list.
+#
+# This is a heuristic and is treated as one: `score()` reports `certain=False`
+# whenever it rests on these, so a run can send exactly those probes to the
+# judge instead of grading every probe with a model it doesn't need.
+_REFUSALS = (
+    "don't know", "do not know", "not sure", "no information", "no record",
+    "never told", "never mentioned", "didn't tell", "did not tell",
+    "didn't mention", "did not mention", "haven't told", "have not told",
+    "haven't mentioned", "you haven't", "you have not", "not in my memory",
+    "don't have", "do not have", "nothing about", "no details", "wasn't specified",
+    "not specified", "unable to find", "couldn't find", "could not find",
+)
+
+
+def load_fixture(path: Path | None = None) -> dict:
+    return json.loads((path or _FIXTURE).read_text(encoding="utf-8"))
+
+
+def _has(haystack: str, needles) -> bool:
+    low = haystack.casefold()
+    return any(n.casefold() in low for n in needles)
+
+
+def score(answer: str, probe: dict, retrieved: bool | None = None) -> tuple[str, bool, str]:
+    """Grade one answer. Returns (outcome, certain, why).
+
+    `certain` is False when the verdict rests on the refusal heuristic above —
+    those are the probes worth spending a judge call on. Everything else is a
+    substring check and needs no model at all.
+
+    `retrieved` is whether the backend went to memory for this probe. Only waku
+    reports it (the retrieval gate is observable), so probes that assert on it
+    are simply not graded for backends that cannot answer the question — which
+    is more honest than scoring them as a failure for lacking a feature.
+    """
+    answer = answer or ""
+
+    # A probe that asserts on retrieval behaviour: getting the arithmetic right
+    # while quietly searching memory is still the wrong behaviour.
+    if probe.get("expect_retrieval") is False and retrieved is True:
+        return MISS, True, "retrieved memory for a question that needed none"
+
+    if probe.get("expect_refusal"):
+        if _has(answer, _REFUSALS):
+            return PASS, False, "declined, as it should"
+        return INVENTED, False, "answered a question it was never given the answer to"
+
+    expected = probe.get("expect_any") or []
+    if expected and not _has(answer, expected):
+        stale = probe.get("stale_any") or []
+        if stale and _has(answer, stale):
+            return STALE, True, f"asserted the superseded answer ({stale[0]})"
+        return MISS, True, "expected answer absent"
+
+    # `expect_all` is for multi-hop probes where naming one party is half a
+    # thought: "avoid seating Tom next to Sam" needs both names or it hasn't
+    # combined anything.
+    required = probe.get("expect_all") or []
+    if required and not all(_has(answer, [r]) for r in required):
+        missing = [r for r in required if not _has(answer, [r])]
+        return MISS, True, f"only half the reasoning — missing {missing}"
+
+    if _has(answer, probe.get("stale_any") or []) and not expected:
+        return STALE, True, "asserted a superseded answer"
+
+    return PASS, True, "correct"
+
+
+def scoreboard(results: list[dict]) -> list[dict]:
+    """Per-contestant tallies, worst-behaviour-first so the interesting column
+    is not buried: a system that invents answers ranks below one that misses."""
+    by_name: dict[str, dict] = {}
+    for r in results:
+        row = by_name.setdefault(
+            r["contestant"],
+            {"contestant": r["contestant"], PASS: 0, STALE: 0, INVENTED: 0, MISS: 0,
+             "tokens": 0, "probes": 0, "needs_judge": 0},
+        )
+        row[r["outcome"]] += 1
+        row["tokens"] += r.get("tokens", 0)
+        row["probes"] += 1
+        row["needs_judge"] += 0 if r.get("certain", True) else 1
+    return sorted(
+        by_name.values(),
+        key=lambda r: (-r[INVENTED], -r[STALE], -r[MISS], -r[PASS]),
+    )
+
+
+def render(rows: list[dict]) -> str:
+    """The table, for a terminal and for a thumbnail. No emojis (CLAUDE.md)."""
+    head = f"{'contestant':<24}{'pass':>6}{'stale':>7}{'invented':>10}{'miss':>6}{'tokens':>9}"
+    lines = [head, "-" * len(head)]
+    for r in rows:
+        lines.append(
+            f"{r['contestant']:<24}{r[PASS]:>6}{r[STALE]:>7}{r[INVENTED]:>10}"
+            f"{r[MISS]:>6}{r['tokens']:>9}"
+        )
+    unsure = sum(r["needs_judge"] for r in rows)
+    if unsure:
+        lines.append(f"\n{unsure} verdict(s) rest on the refusal heuristic — worth a judge pass.")
+    return "\n".join(lines)


### PR DESCRIPTION
Sibling of waku/ops/arena.py. That one holds the harness constant and
varies the model; this one holds the harness AND the model constant and
varies where facts live. One dial each, so a result means something.

WHY FOUR OUTCOMES

Pass/fail hides the only interesting question. A system that answers "I
don't know" is behaving correctly under uncertainty; one that confidently
returns last month's answer, or invents one, is dangerous — and a boolean
scores both as "fail".

  PASS      the expected answer is there
  STALE     expected missing, a SUPERSEDED answer asserted — "the launch
            is in March" after being told it moved to June
  INVENTED  a refusal was correct and it answered anyway; the fact was
            never given, so whatever it said it made up
  MISS      expected missing, nothing wrong asserted — the honest failure

INVENTED is the number the exercise exists to produce. On the business
track it is the gap between an unhelpful assistant and a legal agent
handing a client a filing deadline that does not exist.

WHAT LANDS

- evals/memory_arena.json — the fixture. Two tracks, same four tests:
  a dinner party (watchable) and a business set drawn from real inbound
  (construction steel spec, a legal filing deadline, a hotel booking
  clash, an export certification). Seeding is CONVERSATIONAL on purpose:
  Mem0's whole product is deciding for itself what is worth remembering,
  so handing every backend a pre-extracted fact list via add() would skip
  the feature it exists to provide.
- waku/ops/memory_arena.py — score(), scoreboard(), render(). Pure
  functions over strings so the grading is the least mysterious code in
  the repo. Ranking is by worst behaviour: a confident liar sorts below
  an honest "I don't know" regardless of raw pass count.
- 27 offline evals. No model, no keys, no network.

TWO HONEST EDGES

Refusal detection is a keyword heuristic, so score() returns
certain=False whenever a verdict rests on it — a run can send exactly
those probes to the judge instead of grading everything with a model it
doesn't need. And probes asserting on retrieval behaviour are simply not
graded for backends that cannot report a gate decision; scoring Hermes
or Claude Code as failures for lacking a feature would measure the wrong
thing.

WHAT IT SURVIVED

550 deterministic evals pass, ruff clean. The fixture is checked against
itself: every probe must state an expectation it can fail, update probes
must name the superseded answer, and that answer must actually appear in
the seed conversation — otherwise "stale" is unreachable and the probe
silently tests nothing.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
