### PR TITLE
fix: a model name belongs to the provider it was configured for

### DIFF
--- a/evals/deterministic/test_providers.py
+++ b/evals/deterministic/test_providers.py
@@ -179,3 +179,99 @@ def test_every_priced_model_has_a_knowledge_cutoff():
     # The motivating case, plus the unknown-model path (no guessing).
     assert cutoff_for("gemini-3.1-pro-preview") == "2025-01"
     assert cutoff_for("some-future-model") is None
+
+
+# --- a model name belongs to the provider it was configured for --------------
+# Found live: `.venv/bin/python examples/tiny_memory_agent.py` under
+# WAKU_PROVIDER=xai printed "gate failed open (BadRequestError)". WAKU_SMALL_MODEL
+# is global, so anthropic's gate model was sent to xAI, which 400s. The retrieval
+# gate fails open on error BY DESIGN, so this did not surface as a failure — it
+# surfaced as "retrieve", on every turn, for every non-anthropic model in the
+# arena. These pin the rule that stops it.
+
+def test_env_model_names_do_not_leak_into_another_provider(monkeypatch):
+    from waku.config import Settings
+    from waku.loop.models import get_client
+
+    monkeypatch.setenv("WAKU_PROVIDER", "anthropic")
+    monkeypatch.setenv("WAKU_MODEL", "claude-fable-5")
+    monkeypatch.setenv("WAKU_SMALL_MODEL", "claude-haiku-4-5-20251001")
+    monkeypatch.setenv("XAI_API_KEY", "test-key")
+
+    settings = Settings(provider="xai")
+    get_client(settings)
+
+    assert settings.model == "grok-4", "anthropic's model was sent to xAI"
+    assert settings.small_model == "grok-4-fast", (
+        "anthropic's gate model was sent to xAI — the gate 400s and fails open, "
+        "so this bug reports itself as a healthy 'retrieve' forever"
+    )
+
+
+def test_an_explicit_model_survives_the_provider_switch(monkeypatch):
+    """The rule drops INHERITED env values, not deliberate ones. Without this
+    the fix would quietly override the arena's own model picker."""
+    from waku.config import Settings
+    from waku.loop.models import get_client
+
+    monkeypatch.setenv("WAKU_PROVIDER", "anthropic")
+    monkeypatch.setenv("WAKU_MODEL", "claude-fable-5")
+    monkeypatch.setenv("XAI_API_KEY", "test-key")
+
+    settings = Settings(provider="xai", model="grok-4.3")
+    get_client(settings)
+
+    assert settings.model == "grok-4.3"
+
+
+def test_the_env_still_wins_for_its_own_provider(monkeypatch):
+    """The whole point of WAKU_MODEL is to override the default — the fix must
+    not break the ordinary single-provider case."""
+    from waku.config import Settings
+    from waku.loop.models import get_client
+
+    monkeypatch.setenv("WAKU_PROVIDER", "anthropic")
+    monkeypatch.setenv("WAKU_MODEL", "claude-fable-5")
+    monkeypatch.setenv("WAKU_SMALL_MODEL", "claude-haiku-4-5-20251001")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+    settings = Settings(provider="anthropic")
+    get_client(settings)
+
+    assert settings.model == "claude-fable-5"
+    assert settings.small_model == "claude-haiku-4-5-20251001"
+
+
+def test_a_foreign_gate_model_is_dropped_even_when_the_env_names_the_provider(monkeypatch):
+    """The case that was actually live in Sean's .env: WAKU_PROVIDER=xai with
+    WAKU_SMALL_MODEL still holding anthropic's gate model. Scoping by "did the
+    caller switch provider" missed this one — the env agreed with itself and was
+    still wrong."""
+    from waku.config import Settings
+    from waku.loop.models import get_client
+
+    monkeypatch.setenv("WAKU_PROVIDER", "xai")
+    monkeypatch.setenv("WAKU_SMALL_MODEL", "claude-haiku-4-5-20251001")
+    monkeypatch.setenv("XAI_API_KEY", "test-key")
+
+    settings = Settings(provider="xai")
+    get_client(settings)
+
+    assert settings.small_model == "grok-4-fast"
+
+
+def test_an_unfamiliar_model_name_is_left_alone(monkeypatch):
+    """The check asks "is this positively someone else's?", not "does it look
+    like ours?". The second question would silently downgrade any id we don't
+    recognise — a preview name, a model released after this code was written."""
+    from waku.config import Settings
+    from waku.loop.models import get_client
+
+    monkeypatch.setenv("WAKU_PROVIDER", "kimi")
+    monkeypatch.setenv("WAKU_SMALL_MODEL", "moonshot-v1-8k")
+    monkeypatch.setenv("MOONSHOT_API_KEY", "test-key")
+
+    settings = Settings(provider="kimi")
+    get_client(settings)
+
+    assert settings.small_model == "moonshot-v1-8k", "a deliberate choice was overridden"

