### PR TITLE
ui/memory arena tab

### DIFF
--- a/evals/deterministic/test_memory_arena.py
+++ b/evals/deterministic/test_memory_arena.py
@@ -17,6 +17,8 @@ a legal probe where the deadline was never given.
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from waku.ops import memory_arena as arena
@@ -61,13 +63,17 @@ def test_declining_gracefully_passes_the_restraint_probe():
     assert certain is False
 
 
-def test_a_legal_deadline_that_was_never_given_is_invented():
-    """The business-track version, and the one with real consequences: an
-    invented filing date is a missed court date, not a bad reply."""
-    probe = arena.load_fixture()["tracks"]["business"]["probes"][2]
-    assert probe["id"] == "business-restraint"
-    outcome, _, _ = arena.score("The filing deadline is 14 October.", probe)
-    assert outcome == INVENTED
+def test_inventing_a_deadline_that_was_never_given_is_invented():
+    """The version with real consequences. An assistant that makes up a filing
+    date has not been unhelpful, it has caused a missed court date — which is
+    why INVENTED is scored apart from MISS rather than both counting as "fail".
+
+    Written against an inline probe on purpose: the scorer's behaviour must not
+    depend on which fixture happens to be loaded, since the interesting probe
+    sets live outside this repo (see WAKU_MEMORY_PROBES)."""
+    probe = {"expect_refusal": True}
+    assert arena.score("The filing deadline is 14 October.", probe)[0] == INVENTED
+    assert arena.score("You never gave me a deadline for that.", probe)[0] == PASS
 
 
 # --- the two probe types that need more than a substring ---------------------
@@ -125,9 +131,10 @@ FIXTURE = arena.load_fixture()
 PROBES = [(t, p) for t, spec in FIXTURE["tracks"].items() for p in spec["probes"]]
 
 
-def test_both_tracks_run_the_same_four_tests():
-    """Two audiences, one methodology. If the business track quietly tested
-    something else, the two scoreboards couldn't be compared."""
+def test_every_track_runs_the_same_four_tests():
+    """One methodology, however many tracks a probe file defines. A track that
+    quietly tested something else could not be compared against the others on
+    the same scoreboard."""
     for track, spec in FIXTURE["tracks"].items():
         tests = {p["test"] for p in spec["probes"]}
         assert tests == {"recall", "update", "restraint", "reasoning"}, track
@@ -162,3 +169,29 @@ def test_the_superseded_fact_was_actually_said_during_seeding():
         for probe in spec["probes"]:
             for stale in probe.get("stale_any", []):
                 assert stale.casefold() in seed, f"{probe['id']}: {stale} never seeded"
+
+
+# --- where the probes come from ----------------------------------------------
+
+def test_the_shipped_fixture_is_only_an_example():
+    """waku ships the mechanism, not the questions. The bundled probes exist to
+    document the format and give this file something to grade; a real benchmark
+    is against facts the maintainer's own users store. If this ever stops being
+    an example, the repo has started carrying somebody's content."""
+    assert arena.load_fixture()["is_example"] is True
+    assert arena.fixture_path() == arena._EXAMPLE
+
+
+def test_probes_can_be_pointed_somewhere_else(monkeypatch, tmp_path):
+    mine = tmp_path / "probes.json"
+    mine.write_text(json.dumps({"tracks": {"mine": {"label": "Mine", "seed": ["hi"], "probes": [
+        {"id": "x", "test": "recall", "question": "?", "expect_any": ["y"], "note": "n"}]}}}),
+        encoding="utf-8")
+    monkeypatch.setenv(arena.PROBES_ENV, str(mine))
+
+    fixture = arena.load_fixture()
+
+    assert arena.fixture_path() == mine
+    assert list(fixture["tracks"]) == ["mine"]
+    assert fixture["is_example"] is False, "a caller's own probes must not claim to be the example"
+    assert fixture["source"] == str(mine), "the UI names the file it scored, so it cannot be a guess"

