### PR TITLE
refactor(ui): group the sidebar, and call the settings page what it is

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Type these in the chat dock (or `make run`) and watch the dashboard light up:
 
 **The money shot** is the World Cup one. In one turn, Waku searches the web a few times, reasons
 over the results, and books every remaining match — **8 loop iterations**, live. Needs a free
-`TAVILY_API_KEY` (paste it in **Settings**). Watch the **LOOP** box pulse per cycle. That's loop
+`TAVILY_API_KEY` (paste it in **Connections**). Watch the **LOOP** box pulse per cycle. That's loop
 engineering, on tape.
 
 ## How is this different from ChatGPT / Claude Desktop?

--- a/docs/DEMO-CHECKLIST.md
+++ b/docs/DEMO-CHECKLIST.md
@@ -5,8 +5,8 @@ proves, where to look, and whether it's been dry-run verified. Keep this updated
 
 ## Pre-flight
 
-- [x] Provider = `anthropic` (best streaming; Gemini breaks multi-turn tool use) — Settings
-- [x] Free `TAVILY_API_KEY` pasted on the Settings page (for the World Cup beat)
+- [x] Provider = `anthropic` (best streaming; Gemini breaks multi-turn tool use) — Models
+- [x] Free `TAVILY_API_KEY` pasted on the Connections page (for the World Cup beat)
 - [x] Clean curated state — `python scripts/demo_seed.py --yes` (clears Loop/Tools traces + Ops eval history; keeps `usage.jsonl` spend unless you add `--reset-spend`). Refuses without `--yes` — it's destructive.
 - [x] `waku dashboard` running on your own machine (also starts Telegram if a token is set) → `localhost:7777` in a real browser
 

--- a/waku/ops/static/index.html
+++ b/waku/ops/static/index.html
@@ -14,10 +14,12 @@
   <a href="#tools" data-v="tools">Tools <span class="n" id="n-tools"></span></a>
   <a href="#database" data-v="database">Database <span class="n" id="n-db"></span></a>
   <a href="#ops" data-v="ops">Ops <span class="n" id="n-ops"></span></a>
-  <!-- Arena is deliberately ungrouped: it is neither a system view nor setup,
-       and a group header over a single row reads as broken navigation. Its own
-       Models / Memory split lives in sub-tabs inside the page, the same way the
-       Memory tab holds semantic / episodic / skills / soul. -->
+  <!-- Arena belongs to System: like every row above it, it is a place you WATCH
+       something run — models racing through the real loop rather than one turn.
+       It gets no header of its own because a header over a single row reads as
+       broken navigation, and because its Models / Memory split belongs in
+       sub-tabs inside the page, the way Memory holds semantic / episodic /
+       skills / soul. -->
   <a href="#compare" data-v="compare">Arena</a>
   <div class="grp">Setup</div>
   <a href="#models" data-v="models">Models</a>

--- a/waku/ops/static/index.html
+++ b/waku/ops/static/index.html
@@ -14,10 +14,15 @@
   <a href="#tools" data-v="tools">Tools <span class="n" id="n-tools"></span></a>
   <a href="#database" data-v="database">Database <span class="n" id="n-db"></span></a>
   <a href="#ops" data-v="ops">Ops <span class="n" id="n-ops"></span></a>
+  <!-- Arena is deliberately ungrouped: it is neither a system view nor setup,
+       and a group header over a single row reads as broken navigation. Its own
+       Models / Memory split lives in sub-tabs inside the page, the same way the
+       Memory tab holds semantic / episodic / skills / soul. -->
   <a href="#compare" data-v="compare">Arena</a>
+  <div class="grp">Setup</div>
   <a href="#models" data-v="models">Models</a>
   <a href="#connections" data-v="connections">Connections</a>
-  <a href="#settings" data-v="settings">Settings</a>
+  <a href="#settings" data-v="settings">Behaviour</a>
 </nav>
 <div class="resizer" id="nav-resizer" title="Drag to resize sidebar"></div>
 <main>

