### PR TITLE
fix(arena): run the judge, and clear the conversation before probing

### DIFF
--- a/evals/deterministic/test_memory_arena.py
+++ b/evals/deterministic/test_memory_arena.py
@@ -18,6 +18,7 @@ a legal probe where the deadline was never given.
 from __future__ import annotations
 
 import json
+from typing import ClassVar
 
 import pytest
 
@@ -245,12 +246,25 @@ class _FakeWaku:
     """Records what it was told, answers what the script says, and writes the
     same usage.jsonl the real app does — so token accounting is exercised too."""
 
+    built: ClassVar[list] = []   # every instance a run created, so a test can inspect it
+
     def __init__(self, settings=None, **kw):
+        from types import SimpleNamespace
         self.settings = settings
         self.seen: list[str] = []
         self.home = settings.home
         self.home.mkdir(parents=True, exist_ok=True)
         self._answers = dict(_FakeWaku.script)
+        self.client = object()
+        # The runner flushes consolidation and then CLEARS the session before
+        # probing, so a seeded fact can only be reached through the store. A
+        # fake that cannot do that would let the real thing regress silently —
+        # which is the whole reason the bypass survived until a live race.
+        self.memory = SimpleNamespace(conn=object(), facts=object(), episodes=object())
+        self.cleared_after: list[int] = []
+        self.session = SimpleNamespace(
+            start_new=lambda sid: self.cleared_after.append(len(self.seen)))
+        _FakeWaku.built.append(self)
 
     def respond(self, message, source="cli", observer=None, **kw):
         from types import SimpleNamespace
@@ -275,11 +289,24 @@ def _arena_fixture(tmp_path):
     return fx
 
 
+def _offline(monkeypatch, declined=None):
+    """No network. The consolidation flush and the referee are both real calls
+    in run_arena now; `declined=None` is the adjudicator's own "judge
+    unreachable" answer, which must leave the heuristic verdict untouched."""
+    from waku.memory import consolidation
+
+    monkeypatch.setattr(consolidation, "consolidate_if_due", lambda *a, **k: 0)
+    monkeypatch.setattr(arena, "adjudicate_refusal", lambda *a, **k: declined)
+
+
 def _run(monkeypatch, tmp_path, script, gate=False, backends=("sqlite",)):
     import waku.app
+
     _FakeWaku.script = script
     _FakeWaku.gate = gate
+    _FakeWaku.built = []
     monkeypatch.setattr(waku.app, "Waku", _FakeWaku)
+    _offline(monkeypatch)
     events = []
     arena.run_arena(list(backends), "t", lambda k, e: events.append((k, e)),
                     fixture=_arena_fixture(tmp_path))
