### PR TITLE
fix: stop telling users their working integrations need setting up

### DIFF
--- a/evals/deterministic/test_integrations.py
+++ b/evals/deterministic/test_integrations.py
@@ -39,14 +39,19 @@ def test_status_masking_health_persistence_and_invalidation(monkeypatch, tmp_pat
     _isolate(monkeypatch, tmp_path)
     monkeypatch.setenv("OPENAI_API_KEY", "super-secret-1234")
     view = next(view for view in integrations.list_integrations() if view.key == "openai")
-    assert view.status.state is IntegrationState.INSTALLED_BUT_UNCONFIGURED
+    # A key is present and nothing required is missing, so this is CONFIGURED —
+    # not INSTALLED_BUT_UNCONFIGURED, which the dashboard renders as "needs
+    # setup". See test_configured_is_not_confused_with_needing_setup below.
+    assert view.status.state is IntegrationState.CONFIGURED
     assert view.fields[0].value == ""
     assert view.fields[0].last4 == "1234"
     integrations.record_health("openai", IntegrationStatus(IntegrationState.CONNECTED))
     integrations._HEALTH = None
     assert next(view for view in integrations.list_integrations() if view.key == "openai").status.state is IntegrationState.CONNECTED
     integrations.invalidate_health("openai")
-    assert next(view for view in integrations.list_integrations() if view.key == "openai").status.message == "Configured, not tested"
+    after = next(view for view in integrations.list_integrations() if view.key == "openai")
+    assert after.status.state is IntegrationState.CONFIGURED
+    assert after.status.message == "configured — not tested yet"
 
 
 def test_otel_probe_checks_configured_collector_tcp_port(monkeypatch):
@@ -404,3 +409,46 @@ def test_disabled_google_test_connection_skips_probe(monkeypatch, tmp_path):
 
     assert view.status.state is not IntegrationState.CONNECTED
     assert view.status.message == "integration is disabled"
+
+
+def test_configured_is_not_confused_with_needing_setup(monkeypatch, tmp_path):
+    """THE regression. Both of these used to return INSTALLED_BUT_UNCONFIGURED,
+    which the dashboard renders as "needs setup" — so a working Tavily key
+    reported itself as broken. The health store is empty on a fresh checkout,
+    so EVERY user met that on their first visit to Connections, about
+    integrations that were already working.
+
+    The two situations are not the same and now cannot collapse:
+      missing a required value -> installed_but_unconfigured ("needs setup")
+      complete but never probed -> configured ("configured, not tested")
+    """
+    _isolate(monkeypatch, tmp_path)
+    monkeypatch.setenv("TAVILY_API_KEY", "tvly-working-key")
+    tavily = next(v for v in integrations.list_integrations() if v.key == "tavily")
+    assert tavily.status.state is IntegrationState.CONFIGURED, (
+        "a filled-in integration must not tell the user it needs setting up"
+    )
+
+    monkeypatch.delenv("TAVILY_API_KEY")
+    integrations._HEALTH = None
+    empty = next(v for v in integrations.list_integrations() if v.key == "tavily")
+    assert empty.status.state is IntegrationState.NOT_CONFIGURED
+
+
+def test_a_genuinely_missing_required_field_still_says_needs_setup(monkeypatch, tmp_path):
+    """The other half: widening the states must not swallow a real problem.
+    Telegram with a token but no allowed-chat id is incomplete, and has to keep
+    saying so."""
+    _isolate(monkeypatch, tmp_path)
+    monkeypatch.setattr(integrations, "_extra_installed", lambda name: True)
+    # Notion, not Telegram: Telegram has a single required field, so "half
+    # filled in" is not expressible there and the test would prove nothing.
+    notion = next(i for i in integrations.registry() if i.key == "notion")
+    required = [f.name for f in notion.env if f.required]
+    assert len(required) > 1, "this test needs an integration with 2+ required fields"
+    monkeypatch.setenv(required[0], "set")
+    for name in required[1:]:
+        monkeypatch.delenv(name, raising=False)
+    view = next(v for v in integrations.list_integrations() if v.key == "notion")
+    assert view.status.state is IntegrationState.INSTALLED_BUT_UNCONFIGURED
+    assert required[1] in view.status.message

--- a/waku/integrations.py
+++ b/waku/integrations.py
@@ -25,9 +25,22 @@ from waku.memory.episodic.notion_store import normalize_database_id
 
 
 class IntegrationState(StrEnum):
-    NOT_CONFIGURED = "not_configured"
-    INSTALLED_BUT_UNCONFIGURED = "installed_but_unconfigured"
-    CONNECTED = "connected"
+    """Where an integration stands, from empty to proven working.
+
+    CONFIGURED exists because the other four could not tell two very different
+    situations apart. "Telegram is missing its token" and "Telegram has
+    everything and I simply have not probed it yet" both returned
+    INSTALLED_BUT_UNCONFIGURED, and the dashboard renders that as "needs
+    setup" — so a working Tavily key, a live Telegram gateway and a connected
+    Notion database all told the user they needed setting up. The health store
+    is empty on a fresh checkout, which means EVERY user saw that on their
+    first visit, about integrations that were already working.
+    """
+
+    NOT_CONFIGURED = "not_configured"                        # nothing filled in
+    INSTALLED_BUT_UNCONFIGURED = "installed_but_unconfigured"  # something REQUIRED is missing
+    CONFIGURED = "configured"                                # complete, never tested
+    CONNECTED = "connected"                                  # probed, and it worked
     ERROR = "error"
 
 
@@ -323,8 +336,11 @@ def _status(integration: Integration, env: Mapping[str, str]) -> IntegrationStat
         status = _gateway_status_provider(integration.key)
         if status is not None:
             return status
-    return _health().get(integration.key, IntegrationStatus(IntegrationState.INSTALLED_BUT_UNCONFIGURED,
-                                                              "Configured, not tested"))
+    # Everything required is present and the extra is installed. Whether it
+    # actually WORKS is a separate question, answered only by a probe — so the
+    # honest answer when no probe has run is "configured", not "needs setup".
+    return _health().get(integration.key, IntegrationStatus(IntegrationState.CONFIGURED,
+                                                            "configured — not tested yet"))
 
 
 def list_integrations() -> tuple[IntegrationView, ...]:
@@ -622,10 +638,15 @@ def test_integration(key: str) -> IntegrationView:
     if not integration.enabled(values):
         view = _current_view(key)
         assert view is not None
+        # Switched off. The two "not ready" states survive as they are — turning
+        # a toggle off doesn't fill in a missing token. Anything that WAS ready
+        # (configured / connected / error) drops to CONFIGURED, because a
+        # disabled integration must never keep claiming it is connected.
         state = (
-            IntegrationState.NOT_CONFIGURED
-            if view.status.state is IntegrationState.NOT_CONFIGURED
-            else IntegrationState.INSTALLED_BUT_UNCONFIGURED
+            view.status.state
+            if view.status.state in (IntegrationState.NOT_CONFIGURED,
+                                     IntegrationState.INSTALLED_BUT_UNCONFIGURED)
+            else IntegrationState.CONFIGURED
         )
         status = IntegrationStatus(state, "integration is disabled", view.status.checked_at)
         return IntegrationView(view.key, view.group, view.name, view.what, status, view.fields,

--- a/waku/ops/static/js/views.js
+++ b/waku/ops/static/js/views.js
@@ -294,6 +294,12 @@ function connectionStatusDisplay(status){
   const state = (status && status.state) || "not_configured";
   if (state === "connected") return {label:"connected", className:"connected"};
   if (state === "error") return {label:"error", className:"error"};
+  // "configured" means every required field is filled and the extra is
+  // installed — it just hasn't been probed. That is not a warning, so it must
+  // not wear the amber "needs setup" pill: this state covers most of a working
+  // setup on first visit, and colouring it like a problem told every new user
+  // their Telegram, Notion and Tavily needed fixing when they were fine.
+  if (state === "configured") return {label:"configured · not tested", className:"configured"};
   if (state === "installed_but_unconfigured") return {label:"needs setup", className:"needs-setup"};
   return {label:"not configured", className:"not-configured"};
 }
@@ -301,10 +307,19 @@ function connectionStatusDisplay(status){
 function connectionCard(item){
   const display = connectionStatusDisplay(item.status);
   const action = item.status && item.status.state !== "not_configured" ? "Edit" : "Configure";
+  // Say WHY on the card. "needs setup" covers two unrelated fixes — a missing
+  // value ("missing NOTION_TOKEN") and a missing package ("missing notion
+  // extra", which wants a pip install, not a key) — and the reason used to be
+  // hidden until you opened the modal. The message repeats the label for
+  // connected/configured, so only show it where it adds something.
+  const why = (item.status && item.status.message
+    && (item.status.state === "installed_but_unconfigured" || item.status.state === "error"))
+    ? `<div class="connwhy">${esc(item.status.message)}</div>` : "";
   return `<article class="provcard conncard" data-connection-card="${esc(item.key)}">
     <img class="provlogo connlogo" src="/static/logos/connections/${esc(item.key)}.svg" alt="">
     <div class="provname">${esc(item.name)}</div>
     <div class="connstatus ${display.className}"><span class="conndot"></span>${esc(display.label)}</div>
+    ${why}
     <div class="conndesc">${esc(item.what)}</div>
     <div class="provactions connactions">
       <button class="save ghost" onclick="openConnectionModal('${esc(item.key)}')">${action}</button>

--- a/waku/ops/static/style.css
+++ b/waku/ops/static/style.css
@@ -526,7 +526,14 @@ details.subterm > summary.subterm-h::-webkit-details-marker{ display:none; }
 .connstatus.error .conndot{background:var(--bad)}
 .connstatus.needs-setup{color:#a87312}
 .connstatus.needs-setup .conndot{background:#c8951f}
+/* Configured but unproven: deliberately calm. Amber here would read as a
+   warning about something that is merely untested, which is the whole bug
+   this state exists to fix. Accent, not alarm. */
+.connstatus.configured{color:var(--accent)}
+.connstatus.configured .conndot{background:var(--accent)}
 .connstatus.not-configured .conndot{background:var(--ink3)}
+/* The one-line reason under the pill: what to actually do about it. */
+.connwhy{font-size:11px;color:var(--ink3);margin-top:2px;font-family:var(--mono)}
 .conndesc{color:var(--ink2);font-size:12px;line-height:1.5}
 .conncard .conndesc{display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;
   overflow:hidden;min-height:36px}


### PR DESCRIPTION
Open Connections on a fresh checkout and Tavily, Apple Calendar and
Apple Tools all reported "needs setup" — with an Edit button, because
their values were right there. Nothing was broken. The label was.

WHY

_status() returned INSTALLED_BUT_UNCONFIGURED for two unrelated
situations, and the dashboard renders that one state as "needs setup":

  a required value is missing        -> "missing NOTION_TOKEN"
  everything present, never probed   -> "Configured, not tested"

The health store is empty until something triggers a probe, and nothing
does on first run — so EVERY user's first visit to Connections accused
their working integrations of being unconfigured. Reported from a real
session: "previously they were all configured, what's going on?"

THE FIX

A fifth state, CONFIGURED: all required values present, extra installed,
simply not tested yet. It renders as "configured · not tested" in accent,
not amber — colouring an untested integration like a warning is the whole
bug. A disabled integration now drops to CONFIGURED too, rather than
claiming CONNECTED or pretending it needs setup.

The card also shows the status message under the pill. "needs setup"
covers two unrelated fixes — a missing value wants a key, a missing extra
wants a pip install — and the reason was buried in the modal. On the
machine this was found on, Telegram, Discord and Notion all had their
tokens set and were flagged only because python-telegram-bot, discord.py
and notion-client are not installed in the venv. That is a correct
verdict the page had no way to communicate.

WHAT IT SURVIVED

552 deterministic evals (was 550), ruff clean. The new regression test
pins the distinction from both sides: a filled-in Tavily must be
CONFIGURED, and a half-filled Notion must still say needs setup and name
the field it is missing. The existing health-persistence test was
asserting the old message and now asserts the new state — proof the
suite would have caught this had the state existed to assert on.

Verified live at 1155px: 3 configured, 3 needs-setup each naming its
missing extra, 4 not configured.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