--- a/waku/loop/models.py
+++ b/waku/loop/models.py
@@ -203,6 +203,35 @@ def _no_key_message(name: str, key_env: str) -> str:
     )
 
 
+def _families(provider: Provider) -> set[str]:
+    """The model FAMILIES this provider ships — "claude", "grok", "gemini"...
+
+    Taken from the provider's own four defaults rather than a hand-kept list, so
+    a new provider is covered the moment it is added. Aggregators whose ids are
+    vendor-namespaced ("anthropic/claude-3" on openrouter) are excluded by the
+    caller: for them the first segment names a VENDOR, not the host.
+    """
+    names = (provider.model, provider.small_model, provider.flagship, provider.fast)
+    return {n.split("-")[0].lower() for n in names if n and "/" not in n}
+
+
+def _belongs_elsewhere(model: str, provider_name: str) -> bool:
+    """Is this model name positively another provider's?
+
+    Deliberately asks the POSITIVE question. "Does it not look like ours?" would
+    drop anything unfamiliar — a legitimately odd id, a preview name, a model
+    added since — and silently downgrade a deliberate choice. This only fires
+    when the family is one some OTHER provider actually owns, which is the case
+    that produces a 400 rather than a surprise.
+    """
+    family = model.split("-")[0].lower()
+    if "/" in model or not family:
+        return False
+    owner = {f: name for name, p in PROVIDERS.items() if "/" not in (p.model or "x")
+             for f in _families(p)}.get(family)
+    return bool(owner) and owner != provider_name
+
+
 def get_client(settings: Settings):
     """Build the client for settings.provider and fill in default model ids.
     Returns anything with .messages.create(...) in the Anthropic shape."""
@@ -223,6 +252,25 @@ def get_client(settings: Settings):
             f"{provider.key_env} contains a non-ASCII character (e.g. a smart quote "
             f"or arrow from a bad paste). Re-paste the key with no spaces or line breaks."
         )
+
+    # A model name belongs to the provider it was configured FOR. WAKU_MODEL and
+    # WAKU_SMALL_MODEL are global, so code that switches provider — the arena
+    # races ten of them — carried anthropic's gate model to xAI, which answers
+    # `400 Model not found: claude-haiku-4-5-20251001`. The retrieval gate then
+    # FAILS OPEN by design, so it retrieved on every single turn for every
+    # non-anthropic model instead of deciding, and reported that as a normal
+    # "retrieve". A silent permanent failure wearing the costume of a healthy
+    # decision.
+    #
+    # So: a value INHERITED from the env for a different provider is dropped
+    # (the provider's own default fills in below); a value the caller passed
+    # explicitly is kept, because that is a choice, not a leak. The two are
+    # distinguishable exactly when the setting still equals the env string.
+    for attr in ("model", "small_model"):
+        inherited = os.getenv(f"WAKU_{attr.upper()}", "").strip()
+        if inherited and getattr(settings, attr) == inherited \
+                and _belongs_elsewhere(inherited, settings.provider):
+            setattr(settings, attr, "")
 
     settings.model = settings.model or provider.model
     settings.small_model = settings.small_model or provider.small_model


### PR DESCRIPTION
## What this is

`WAKU_MODEL` / `WAKU_SMALL_MODEL` are global, so any non-anthropic provider was sent anthropic's gate model:

```
400 Model not found: claude-haiku-4-5-20251001
```

The retrieval gate **fails open by design** — correct for a network blip, wrong forever for a name that will never resolve. So it never looked broken. It looked like it decided `retrieve`, every turn, for every non-anthropic model, including for *"what is 17 times 4"*.

## Why it matters

**8 of the 10 pinned arena models are non-anthropic.** Their `gate · retrieve` chips were not decisions — they were failures wearing a decision's costume. Any gate statistic taken from a non-anthropic race is invalid.

## The rule

An **inherited** env value whose family is **positively owned** by another provider is dropped; the provider's own default fills in.

- **inherited, not explicit** — the arena's own model picker still wins
- **positively owned** — asks "is this someone else's?", never "does this look like ours?"; `moonshot-v1-8k` on kimi is left alone
- **families derive from each provider's own defaults** — a new provider is covered when it is added; openrouter-style `vendor/model` ids are excluded

## How to test it together

```bash
WAKU_PROVIDER=xai .venv/bin/python examples/tiny_memory_agent.py --demo "What is 17 times 4?"
```

Before: `gate : retrieve — gate failed open (BadRequestError)`
After: `gate : skip — Math question no memory`

## Ready?

Tests: 564 deterministic pass, ruff clean. All five new cases confirmed to **fail** against the unpatched source.

Not in scope, filed separately: the gate's API call bypasses `usage.jsonl`, so its spend is missing from the dashboard's all-time total.