--- a/waku/ops/static/js/graph.js
+++ b/waku/ops/static/js/graph.js
@@ -119,7 +119,7 @@ function graphPanel(d){
   if (!g.enabled && !last)
     return `<div class="card"><div class="meta">The per-message graph door is <b>off</b> — every chat turn
       runs the classic loop above. Switch on <b>graph workflows</b> in
-      <a class="reveal" onclick="location.hash='settings'">Settings</a> to triage each message first.
+      <a class="reveal" onclick="location.hash='settings'">Behaviour</a> to triage each message first.
       Workflows you run yourself, like <code>make gather</code>, do not need the flag —
       <a class="reveal" onclick="location.hash='graph'">see them here</a>.</div></div>`;
   const when = GRAPH_LIVE

--- a/waku/ops/static/js/main.js
+++ b/waku/ops/static/js/main.js
@@ -3,9 +3,15 @@
 // step, no modules). Load order + rules: static/README.md.
 
 let activeView = null, activeSub = null;
+// The hash keys stay as they are — #settings is linked from graph.js, views.js,
+// the README and DEMO-CHECKLIST, and from anyone's bookmark. Only the LABEL
+// moved: after the Connections registry took keys, providers and integrations
+// out of that page, what remained was two switches that change how a turn runs,
+// which is a behaviour, not a setting.
 const TITLES = {chat:"Chat & watch", ops:"LLM Ops",
                 graph:"Graph workflows — structure around the loop",
                 compare:"Arena — race models through the real loop",
+                settings:"Behaviour — how a turn runs",
                 database:"Database — everything Waku stores (state.db)"};
 function render(){
   if (!D) return;

--- a/waku/ops/static/js/views.js
+++ b/waku/ops/static/js/views.js
@@ -442,7 +442,7 @@ const VIEWS = {
     if (!g.enabled)
       h += `<div class="card"><b>Off</b> — every turn currently runs the classic loop.
         <div class="meta" style="margin-top:6px">Switch on <b>graph workflows</b> in
-        <a class="reveal" onclick="location.hash='settings'">Settings</a>, or set
+        <a class="reveal" onclick="location.hash='settings'">Behaviour</a>, or set
         <code>WAKU_GRAPH_WORKFLOWS=1</code> in <code>.env</code>. Any failure anywhere fails open to the
         plain loop — this can never lose a reply, only save time and tokens.</div></div>`;
     // The two workflows are two different JOBS with different triggers, which is

--- a/waku/ops/static/style.css
+++ b/waku/ops/static/style.css
@@ -32,13 +32,26 @@
   body.nav-hidden #nav-reopen{display:block}
   .brand{font-weight:650;font-size:15px;padding:0 10px 4px}
   .brand small{display:block;color:var(--ink3);font-weight:400;font-size:11px;margin-top:2px}
+  /* Links are indented past their group header, which is what makes the header
+     read as a PARENT instead of a line of text dropped between rows. Header and
+     links used to share the same 10px left edge, so the sidebar looked like one
+     flat list with two captions randomly inserted into it. */
   nav a{display:flex;justify-content:space-between;align-items:center;color:var(--ink2);
-        text-decoration:none;padding:6px 10px;border-radius:6px;font-size:13.5px;margin-top:2px}
+        text-decoration:none;padding:6px 10px 6px 20px;border-radius:6px;font-size:13.5px;margin-top:2px}
   nav a:hover{background:var(--panel);color:var(--ink)}
   nav a.on{background:var(--accent-soft);color:var(--accent);font-weight:550}
   nav .n{font-size:11px;color:var(--ink3);font-variant-numeric:tabular-nums}
+  /* Proximity does the rest: a big gap ABOVE the header, a small one below it,
+     so each header sits with its own children rather than floating between two
+     groups. The rule separates sections without adding another colour. */
   nav .grp{font-size:10.5px;text-transform:uppercase;letter-spacing:.09em;color:var(--ink3);
-           padding:16px 10px 4px}
+           font-weight:600;padding:8px 10px 5px;margin-top:14px;border-top:1px solid var(--line)}
+  /* NOT :first-of-type — that is type-based, and `.brand` is the first div in
+     the nav, so the selector silently matched nothing and the top header kept a
+     stray rule under the brand. The adjacent-sibling form says what is meant:
+     the header that comes straight after the brand opens the list, so it has
+     nothing to be separated from. */
+  nav .brand + .grp{margin-top:6px;border-top:none;padding-top:2px}
   main{flex:1;min-width:0;height:100vh;overflow-y:auto;padding:0 40px 32px}
   .pagehead{position:sticky;top:0;z-index:6;background:var(--bg);padding:28px 0 10px;
             border-bottom:1px solid var(--line);margin-bottom:18px}


### PR DESCRIPTION
Twelve nav links sat under one "System" header, so Arena, Models,
Connections and Settings all read as system-observability views. The
sidebar had no second group — that missing header, not the page split,
is why the navigation felt like an undifferentiated list.

  System   Overview · Gateway · Loop · Graph · Memory · Tools ·
           Database · Ops        — watch it run
  Arena                          — prove it works
  Setup    Models · Connections · Behaviour   — configure it

Arena is deliberately left ungrouped. A header over a single row reads
as broken navigation, and its own Models / Memory split belongs in
sub-tabs inside the page — the pattern the Memory tab already uses for
semantic / episodic / skills / soul.

SETTINGS -> BEHAVIOUR

After the Connections registry (#72) moved keys, providers and
integrations out, that page holds exactly two switches: sub-agent
delegation and graph workflows. Both change what happens when a message
arrives. That is a behaviour, not a setting, and "Settings" was the
vaguest available name for the most specific available content. The three
setup pages now answer three different questions — Models: which brain.
Connections: what it can reach. Behaviour: how it runs.

Only the LABEL moved. The #settings hash is unchanged, because graph.js,
views.js, the README, DEMO-CHECKLIST and anyone's bookmark point at it.

DOCS THAT WERE ALREADY WRONG

Chasing the label turned up drift #72 left behind: the README told new
users to paste TAVILY_API_KEY "in Settings", and DEMO-CHECKLIST said the
same and sourced the provider there too. Both moved to Connections and
Models in that PR. A newcomer following the README opened a page with two
toggles on it and no key field. Fixed here rather than filed.

WHAT IT SURVIVED

550 deterministic evals, ruff clean. Checked live at 1155px: every setup
page routes, highlights and titles correctly, and none of them scroll
sideways — the overflow fix in #86 still holds.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