--- a/evals/memory_arena.json
+++ b/evals/memory_arena.json
@@ -1,137 +1,70 @@
 {
   "_doc": [
-    "The memory bake-off's fixture: what every contestant gets told, and what it",
-    "is then asked. One file so a run is reproducible and a viewer can check the",
-    "questions were not tilted.",
+    "The example fixture for the memory bake-off: four probes, one per test.",
     "",
-    "JSON, not JSONL, on purpose. evals/dataset.jsonl is a stream of independent",
-    "cases; this is one structured fixture with two halves (seed, then probes)",
-    "that only mean anything together.",
+    "Deliberately dull. This file exists to document the FORMAT and to give the",
+    "scorer's tests something to grade — it is not the benchmark anyone should",
+    "care about. Bring your own:",
     "",
-    "SEEDING IS CONVERSATIONAL, and that is a fairness decision. Mem0's whole",
-    "product is deciding for itself what is worth remembering; handing every",
-    "backend a pre-extracted fact list via add() would skip the feature it exists",
-    "to provide. So every system hears the same sentences a user would say.",
+    "    WAKU_MEMORY_PROBES=/path/to/your/probes.json",
     "",
-    "Two tracks, same four tests. 'dinner' is the one you watch; 'business' is",
-    "the one a CTO screenshots. Failures cost differently: forgetting Jensen's",
-    "jacket is funny, inventing a legal filing deadline is a missed court date.",
+    "waku ships the mechanism (waku/ops/memory_arena.py scores it, the Arena's",
+    "Memory tab renders whatever is loaded). The questions are yours, and they",
+    "should be: a memory benchmark is only meaningful against the kind of facts",
+    "your users actually store.",
     "",
-    "Each probe declares what a right answer contains, and — more usefully —",
-    "what a WRONG one contains. That is what separates 'I don't know' (honest)",
-    "from 'the launch is in March' (confidently stale) from an invented fact.",
-    "See waku/ops/memory_arena.py for how the three outcomes are scored."
+    "SEEDING IS CONVERSATIONAL, and that is a fairness decision. Some backends",
+    "sell their own extraction step — deciding for themselves what is worth",
+    "remembering. Handing every backend a pre-extracted fact list would skip the",
+    "feature half of them exist to provide, so each hears the same sentences a",
+    "user would type.",
+    "",
+    "Each probe declares what a right answer contains and — more usefully — what",
+    "a WRONG one contains. That is what separates 'I don't know' (honest) from a",
+    "confidently superseded answer. See waku/ops/memory_arena.py for how the four",
+    "outcomes are scored."
   ],
 
   "tracks": {
-    "dinner": {
-      "label": "The dinner party",
+    "example": {
+      "label": "Example — a working week",
       "seed": [
-        "I'm planning a dinner party. Let me tell you about the guests.",
-        "Jensen's coming — he wears that leather jacket to absolutely everything, even breakfast.",
-        "Paul Graham will be there. He'd rather write an essay than sit through a meeting.",
-        "Elon's coming too. He told me the launch is in March.",
-        "Tom Holland's on the list. Do not tell him anything you want kept secret.",
-        "Sam is coming, and they've got a big announcement dropping soon.",
-        "And Pikachu's coming, obviously.",
-        "Update on Elon — the launch moved to June."
+        "Let me tell you about this week so you can keep track.",
+        "Priya prefers morning meetings — she's heads-down after lunch.",
+        "The design review is on Tuesday.",
+        "Marcus is out of office on Thursday and Friday.",
+        "Correction: the design review moved to Wednesday."
       ],
       "probes": [
         {
-          "id": "dinner-recall-exact",
+          "id": "example-recall",
           "test": "recall",
-          "question": "What does Jensen always wear?",
-          "expect_any": ["leather jacket", "leather"],
-          "note": "The floor. A system that misses this stored nothing."
+          "question": "When does Priya like to meet?",
+          "expect_any": ["morning"],
+          "note": "The floor. A backend that misses this stored nothing."
         },
         {
-          "id": "dinner-recall-paraphrase",
-          "test": "recall",
-          "question": "What's Jensen's usual outfit?",
-          "expect_any": ["leather jacket", "leather"],
-          "note": "Same fact, none of the same words. Keyword stores lose here and vector stores win — this is the probe waku is expected to fail."
-        },
-        {
-          "id": "dinner-recall-chinese",
-          "test": "recall",
-          "question": "保罗·格雷厄姆最不喜欢做什么？",
-          "expect_any": ["meeting", "essay", "会议", "开会"],
-          "note": "Asked in a language it was never told in. unicode61 does not segment CJK, so waku matches prefix-only here."
-        },
-        {
-          "id": "dinner-update",
+          "id": "example-update",
           "test": "update",
-          "question": "When is the launch?",
-          "expect_any": ["June"],
-          "stale_any": ["March"],
-          "note": "THE test. Both facts were stated; only the newer one is true. Answering March is not a miss, it is a confident wrong answer."
+          "question": "When is the design review?",
+          "expect_any": ["Wednesday"],
+          "stale_any": ["Tuesday"],
+          "note": "Both days were stated; only the later one is true. Answering Tuesday is not a gap in knowledge, it is a confident wrong answer — which is why stale is scored apart from miss."
         },
         {
-          "id": "dinner-restraint-invent",
+          "id": "example-restraint",
           "test": "restraint",
-          "question": "What is Pikachu's favourite food?",
+          "question": "What is Priya's phone number?",
           "expect_refusal": true,
-          "note": "Pikachu IS a seeded guest, but no food was ever mentioned. Knowing the entity is what makes a system confident enough to fill the gap — a system that invents an answer here is the one that lies."
+          "note": "Priya was introduced, but no number ever was. Knowing the person is what makes a system confident enough to fill the gap — inventing one here is the failure that matters outside a demo."
         },
         {
-          "id": "dinner-restraint-gate",
-          "test": "restraint",
-          "question": "What's 17 times 4?",
-          "expect_any": ["68"],
-          "expect_retrieval": false,
-          "note": "Nothing about the user's life. Retrieving here wastes a call and risks biasing the answer with irrelevant memory. Only scorable on backends that expose a retrieval decision."
-        },
-        {
-          "id": "dinner-reasoning",
+          "id": "example-reasoning",
           "test": "reasoning",
-          "question": "Is there anyone I should avoid seating next to each other?",
-          "expect_any": ["tom", "holland"],
-          "expect_all": ["sam"],
-          "note": "Neither fact answers this alone: Tom cannot keep a secret AND Sam has an unannounced announcement. Requires finding two and combining them."
-        }
-      ]
-    },
-
-    "business": {
-      "label": "The business track",
-      "seed": [
-        "Let me brief you on a few live client matters.",
-        "The German buyer for the cosmetics order requires vegan certification on every SKU.",
-        "On the Riverside project, the client approved steel spec S355 back in March.",
-        "Guest in room 402 has complained twice about noise.",
-        "The wedding party has booked the ballroom directly below room 402 for Saturday night.",
-        "Correction on Riverside — the client changed the steel spec to S275 in May."
-      ],
-      "probes": [
-        {
-          "id": "business-recall",
-          "test": "recall",
-          "question": "Any special requirements on the German cosmetics order?",
-          "expect_any": ["vegan"],
-          "note": "Export sales. Forgetting this ships a container that gets rejected at the border."
-        },
-        {
-          "id": "business-update",
-          "test": "update",
-          "question": "Which steel spec are we building Riverside to?",
-          "expect_any": ["S275"],
-          "stale_any": ["S355"],
-          "note": "Construction. A stale answer here is not a bad reply — it is the wrong building, and the rework is physical."
-        },
-        {
-          "id": "business-restraint",
-          "test": "restraint",
-          "question": "What's the filing deadline on the Riverside contract dispute?",
-          "expect_refusal": true,
-          "note": "Legal. No deadline was ever given. An invented date is not a bad UX — it is a missed court date. This is the probe every system is most likely to fail, including waku."
-        },
-        {
-          "id": "business-reasoning",
-          "test": "reasoning",
-          "question": "Any problem with Saturday night's bookings?",
-          "expect_any": ["402"],
-          "expect_all": ["ballroom", "noise"],
-          "note": "Hotel. Two facts, neither sufficient alone: a guest already complaining about noise, and a wedding booked directly below them."
+          "question": "Can Marcus make the design review?",
+          "expect_any": ["yes", "can", "able"],
+          "expect_all": ["Wednesday"],
+          "note": "Neither fact answers this alone: the review moved to Wednesday AND Marcus is only away Thursday and Friday. Requires finding two and combining them."
         }
       ]
     }

--- a/waku/ops/dashboard.py
+++ b/waku/ops/dashboard.py
@@ -898,6 +898,19 @@ class Handler(BaseHTTPRequestHandler):
         elif self.path == "/api/compare/history":
             runs = compare_history.load_runs(load_settings().home)
             self._send(json.dumps(history_response(runs)).encode(), "application/json")
+        elif self.path == "/api/memory-arena":
+            # The bake-off fixture, so the Arena's Memory tab can show WHAT is
+            # being asked before any of it has been run. It lives in evals/,
+            # which a wheel does not ship — a pip-installed Waku answers with
+            # `available: false` instead of 500ing on a file that was never
+            # meant to be there.
+            from waku.ops import memory_arena
+
+            try:
+                self._send(json.dumps({"available": True, **memory_arena.load_fixture()}).encode(),
+                           "application/json")
+            except (OSError, ValueError):
+                self._send(json.dumps({"available": False}).encode(), "application/json")
         elif self.path.startswith("/api/models"):
             from urllib.parse import parse_qs, urlparse
 

--- a/waku/ops/memory_arena.py
+++ b/waku/ops/memory_arena.py
@@ -39,9 +39,15 @@ costs money, and it is deliberately thin.
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
-_FIXTURE = Path(__file__).resolve().parents[2] / "evals" / "memory_arena.json"
+# The shipped fixture is four dull probes whose only job is to document the
+# format. The interesting questions are the ones a maintainer brings — a memory
+# benchmark is only meaningful against the kind of facts their users store — so
+# the file is swappable and waku keeps the mechanism, not the content.
+_EXAMPLE = Path(__file__).resolve().parents[2] / "evals" / "memory_arena.json"
+PROBES_ENV = "WAKU_MEMORY_PROBES"
 
 PASS, STALE, INVENTED, MISS = "pass", "stale", "invented", "miss"
 
@@ -54,16 +60,36 @@ PASS, STALE, INVENTED, MISS = "pass", "stale", "invented", "miss"
 # judge instead of grading every probe with a model it doesn't need.
 _REFUSALS = (
     "don't know", "do not know", "not sure", "no information", "no record",
-    "never told", "never mentioned", "didn't tell", "did not tell",
-    "didn't mention", "did not mention", "haven't told", "have not told",
-    "haven't mentioned", "you haven't", "you have not", "not in my memory",
+    "never told", "never mentioned", "never gave", "never shared",
+    "didn't tell", "did not tell", "didn't mention", "did not mention",
+    "didn't give", "did not give", "haven't told", "have not told",
+    "haven't given", "have not given", "haven't mentioned",
+    "you haven't", "you have not", "not in my memory",
     "don't have", "do not have", "nothing about", "no details", "wasn't specified",
     "not specified", "unable to find", "couldn't find", "could not find",
 )
+# This list will never be complete — models decline in more ways than anyone can
+# enumerate, and a missed phrasing scores an honest refusal as INVENTED, which is
+# the worst direction to be wrong in. That is exactly what `certain=False` is
+# for: every verdict resting on this list is flagged so a judge can settle it.
+
+
+def fixture_path() -> Path:
+    """Where the probes are coming from. WAKU_MEMORY_PROBES wins, so a run can
+    be pointed at a real question set without editing anything in the repo."""
+    override = os.getenv(PROBES_ENV, "").strip()
+    return Path(override).expanduser() if override else _EXAMPLE
 
 
 def load_fixture(path: Path | None = None) -> dict:
-    return json.loads((path or _FIXTURE).read_text(encoding="utf-8"))
+    """The probes, plus where they came from — the UI says so on screen, because
+    'which questions was this scored against' is the first thing anyone should
+    ask of a benchmark, and the answer must not be a guess."""
+    source = path or fixture_path()
+    fixture = json.loads(source.read_text(encoding="utf-8"))
+    fixture["source"] = str(source)
+    fixture["is_example"] = source == _EXAMPLE
+    return fixture
 
 
 def _has(haystack: str, needles) -> bool:

--- a/waku/ops/static/js/compare.js
+++ b/waku/ops/static/js/compare.js
@@ -334,7 +334,19 @@ function compareCol(res){
   </div>`;
 }
 
-VIEWS.compare = function(d){
+// The Arena runs two races, and they are the same machine with a different
+// dial: Models holds the harness constant and varies the brain; Memory holds
+// the harness AND the brain constant and varies where facts live. Sub-tabs
+// rather than two sidebar rows, so "Models" doesn't appear twice in the nav
+// (once as a race, once as configuration) — the same reason Memory keeps
+// semantic / episodic / skills behind tabs instead of four sidebar entries.
+VIEWS.compare = function(d, sub){
+  sub = sub === "memory" ? "memory" : "models";
+  const bar = subtabBar("compare", [["models","Models"],["memory","Memory"]], sub);
+  return bar + (sub === "memory" ? memoryArenaView() : modelArenaView(d));
+};
+
+function modelArenaView(d){
   const pinned = compareModels(d);
   const chips = pinned.length ? pinned.map(p => {
     const spec = `${p.provider}:${p.model}`, on = compareState.picked.has(spec);
@@ -419,7 +431,81 @@ VIEWS.compare = function(d){
       oninput="compareState.message=this.value">${esc(compareState.message)}</textarea>
     <div class="cmp-picks">${chips}</div>
   </div>${grid}${compareHistoryHtml()}`;
-};
+}
+
+// --- Memory arena -----------------------------------------------------------
+// Same four tests, two tracks. Until a runner exists this tab shows the
+// FIXTURE: what every contestant is told and what it is then asked. That is
+// deliberately not a placeholder — a benchmark whose questions you cannot read
+// is a benchmark you have to take on faith, and the whole point of this one is
+// that the numbers are checkable.
+let memoryArenaFixture;   // undefined = not fetched, null = unavailable here
+
+async function loadMemoryArena(){
+  try {
+    const r = await fetch("/api/memory-arena");
+    const j = await r.json();
+    memoryArenaFixture = j && j.available ? j : null;
+  } catch { memoryArenaFixture = null; }
+  render();
+}
+
+const OUTCOME_HELP = [
+  ["pass", "the expected answer is there"],
+  ["stale", "the expected answer is missing and a SUPERSEDED one is asserted"],
+  ["invented", "a refusal was correct and it answered anyway — the fact was never given"],
+  ["miss", "the expected answer is missing and nothing wrong was asserted"],
+];
+
+function probeRow(p){
+  const expect = p.expect_refusal
+    ? `<span class="ma-expect">must decline</span>`
+    : `<span class="ma-expect">${esc((p.expect_any||[]).join(" / "))}</span>`
+      + ((p.expect_all||[]).length ? ` <span class="meta">+ ${esc(p.expect_all.join(", "))}</span>` : "");
+  const forbid = (p.stale_any||[]).length
+    ? `<span class="ma-forbid">${esc(p.stale_any.join(" / "))}</span>` : '<span class="meta">—</span>';
+  return `<tr>
+    <td><code>${esc(p.test)}</code></td>
+    <td>${esc(p.question)}</td>
+    <td>${expect}</td>
+    <td>${forbid}</td>
+    <td class="meta">${esc(p.note||"")}</td></tr>`;
+}
+
+function memoryArenaView(){
+  if (memoryArenaFixture === undefined){
+    setTimeout(loadMemoryArena, 0);
+    return `<div class="card empty">loading the fixture…</div>`;
+  }
+  if (memoryArenaFixture === null){
+    return `<div class="card empty">The bake-off fixture lives in <code>evals/memory_arena.json</code>,
+      which a packaged install does not ship. Run Waku from a clone to see it.</div>`;
+  }
+  const tracks = Object.entries(memoryArenaFixture.tracks).map(([key, t]) => `
+    <h2 style="margin-top:22px">${esc(t.label)}
+      <span class="meta" style="font-weight:400">— ${t.probes.length} probes</span></h2>
+    <div class="card">
+      <div class="meta" style="margin-bottom:8px">Seeded conversationally, in this order — the same
+        sentences a user would type. Handing each backend a pre-extracted fact list would skip the
+        extraction step that is half of what some of them sell.</div>
+      <ol class="ma-seed">${t.seed.map(s=>`<li>${esc(s)}</li>`).join("")}</ol>
+    </div>
+    <div class="card" style="padding:4px 8px"><div class="tablescroll"><table>
+      <tr><th>test</th><th>question</th><th>expects</th><th>must not say</th><th>why</th></tr>
+      ${t.probes.map(probeRow).join("")}
+    </table></div></div>`).join("");
+
+  return `<div class="card">
+    <div class="meta">One agent, one model, one loop — only the memory backend changes. Four tests:
+      <b>recall</b> (can it get the fact back), <b>update</b> (does the newest fact win),
+      <b>restraint</b> (does it invent things it was never told), <b>reasoning</b> (can it combine two).
+      Scored by <code>waku/ops/memory_arena.py</code>; tokens counted on every probe.</div>
+    <div class="ma-legend">${OUTCOME_HELP.map(([k,v])=>
+      `<div><span class="ma-o ma-${k}">${k}</span> <span class="meta">${esc(v)}</span></div>`).join("")}</div>
+    <div class="meta" style="margin-top:10px">No runs yet — the runner needs the Mem0 / Zep / LangMem
+      adapters, which are not wired up. Everything below is what they will be asked.</div>
+  </div>${tracks}`;
+}
 
 // The cumulative view under the current race: a per-model scoreboard averaged
 // across every logged race, then the list of recent races (click to reopen).

--- a/waku/ops/static/js/compare.js
+++ b/waku/ops/static/js/compare.js
@@ -502,6 +502,10 @@ function memoryArenaView(){
       Scored by <code>waku/ops/memory_arena.py</code>; tokens counted on every probe.</div>
     <div class="ma-legend">${OUTCOME_HELP.map(([k,v])=>
       `<div><span class="ma-o ma-${k}">${k}</span> <span class="meta">${esc(v)}</span></div>`).join("")}</div>
+    <div class="ma-source">${memoryArenaFixture.is_example
+      ? `Scoring the shipped <b>example</b> probes — four dull questions that document the format.
+         Point <code>WAKU_MEMORY_PROBES</code> at your own file to score something you care about.`
+      : `Probes: <code>${esc(memoryArenaFixture.source)}</code>`}</div>
     <div class="meta" style="margin-top:10px">No runs yet — the runner needs the Mem0 / Zep / LangMem
       adapters, which are not wired up. Everything below is what they will be asked.</div>
   </div>${tracks}`;

--- a/waku/ops/static/js/main.js
+++ b/waku/ops/static/js/main.js
@@ -10,7 +10,11 @@ let activeView = null, activeSub = null;
 // which is a behaviour, not a setting.
 const TITLES = {chat:"Chat & watch", ops:"LLM Ops",
                 graph:"Graph workflows — structure around the loop",
-                compare:"Arena — race models through the real loop",
+                // Covers both sub-tabs. TITLES is keyed by view, not by view+sub,
+                // so a models-only title sat above the Memory race and read as a
+                // mislabel; one honest sentence beats teaching the router about
+                // sub-tabs for a single page.
+                compare:"Arena — race models and memory through the same loop",
                 settings:"Behaviour — how a turn runs",
                 database:"Database — everything Waku stores (state.db)"};
 function render(){

--- a/waku/ops/static/style.css
+++ b/waku/ops/static/style.css
@@ -587,3 +587,17 @@ details.subterm > summary.subterm-h::-webkit-details-marker{ display:none; }
   .connmodal-actions .save{flex:1}
   .connmodal-message{flex-basis:100%}
 }
+
+/* --- Memory arena: the fixture, readable before any of it has been run --- */
+.ma-seed{margin:0;padding-left:20px;font-size:13px;color:var(--ink2);line-height:1.7}
+.ma-seed li{margin:1px 0}
+.ma-legend{display:flex;flex-wrap:wrap;gap:6px 18px;margin-top:10px;font-size:12px}
+.ma-o{font-family:var(--mono);font-size:11px;padding:1px 7px;border-radius:99px;border:1px solid var(--line2)}
+.ma-pass{color:var(--good);border-color:var(--good)}
+.ma-stale{color:#a87312;border-color:#c8951f}
+/* invented is the headline failure — a confident answer to something it was
+   never told. It gets the alarm colour; miss, an honest gap, deliberately does not. */
+.ma-invented{color:var(--bad);border-color:var(--bad)}
+.ma-miss{color:var(--ink3)}
+.ma-expect{color:var(--good);font-family:var(--mono);font-size:12px}
+.ma-forbid{color:var(--bad);font-family:var(--mono);font-size:12px}

--- a/waku/ops/static/style.css
+++ b/waku/ops/static/style.css
@@ -601,3 +601,5 @@ details.subterm > summary.subterm-h::-webkit-details-marker{ display:none; }
 .ma-miss{color:var(--ink3)}
 .ma-expect{color:var(--good);font-family:var(--mono);font-size:12px}
 .ma-forbid{color:var(--bad);font-family:var(--mono);font-size:12px}
+.ma-source{margin-top:10px;padding:8px 10px;border-radius:6px;background:var(--accent-soft);
+           color:var(--ink2);font-size:12px;line-height:1.6}


### PR DESCRIPTION
- **feat(ui): a Memory tab in the Arena, showing what the bake-off actually asks**
- **refactor: waku ships the memory benchmark's mechanism, not its questions**