@@ -324,6 +351,7 @@ def test_a_backend_that_blows_up_does_not_take_the_others_with_it(monkeypatch, t
 
     monkeypatch.setattr(_FakeWaku, "__init__", explode)
     monkeypatch.setattr(waku.app, "Waku", _FakeWaku)
+    _offline(monkeypatch)
     events = []
     arena.run_arena(["boom", "sqlite"], "t", lambda k, e: events.append((k, e)),
                     fixture=_arena_fixture(tmp_path))
@@ -344,6 +372,7 @@ def test_the_gate_decision_reaches_the_scorer(monkeypatch, tmp_path):
     _FakeWaku.script = {"q1?": "68"}
     _FakeWaku.gate = True          # it retrieved when it should not have
     monkeypatch.setattr(waku.app, "Waku", _FakeWaku)
+    _offline(monkeypatch)
     events = []
     arena.run_arena(["sqlite"], "t", lambda k, e: events.append((k, e)), fixture=fx)
 
@@ -360,3 +389,58 @@ def test_the_live_store_is_never_switched(monkeypatch, tmp_path):
     assert homes == {"sqlite", "mem0"}
     from waku.config import load_settings
     assert load_settings().semantic_store == "sqlite", "the real config must be untouched"
+
+
+# --- the two fixes this file exists to hold in place -------------------------
+
+def test_the_conversation_is_cleared_before_any_probe_is_asked(monkeypatch, tmp_path):
+    """history_turns is 12 (24 messages), and a track seeds far fewer than that,
+    so every seeded fact was still in the context window when the probes ran.
+    Three probes in the first honest race passed while the gate reported "no
+    lookup" — the store was never consulted. A benchmark whose subject can be
+    bypassed is not measuring it."""
+    events = _run(monkeypatch, tmp_path, {"q1?": "alpha", "q2?": "the new one"})
+    assert [e for k, e in events if k == "probe"], "the run must have happened"
+    app = _FakeWaku.built[0]
+    assert app.cleared_after == [2], (
+        "the session must be cleared exactly once, after the 2 seed lines and "
+        f"before any probe — got {app.cleared_after}"
+    )
+
+
+def test_an_unreachable_judge_leaves_the_heuristic_verdict_alone(monkeypatch, tmp_path):
+    """adjudicate_refusal returns None when the referee cannot be reached. That
+    must not be read as either verdict — an unavailable judge cannot turn "I
+    could not check" into "it passed" or "it lied"."""
+    fx = {"tracks": {"t": {"label": "T", "seed": ["s"], "probes": [
+        {"id": "p", "test": "restraint", "question": "q?", "expect_refusal": True, "note": "n"}]}}}
+    import waku.app
+
+    _FakeWaku.script = {"q?": "Pikachu loves ketchup."}
+    _FakeWaku.gate = False
+    monkeypatch.setattr(waku.app, "Waku", _FakeWaku)
+    _offline(monkeypatch)
+    events = []
+    arena.run_arena(["sqlite"], "t", lambda k, e: events.append((k, e)), fixture=fx)
+    row = next(e for k, e in events if k == "probe")
+    assert row["outcome"] == INVENTED
+    assert row["certain"] is False, "an unchecked verdict must still say it is unchecked"
+
+
+def test_the_judge_overrules_a_phrase_the_list_never_had(monkeypatch, tmp_path):
+    """The live miss: LangMem replied "Nothing shared about Pikachu's food
+    preferences" — a correct refusal — and scored INVENTED, because _REFUSALS
+    holds "nothing about" and not "nothing shared"."""
+    fx = {"tracks": {"t": {"label": "T", "seed": ["s"], "probes": [
+        {"id": "p", "test": "restraint", "question": "q?", "expect_refusal": True, "note": "n"}]}}}
+    import waku.app
+
+    _FakeWaku.script = {"q?": "Nothing shared about Pikachu's food preferences."}
+    _FakeWaku.gate = False
+    monkeypatch.setattr(waku.app, "Waku", _FakeWaku)
+    _offline(monkeypatch, declined=True)
+    events = []
+    arena.run_arena(["sqlite"], "t", lambda k, e: events.append((k, e)), fixture=fx)
+    row = next(e for k, e in events if k == "probe")
+    assert row["outcome"] == PASS, "a correct refusal must not be published as INVENTED"
+    assert row["certain"] is True

--- a/waku/ops/judge.py
+++ b/waku/ops/judge.py
@@ -57,6 +57,21 @@ Reply with ONLY a JSON object, no prose:
 {{"score": <int 0-10>, "reason": "<one short sentence>"}}"""
 
 
+def judge_client(provider: str | None = None, model: str | None = None):
+    """The referee's client and resolved model id, for callers whose question is
+    not the 0-10 rubric — the memory arena asks a binary "did this reply
+    decline?". Sharing this keeps one definition of who the referee is: a model
+    that isn't racing, configured in one place.
+
+    Returns (client, model_id). get_client fills in the provider's default when
+    the id is blank, so read the id back off settings rather than the argument.
+    """
+    settings = Settings(provider=provider or JUDGE_PROVIDER, model=model or JUDGE_MODEL,
+                        small_model="", home=load_settings().home, apple_calendar=False)
+    client = get_client(settings)
+    return client, settings.model
+
+
 def judge_reply(task: str, reply: str, provider: str | None = None,
                 model: str | None = None, tools: list | None = None) -> dict | None:
     """Grade one reply. `tools` is the list of tool names that ACTUALLY fired this

--- a/waku/ops/memory_arena.py
+++ b/waku/ops/memory_arena.py
@@ -171,6 +171,55 @@ def _has(haystack: str, needles) -> bool:
     return any(n.casefold() in low for n in needles)
 
 
+# --- the judge the scorer has always asked for ------------------------------
+# score() returns `certain=False` on every refusal verdict, because that verdict
+# rests on a phrase list that cannot be complete. The runner counted those rows
+# as `needs_judge` and then never judged them, so the list was the final word.
+#
+# It got one wrong in the first honest race: LangMem answered "Nothing shared
+# about Pikachu's food preferences" — a correct refusal — and scored INVENTED,
+# because _REFUSALS holds "nothing about" and not "nothing shared". INVENTED is
+# the headline number, and that is a public accusation against someone else's
+# product for doing the right thing. A benchmark may not publish a verdict it
+# cannot defend.
+
+_ADJUDICATE = """A user asked an assistant a question the assistant was never told the answer to.
+The only correct behaviour is to DECLINE — to say it does not know or has nothing on file.
+
+Question: {question}
+Reply: {answer}
+
+Did the reply DECLINE, or did it assert an answer? Wording varies enormously;
+judge the meaning, not the phrasing. A reply that declines and then adds general
+knowledge clearly marked as general knowledge still counts as declining.
+
+Reply with ONLY this JSON: {{"declined": true/false}}"""
+
+
+def adjudicate_refusal(question: str, answer: str) -> bool | None:
+    """Did this reply decline? True/False, or None if the judge is unreachable.
+
+    None is deliberate and is NOT treated as either verdict — an unavailable
+    judge must leave the heuristic's answer standing and say so, rather than
+    silently converting "I could not check" into "it passed" or "it lied".
+    """
+    from waku.ops import judge as _judge
+
+    try:
+        client, model = _judge.judge_client()
+        with _judge._JUDGE_SEM:   # same cap as the model arena: don't stampede the referee
+            reply = client.messages.create(
+                model=model, max_tokens=200,
+                messages=[{"role": "user",
+                           "content": _ADJUDICATE.format(question=question, answer=answer)}])
+        text = "".join(b.text for b in reply.content if b.type == "text")
+        if "{" not in text:
+            return None
+        return bool(json.loads(text[text.index("{"): text.rindex("}") + 1])["declined"])
+    except Exception:
+        return None
+
+
 def score(answer: str, probe: dict, retrieved: bool | None = None) -> tuple[str, bool, str]:
     """Grade one answer. Returns (outcome, certain, why).
 
@@ -283,6 +332,7 @@ def run_arena(backends: list[str], track: str, emit, fixture: dict | None = None
 
     from waku.app import Waku
     from waku.config import Settings
+    from waku.memory import consolidation
 
     # `model` is "provider:model". The arena holds the model CONSTANT and varies
     # only the store, so which model it is cannot change the finding — which
@@ -310,6 +360,32 @@ def run_arena(backends: list[str], track: str, emit, fixture: dict | None = None
                 app.respond(line, source="memory-arena")
                 emit("seeded", {"contestant": backend, "line": line})
 
+            # SEEDING IS DONE. Two things have to happen before the first probe,
+            # or this measures something other than memory.
+            #
+            # 1. FLUSH. Consolidation runs every N exchanges, so the tail of the
+            #    seed conversation can still be sitting unconsolidated in
+            #    chat_log — facts the store was never given. every_n=1 drains
+            #    it. If a fact still does not land, THAT is a finding about the
+            #    harness, and it is the same harness for every contestant.
+            # 2. FORGET THE CONVERSATION. history_turns is 12, so the prompt
+            #    carries the last 24 messages — and the dinner track seeds 8
+            #    exchanges, which is 16. Every seeded fact was therefore still
+            #    sitting in the context window when the probes ran, and the
+            #    model could answer without consulting the store at all. Three
+            #    probes did exactly that: they passed with the gate reporting
+            #    "no lookup", which means the contestant was never used. A
+            #    benchmark where the thing under test can be bypassed is not
+            #    measuring it.
+            #
+            #    This was invisible until the gate was fixed (#94). While the
+            #    gate was failing open, every probe reported "searched", so the
+            #    bypass never showed up on screen.
+            consolidation.consolidate_if_due(app.memory.conn, app.client,
+                                             app.settings.small_model, 1,
+                                             app.memory.facts, app.memory.episodes)
+            app.session.start_new("probes")
+
             # The ledger is cumulative, so each probe's cost is the DELTA. Storing
             # the running total per row would make scoreboard() sum a triangular
             # number and report several times the tokens actually spent — the
@@ -326,6 +402,22 @@ def run_arena(backends: list[str], track: str, emit, fixture: dict | None = None
                 turn = app.respond(probe["question"], source="memory-arena", observer=watch)
                 after, calls_now = _ledger(home)
                 outcome, certain, why = score(turn.reply, probe, gate.get("retrieved"))
+
+                # `certain=False` means the verdict came from the refusal phrase
+                # list, which cannot be complete. Ask the referee rather than let
+                # a missing phrase publish a false INVENTED. A judge that cannot
+                # be reached returns None and changes nothing — the heuristic
+                # stands, still flagged uncertain, which is the honest state.
+                if not certain:
+                    declined = adjudicate_refusal(probe["question"], turn.reply)
+                    if declined is True and outcome == INVENTED:
+                        outcome, certain, why = PASS, True, "declined — judge overruled the phrase list"
+                    elif declined is False and outcome == PASS:
+                        outcome, certain, why = (INVENTED, True,
+                                                 "asserted an answer — judge overruled the phrase list")
+                    elif declined is not None:
+                        certain, why = True, why + " (judge agreed)"
+
                 row = {"contestant": backend, "probe": probe["id"], "test": probe["test"],
                        "question": probe["question"], "answer": turn.reply,
                        "outcome": outcome, "certain": certain, "why": why,


### PR DESCRIPTION
## What this is

Two ways the memory arena published verdicts it had not earned.

**1. A false accusation.** `score()` flags every refusal verdict `certain=False` — the phrase list can't be complete. The runner counted those as `needs_judge` and **never judged them**. Live result: LangMem answered *"Nothing shared about Pikachu's food preferences"* — a correct refusal — and scored `INVENTED`, because `_REFUSALS` has `"nothing about"` but not `"nothing shared"`.

`INVENTED` is the headline number. That's a public accusation against someone else's product for doing the right thing.

**2. A bypass.** `history_turns=12` → 24 messages in the prompt. The dinner track seeds 8 exchanges = 16. Every seeded fact was still in the context window when probes ran, so the model could answer **without consulting the store at all**. Three probes did exactly that — passed while the gate said `no lookup`.

## Why it matters

sqlite scored **7/7 before, 5/7 after**. The perfect score was partly the model reading its own transcript.

The bypass was invisible until #94 — while the gate was failing open, every probe reported "searched".

## The rules

- An unreachable judge returns `None` and **changes nothing** — the heuristic stands, still flagged uncertain. "I could not check" never becomes "it passed" or "it lied".
- The runner flushes consolidation (`every_n=1`) before clearing, so facts still sitting unconsolidated aren't lost — if one still doesn't land, that's a finding about the harness, same harness for everyone.

## How to test it together

Race the dinner track on any store. Every row should now read `certain=True`, and the `no lookup` rows should genuinely have had no memory available.

## Ready?

567 deterministic pass, ruff clean. **Both fixes confirmed to bite** — disabling each one turns its test red. My first history test asserted `app is None or ...` and passed on broken code; caught by that same check.

**Not in scope, found while verifying — needs its own fix:** the dinner fixture is partly answerable from world knowledge. Jensen's leather jacket and Paul Graham disliking meetings are public facts; with an empty store and the real system prompt, the model answers both correctly. Those probes measure training data, not memory.