### PR TITLE
fix: stop the Arena and chat dock overflowing their boxes on a narrow window

### DIFF
--- a/waku/ops/static/js/compare.js
+++ b/waku/ops/static/js/compare.js
@@ -401,8 +401,8 @@ VIEWS.compare = function(d){
   if (compareState.history === undefined){ compareState.history = []; setTimeout(loadCompareHistory, 0); }
 
   return `<div class="card">
-    <div style="display:flex;align-items:center;gap:12px;margin-bottom:6px">
-      <span class="meta">One message, every brain at once — same harness, isolated homes, real receipts (gate · latency · cost · tools). Compare, don't guess.</span>
+    <div class="cmp-controls">
+      <span class="meta cmp-blurb">One message, every brain at once — same harness, isolated homes, real receipts (gate · latency · cost · tools). Compare, don't guess.</span>
       <label class="cmp-judge ${compareState.apple?"on":""}" style="margin-left:auto" title="Write create_event results to your REAL Apple Calendar (the 'Waku' calendar). Off by default so a race doesn't spam duplicates — when on, EACH model writes its own event (use 1-2 models).">
         <input type="checkbox" ${compareState.apple?"checked":""} onchange="toggleApple()"> write to calendar</label>
       <label class="cmp-judge ${compareState.coding?"on":""}" title="Coding task: enables the delegate_task tool so the loop can hand real coding work to a pi sub-agent on this card's own model — the full harness runs (gate, tools), delegate_task is one of them">
@@ -532,7 +532,7 @@ function compareHistoryHtml(){
       <span class="meta" style="font-weight:400">— totals across ${raceCount} race${raceCount===1?"":"s"}</span>
       <a class="reveal" style="margin-left:auto;font-size:12px" onclick="clearCompareHistory()">clear all</a></h2>
     ${costQualityScatter(agg)}
-    <div class="card" style="padding:4px 8px"><table>
+    <div class="card" style="padding:4px 8px"><div class="tablescroll"><table>
       <tr><th>model</th><th title="knowledge cutoff — when each model's world knowledge ends; it cannot know releases after this date">cutoff</th>${th("cases_passed","solved")}<th class="cmp-th ${bs.key==="quality_avg"?"on":""}" onclick="setBoardSort('quality_avg')" title="referee's mean 0-10 grade on the replies (correctness, honesty, concision) — referee is not a racing model">grade${arrow("quality_avg")}</th>${th("runs","races")}<th>ok</th>${th("total_latency_ms","total time")}${th("total_tokens_in","in tok")}${th("total_tokens_out","out tok")}${th("total_tokens","total tok")}<th title="list price per million tokens, input / output">rate $/M</th>${th("total_cost_usd","total cost")}</tr>
       ${rows.map(a=>`<tr>
         <td><span class="mm-prov">${esc(a.provider)}</span> <code>${esc(a.model)}</code></td>
@@ -545,7 +545,7 @@ function compareHistoryHtml(){
         <td class="meta">${a.total_tokens}</td>
         <td class="meta">${a.rate_in!=null?`$${a.rate_in}/$${a.rate_out}`:"—"}</td>
         <td class="meta" style="color:var(--good)">${money(a.total_cost_usd)}</td></tr>`).join("")}
-    </table></div>` : "";
+    </table></div></div>` : "";
   const recent = hist.length ? `
     <h2 style="margin-top:18px">Recent races <span class="meta" style="font-weight:400">— click to reopen</span></h2>
     <div class="card">${hist.map((run,i)=>`

--- a/waku/ops/static/style.css
+++ b/waku/ops/static/style.css
@@ -223,9 +223,13 @@
   .sqlbox:focus{border-color:var(--accent)}
   .qexample{font-family:var(--mono);font-size:11.5px;color:var(--accent);cursor:pointer;border-bottom:1px dashed var(--accent)}
   /* session picker in the chat surfaces */
-  .sesshead{display:flex;align-items:center;gap:8px;margin-bottom:10px}
+  /* wrap, don't overflow: the dock is ~230px wide when the window is narrow, and
+     a nowrap row pushed the model chip and Send button clean off the screen.
+     min-width:0 is the other half — without it a flex child refuses to shrink
+     below its content and the row overflows even when it IS allowed to wrap. */
+  .sesshead{display:flex;align-items:center;gap:8px;margin-bottom:10px;flex-wrap:wrap;min-width:0}
   .sessbtn{background:var(--panel);border:1px solid var(--line2);border-radius:7px;color:var(--ink2);
-           padding:5px 11px;font-size:12.5px;cursor:pointer}
+           padding:5px 11px;font-size:12.5px;cursor:pointer;white-space:nowrap}
   .sessbtn:hover{border-color:var(--accent);color:var(--accent)}
   .teletoggle.on{border-color:var(--accent);color:var(--accent);background:var(--accent-soft)}
   /* per-turn stats (gate/seconds/iters/tools) hide together when toggled off */
@@ -233,7 +237,9 @@
   .sessmenu{position:absolute;z-index:30;background:var(--panel);border:1px solid var(--line2);border-radius:10px;
             box-shadow:0 8px 30px rgba(0,0,0,.28);width:300px;max-height:340px;overflow-y:auto;padding:6px}
   /* mini model switcher: a pill in the chat header + its dropdown */
-  .modelchip{margin-left:auto;display:inline-flex;align-items:center;gap:6px;max-width:150px;
+  /* margin-left:auto parks the chip on the right — which, in a row too narrow to
+     hold it, parked it past the right edge of the window. It may shrink now. */
+  .modelchip{margin-left:auto;display:inline-flex;align-items:center;gap:6px;max-width:150px;min-width:0;
              background:var(--accent-soft);border:1px solid var(--line2);border-radius:99px;
              color:var(--ink);padding:4px 9px;font-size:12px;cursor:pointer;line-height:1.2}
   .modelchip:hover{border-color:var(--accent)}
@@ -291,7 +297,7 @@
   .bubble{align-self:flex-end;background:var(--accent);color:#fff;padding:8px 13px;
           border-radius:14px 14px 3px 14px;max-width:75%;font-size:13.5px}
   .chatbar{display:flex;gap:10px;padding:12px 0;border-top:1px solid var(--line);
-           background:var(--bg);position:sticky;bottom:0}
+           background:var(--bg);position:sticky;bottom:0;min-width:0}
   /* the chat side-dock: chat from any tab, watch the harness in main */
   #dock{width:var(--dock-w,380px);flex-shrink:0;border-left:1px solid var(--line);
         height:100vh;display:flex;flex-direction:column;background:var(--bg);padding:0 14px}
@@ -321,11 +327,16 @@
                box-shadow:0 2px 10px rgba(0,0,0,.25)}
   body.dock-closed #dock,body.dock-closed #dock-resizer{display:none}
   body.dock-closed #dock-reopen{display:block}
-  .chatbar input{flex:1;background:var(--panel);border:1px solid var(--line2);border-radius:8px;
+  /* min-width:0 is what actually makes `flex:1` shrink. flex:1 sets the basis
+     to 0, but a flex item's default min-width is `auto` — its intrinsic content
+     width — so the input refused to go below that and pushed Send off the edge
+     of the dock. The buttons then get flex-shrink:0 so the input absorbs the
+     squeeze instead of the controls turning into slivers. */
+  .chatbar input{flex:1;min-width:0;background:var(--panel);border:1px solid var(--line2);border-radius:8px;
                  padding:10px 14px;color:var(--ink);font-size:14px;outline:none}
   .chatbar input:focus{border-color:var(--accent)}
   .chatbar button{background:var(--accent);color:#fff;border:none;border-radius:8px;
-                  padding:0 18px;font-weight:600;font-size:13.5px;cursor:pointer}
+                  padding:0 18px;font-weight:600;font-size:13.5px;cursor:pointer;flex-shrink:0}
   .chatbar button:disabled{opacity:.5;cursor:default}
   .stages{display:flex;gap:6px;margin:2px 0 4px}
   .stage{font-size:11px;padding:2px 9px;border-radius:99px;border:1px solid var(--line2);color:var(--ink3)}
@@ -345,6 +356,18 @@
        padding:10px 12px;color:var(--ink);font-size:13.5px;font-family:inherit;outline:none;resize:vertical}
   .cmp-input:focus{border-color:var(--accent)}
   .cmp-picks{display:flex;flex-wrap:wrap;gap:6px;margin-top:10px;align-items:center}
+  /* The arena's control row: blurb, three toggles, and the Race button. It was
+     a nowrap flex row, so on a narrow window the blurb squeezed to one word per
+     line AND the Race button still ended up outside the card. Wrapping fixes
+     both: the blurb takes a line of its own below ~260px of room, and the
+     controls flow onto the next line instead of escaping. */
+  .cmp-controls{display:flex;align-items:center;gap:12px;margin-bottom:6px;flex-wrap:wrap}
+  .cmp-controls .cmp-blurb{flex:1 1 260px;min-width:0}
+  /* Wide tables scroll inside their own box rather than out of it. The
+     scoreboard is 885px of columns in a 655px card; without this the last
+     columns (total tok, rate, total cost) render past the card's right edge and
+     over the page. Any table that can outgrow its card belongs in one of these. */
+  .tablescroll{overflow-x:auto;max-width:100%}
   .cmp-pick{display:inline-flex;align-items:center;gap:5px;font-size:12px;color:var(--ink2);
        border:1px solid var(--line2);border-radius:99px;padding:4px 10px;cursor:pointer}
   .cmp-pick.on{border-color:var(--accent);color:var(--accent);background:var(--accent-soft)}


### PR DESCRIPTION
Six elements rendered outside their containers below ~1200px, reported
from a real session. All flexbox, three independent causes.

  .cmp-controls    the arena's control row was a nowrap flex row, so the
                   blurb squeezed to roughly one word per line AND the
                   "Race 10 models" button still ended up 59px outside
                   the card
  scoreboard       885px of table inside a 655px card, no scroll
                   container — total tok / rate / total cost rendered
                   past the card edge and over the page
  .sesshead        the chat header refused to wrap: "New chat" broke
                   across three lines, and the model chip's
                   margin-left:auto parked it 80px past the window edge
  .chatbar input   flex:1 with no min-width:0. flex:1 sets the basis to
                   0, but a flex item's default min-width is `auto` — its
                   intrinsic content width — so the input would not
                   shrink and shoved Send off the dock

min-width:0 is the fix in three of the four; it is the half of `flex:1`
that everyone forgets. Wide tables now live in a .tablescroll box and
scroll inside themselves rather than out of the card.

Measured before and after in the browser at 1155px and 900px: six
overflowing elements before, zero after, and the page no longer scrolls
sideways at either width. The Models page was checked too — also clean.

550 deterministic evals pass, ruff clean. Nothing outside CSS and one
wrapper div changed; no behaviour, no layout at desktop width.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
