### PR TITLE
examples: four memory backends, each on its own terms

### DIFF
--- a/examples/memory-native/README.md
+++ b/examples/memory-native/README.md
@@ -1,0 +1,79 @@
+# Four memory backends, each on its own terms
+
+Four scripts. Each one uses a single memory product the way its own docs tell
+you to, with **no waku, no framework, and no shared interface**. Roughly 60
+lines each.
+
+They exist because waku's Arena tab does the opposite. The Arena drives all of
+these through one `FactStore` contract so it can score them fairly — and that
+contract is exactly what hides what makes each one different. The clearest
+case: to satisfy "a write must always store", the Arena calls mem0's `add()`
+with `infer=False`, which switches off the one feature mem0 is known for.
+
+So: read these first, race them second. The Arena's number means something
+quite different once you have seen what it flattened.
+
+## The five beats, identical in all four
+
+Every file does the same things in the same order, so you can put two of them
+side by side:
+
+1. **connect** — the platform's own idiom, not an adapter
+2. **write three sentences** — the same three, everywhere
+3. **read back raw** — what the store *kept*, next to what you *said*
+4. **ask three ways** — exact phrase, paraphrase, and the same question in 中文
+5. **where to look** — the console URL, or an honest "there is no console"
+
+The three sentences are chosen so the **third contradicts the second**:
+
+```
+I met Yuki at the Lisbon AI meetup in March. She runs a robotics startup.
+Our product launch is scheduled for May.
+Actually, the launch moved to June.
+```
+
+Watch what each store does with that. It is the single most revealing thing in
+the folder, and it is where they stop being interchangeable.
+
+## Running them
+
+```bash
+uv pip install -e '.[arena]'
+python examples/memory-native/langmem_native.py
+```
+
+Each script loads your repo-root `.env`, so no exports are needed. Each writes
+to its own quickstart partition (`quickstart-mem0`, `quickstart-zep`, …), never
+to the `waku` partition your real assistant uses.
+
+| file | needs | writes to |
+|---|---|---|
+| `langmem_native.py` | `ANTHROPIC_API_KEY`, `OPENAI_API_KEY` | RAM. Nothing survives the process. |
+| `mem0_native.py` | `MEM0_API_KEY` | your mem0 account, user `quickstart-mem0` |
+| `zep_native.py` | `ZEP_API_KEY` | your Zep project, user `quickstart-zep` |
+| `supabase_native.py` | `SUPABASE_URL`, `SUPABASE_KEY`, `OPENAI_API_KEY` | a table you create (SQL in the file header) |
+
+## What each one is actually for
+
+- **mem0** — decides what is worth remembering. You say a sentence, it stores a
+  different one. Step 3 is the whole product.
+- **Zep** — not rows, a temporal knowledge graph with validity intervals. When
+  you contradict yourself the old edge is marked invalid *at a point in time*
+  rather than out-ranked. Ingestion is async; the script waits, and explains
+  why skipping that wait makes Zep look like it forgot.
+- **LangMem** — a library, not a service. No dashboard, no account, and by
+  default no persistence: the store is a dict in your process. Its extractor
+  reads the **whole conversation at once**, so it resolves the May→June
+  contradiction *before* anything is stored — 3 sentences in, 2 memories out.
+- **Supabase pgvector** — the roll-your-own baseline. ~30 lines, real
+  embeddings, genuinely good at the paraphrase and the Chinese question. And
+  nothing in it ever decides a fact stopped being true, so both launch dates
+  sit there as neighbours forever. That gap is the argument for the other three.
+
+## Adding another one
+
+Keep the five beats and the same three sentences, or it stops being
+comparable. And per `CLAUDE.md`: no new default dependencies, nothing in
+`waku/` may import from here, `make gate` must not depend on it, and put the
+SDK version you verified against in the file header — these libraries move fast
+enough that a silently rotted example is worse than no example.

--- a/examples/memory-native/langmem_native.py
+++ b/examples/memory-native/langmem_native.py
@@ -1,0 +1,118 @@
+"""LangMem on its own terms: a library, not a service. There is no console.
+
+    pip install langmem langgraph   # or: uv pip install -e '.[arena]'
+    export ANTHROPIC_API_KEY=...    # the extractor is an LLM call
+    python examples/memory-native/langmem_native.py
+
+SDK: langmem 0.0.30 + langgraph 1.2.10. Verified live 2026-08-12.
+
+WHY THIS FILE EXISTS
+
+LangMem sits in every "AI memory tools" listicle next to two hosted products,
+and that placement is misleading. It is a set of LangGraph primitives you run
+inside your own process. There is no dashboard to open, no account, and by
+default no persistence at all -- the store lives in RAM and dies when Python
+exits. Step 5 demonstrates that rather than asserting it.
+
+This is also why waku's arena reports LangMem as "unreadable" rather than
+"0 facts": every read through the adapter constructs a fresh empty store, and
+calling that zero would be a true statement about the wrong object.
+
+Nothing here imports waku.
+"""
+
+from __future__ import annotations
+
+import os
+
+from dotenv import load_dotenv
+from langgraph.store.memory import InMemoryStore
+
+load_dotenv()  # your .env at the repo root, same keys waku uses
+
+# The same three sentences in all four quickstarts. The third CONTRADICTS the
+# second -- that is the whole test.
+FACTS = [
+    "I met Yuki at the Lisbon AI meetup in March. She runs a robotics startup.",
+    "Our product launch is scheduled for May.",
+    "Actually, the launch moved to June.",
+]
+
+QUESTIONS = [
+    ("exact     ", "When is the product launch?"),
+    ("paraphrase", "What date did we push the ship date to?"),
+    ("chinese   ", "发布会是什么时候?"),
+]
+
+NAMESPACE = ("quickstart", "facts")
+MODEL = os.environ.get("LANGMEM_MODEL", "anthropic:claude-sonnet-4-5")
+
+
+def main() -> None:
+    # 1. THE STORE IS YOURS TO PROVIDE. This is the fork in the road: an
+    #    InMemoryStore is a dict with a search method, and a PostgresStore is
+    #    the same interface backed by a database YOU run. LangMem itself
+    #    stores nothing.
+    store = InMemoryStore(index={"dims": 1536, "embed": "openai:text-embedding-3-small"})
+    print("store     : InMemoryStore (in this process, gone when it exits)")
+    print(f"model     : {MODEL}\n")
+
+    # 2. EXTRACT. create_memory_manager is LangMem's actual product: an LLM
+    #    that reads a conversation and decides what the durable facts are.
+    #    This is the same job waku's consolidation.py does.
+    from langmem import create_memory_manager
+
+    manager = create_memory_manager(MODEL)
+    conversation = [{"role": "user", "content": f} for f in FACTS]
+
+    print("-- telling it three things ------------------------------------")
+    for fact in FACTS:
+        print(f"  said : {fact}")
+
+    extracted = manager.invoke({"messages": conversation})
+
+    # 3. READ BACK RAW. Compare against the three sentences above. Note the
+    #    manager gets the WHOLE conversation at once, so it can resolve the
+    #    contradiction before anything is stored -- a real advantage over
+    #    stores that ingest one sentence at a time.
+    print("\n-- what it actually kept --------------------------------------")
+    for item in extracted:
+        content = _text(item)
+        print(f"  kept : {content}")
+        store.put(NAMESPACE, _key(content), {"text": content})
+
+    # 4. SEARCH. This is the STORE's search, not LangMem's -- another sign of
+    #    where the library ends and your infrastructure begins.
+    print("\n-- asking ------------------------------------------------------")
+    for label, question in QUESTIONS:
+        hits = store.search(NAMESPACE, query=question, limit=3)
+        top = hits[0].value.get("text") if hits else "(nothing found)"
+        print(f"  {label} : {question}\n              -> {top}")
+
+    # 5. THERE IS NO CONSOLE. Prove the ephemerality instead of claiming it.
+    print("\n-- see it yourself --------------------------------------------")
+    print("  There is no dashboard. This is the entire storage layer:")
+    print(f"    {len(store.search(NAMESPACE, limit=100))} item(s) in a Python dict at {hex(id(store))}")
+    print("  Restart this script and the count is the same, not cumulative --")
+    print("  nothing persisted. For persistence you bring your own Postgres:")
+    print("    from langgraph.store.postgres import PostgresStore")
+
+
+def _text(item) -> str:
+    """Unwrap ExtractedMemory(id=..., content=Memory(content='...')).
+
+    Two layers deep, and printing the outer one gives you `content='...'`
+    instead of a sentence -- which is fine in a REPL and embarrassing on a
+    slide.
+    """
+    node = getattr(item, "content", item)
+    return str(getattr(node, "content", node))
+
+
+def _key(content) -> str:
+    """Stable-ish key so re-running does not silently double every fact."""
+    return str(abs(hash(str(content))))[:12]
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/memory-native/mem0_native.py
+++ b/examples/memory-native/mem0_native.py
@@ -1,0 +1,102 @@
+"""mem0 on its own terms: the store that decides what is worth remembering.
+
+    pip install mem0ai          # or, from the repo root: uv pip install -e '.[arena]'
+    export MEM0_API_KEY=...
+    python examples/memory-native/mem0_native.py
+
+SDK: mem0ai 2.0.17. Written 2026-08-12, NOT YET RUN LIVE -- it writes to a
+hosted account, so it waits for a deliberate go-ahead. Update this line the
+first time it runs clean.
+
+WHY THIS FILE EXISTS
+
+Waku's arena drives mem0 through a common FactStore interface, and to satisfy
+that interface it has to call `add(..., infer=False)` -- because the contract
+says a write must always store exactly what it was given. That switch turns OFF
+the single thing mem0 is actually for.
+
+So this file is the opposite of the arena. Nothing but mem0, extraction left
+on, no abstraction in the way. Step 3 is the one to watch: you will say one
+thing and find a different thing stored. That is the product, not a bug.
+
+Nothing here imports waku.
+"""
+
+from __future__ import annotations
+
+import os
+
+from dotenv import load_dotenv
+from mem0 import MemoryClient
+
+load_dotenv()  # your .env at the repo root, same keys waku uses
+
+# One partition for the quickstart, so this never lands in your real memories.
+USER = os.environ.get("MEM0_QUICKSTART_USER", "quickstart-mem0")
+
+# The same three sentences in all four quickstarts, so the files are
+# comparable. The third one CONTRADICTS the second -- that is the whole test.
+FACTS = [
+    "I met Yuki at the Lisbon AI meetup in March. She runs a robotics startup.",
+    "Our product launch is scheduled for May.",
+    "Actually, the launch moved to June.",
+]
+
+QUESTIONS = [
+    ("exact     ", "When is the product launch?"),
+    ("paraphrase", "What date did we push the ship date to?"),
+    ("chinese   ", "发布会是什么时候?"),
+]
+
+
+def main() -> None:
+    client = MemoryClient()  # reads MEM0_API_KEY
+    print(f"user      : {USER}\n")
+
+    # 1. WRITE. Note there is no `infer=False` here. mem0 reads the sentence,
+    #    decides what the durable fact inside it is, and stores THAT.
+    print("-- telling it three things ------------------------------------")
+    for fact in FACTS:
+        client.add(messages=[{"role": "user", "content": fact}], user_id=USER)
+        print(f"  said : {fact}")
+
+    # 2. READ BACK RAW. The money shot: compare this list against the list
+    #    above. The wording will not match, and the count usually will not
+    #    either -- mem0 merges, rewrites, and drops what it judges disposable.
+    print("\n-- what it actually kept --------------------------------------")
+    for row in _rows(client.get_all(user_id=USER)):
+        print(f"  kept : {row.get('memory')}")
+
+    # 3. SEARCH, three ways. The paraphrase and the Chinese question are the
+    #    ones a keyword index (like waku's FTS5) struggles with.
+    print("\n-- asking ------------------------------------------------------")
+    for label, question in QUESTIONS:
+        hits = _rows(client.search(question, user_id=USER))
+        top = hits[0].get("memory") if hits else "(nothing found)"
+        print(f"  {label} : {question}\n              -> {top}")
+
+    # 4. THE CONTRADICTION. Two facts went in about the launch, one replacing
+    #    the other. Did the old one survive? A row store usually keeps both and
+    #    lets ranking decide; watch whether "May" is still in there anywhere.
+    stale = [r for r in _rows(client.get_all(user_id=USER))
+             if "may" in str(r.get("memory", "")).lower()]
+    print("\n-- the superseded fact ----------------------------------------")
+    print(f"  rows still mentioning May: {len(stale)}")
+    for row in stale:
+        print(f"    {row.get('memory')}")
+
+    # 5. WHERE TO LOOK.
+    print("\n-- see it yourself --------------------------------------------")
+    print(f"  https://app.mem0.ai -> Memories -> filter user = {USER}")
+    print("  Compare 'said' against 'kept' there. The diff is the whole product.")
+
+
+def _rows(payload) -> list[dict]:
+    """mem0 has returned both a bare list and {'results': [...]} across versions."""
+    if isinstance(payload, dict):
+        payload = payload.get("results", [])
+    return [r for r in (payload or []) if isinstance(r, dict)]
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/memory-native/supabase_native.py
+++ b/examples/memory-native/supabase_native.py
@@ -1,0 +1,136 @@
+"""Supabase pgvector on its own terms: roll your own, and see what you get.
+
+    pip install supabase openai   # or, from the repo root: uv pip install -e '.[arena]'
+    export SUPABASE_URL=... SUPABASE_KEY=... OPENAI_API_KEY=...
+    python examples/memory-native/supabase_native.py
+
+SDK: supabase-py 2.x + openai 2.51.0. Written 2026-08-12, NOT YET RUN LIVE --
+needs a Supabase project and the table below. Update this line once it runs.
+
+WHY THIS FILE EXISTS
+
+Most people reading this already have a Supabase project open in another tab,
+and the honest question about the three products in this folder is: what do
+they give you that thirty lines of pgvector does not?
+
+This file is the baseline that makes that question answerable. It is a table,
+an embedding call, and a cosine search. It works, and it will answer the
+paraphrase and the Chinese question better than a keyword index will.
+
+What it does NOT do is the whole point:
+
+  - nothing decides what is worth keeping (mem0 does)
+  - nothing notices that fact 3 contradicts fact 2 (Zep does)
+  - nothing ever forgets, so contradictions accumulate as neighbours forever
+
+A vector table is retrieval. A memory system is retrieval plus judgement about
+what to store and what is no longer true. Step 4 shows the gap.
+
+SETUP -- run this once in the Supabase SQL editor:
+
+    create extension if not exists vector;
+    create table quickstart_memories (
+      id bigserial primary key,
+      content text not null,
+      embedding vector(1536),
+      created_at timestamptz default now()
+    );
+    create or replace function match_quickstart_memories(
+      query_embedding vector(1536), match_count int
+    ) returns table (id bigint, content text, similarity float)
+    language sql stable as $$
+      select id, content, 1 - (embedding <=> query_embedding) as similarity
+      from quickstart_memories
+      order by embedding <=> query_embedding
+      limit match_count;
+    $$;
+
+Nothing here imports waku.
+"""
+
+from __future__ import annotations
+
+import os
+
+import openai
+from dotenv import load_dotenv
+from supabase import create_client
+
+load_dotenv()  # your .env at the repo root, same keys waku uses
+
+TABLE = os.environ.get("SUPABASE_QUICKSTART_TABLE", "quickstart_memories")
+EMBED_MODEL = "text-embedding-3-small"
+
+# The same three sentences in all four quickstarts. The third CONTRADICTS the
+# second -- that is the whole test.
+FACTS = [
+    "I met Yuki at the Lisbon AI meetup in March. She runs a robotics startup.",
+    "Our product launch is scheduled for May.",
+    "Actually, the launch moved to June.",
+]
+
+QUESTIONS = [
+    ("exact     ", "When is the product launch?"),
+    ("paraphrase", "What date did we push the ship date to?"),
+    ("chinese   ", "发布会是什么时候?"),
+]
+
+
+def main() -> None:
+    supabase = create_client(os.environ["SUPABASE_URL"], os.environ["SUPABASE_KEY"])
+    oai = openai.OpenAI()
+    print(f"table     : {TABLE}\n")
+
+    def embed(text: str) -> list[float]:
+        return oai.embeddings.create(model=EMBED_MODEL, input=[text]).data[0].embedding
+
+    # Start clean so re-runs do not stack duplicates and flatter the search.
+    supabase.table(TABLE).delete().neq("id", 0).execute()
+
+    # 1. WRITE. Every sentence is stored verbatim. There is no extraction step
+    #    because there is nothing here to do it -- that is the deal you made.
+    print("-- telling it three things ------------------------------------")
+    for fact in FACTS:
+        supabase.table(TABLE).insert({"content": fact, "embedding": embed(fact)}).execute()
+        print(f"  said : {fact}")
+
+    # 2. READ BACK RAW. Unlike mem0 and Zep, this list is IDENTICAL to the one
+    #    above -- same words, same count. Nothing judged anything.
+    print("\n-- what it actually kept --------------------------------------")
+    for row in supabase.table(TABLE).select("content").order("id").execute().data:
+        print(f"  kept : {row['content']}")
+
+    # 3. SEARCH, three ways. This is where pgvector earns its place: real
+    #    embeddings handle the paraphrase and the Chinese question that a
+    #    keyword index (waku's FTS5) has to have the query rewritten for.
+    print("\n-- asking ------------------------------------------------------")
+    for label, question in QUESTIONS:
+        hits = supabase.rpc(
+            f"match_{TABLE}", {"query_embedding": embed(question), "match_count": 3}
+        ).execute().data or []
+        top = f"{hits[0]['content']}  (sim {hits[0]['similarity']:.3f})" if hits else "(nothing found)"
+        print(f"  {label} : {question}\n              -> {top}")
+
+    # 4. THE CONTRADICTION -- and the gap. Both launch dates are still here,
+    #    both still retrievable, sitting next to each other with nearly
+    #    identical similarity. Whichever wins is an accident of the embedding,
+    #    not a decision about what is true.
+    print("\n-- the superseded fact ----------------------------------------")
+    hits = supabase.rpc(
+        f"match_{TABLE}", {"query_embedding": embed("product launch date"), "match_count": 5}
+    ).execute().data or []
+    for hit in hits:
+        print(f"  sim {hit['similarity']:.3f}  {hit['content']}")
+    print("  Both dates survive, ranked by similarity. Nothing here knows one")
+    print("  of them stopped being true. That judgement is what you are buying")
+    print("  when you pay for a memory layer instead of a vector table.")
+
+    # 5. WHERE TO LOOK.
+    print("\n-- see it yourself --------------------------------------------")
+    print(f"  Supabase -> your project -> Table editor -> {TABLE}")
+    print("  Rows and embeddings, exactly as written. The most transparent of")
+    print("  the four, and the least opinionated -- those are the same fact.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/memory-native/zep_native.py
+++ b/examples/memory-native/zep_native.py
@@ -1,0 +1,151 @@
+"""Zep on its own terms: not rows, a temporal knowledge graph.
+
+    pip install zep-cloud        # or, from the repo root: uv pip install -e '.[arena]'
+    export ZEP_API_KEY=...
+    python examples/memory-native/zep_native.py
+
+SDK: zep-cloud 3.27.0. Written 2026-08-12, NOT YET RUN LIVE -- it writes to a
+hosted account, so it waits for a deliberate go-ahead. Update this line the
+first time it runs clean.
+
+WHY THIS FILE EXISTS
+
+Every other store in this folder keeps a list and ranks it. Zep decomposes what
+you say into entities and edges, and stamps each edge with a VALIDITY INTERVAL.
+When you correct yourself, the old edge is not out-ranked -- it is marked
+invalid from a point in time, and it stays queryable as history.
+
+Step 4 is why this file is longer than the others. It is the only place in this
+folder where "the launch moved to June" does something structurally different
+from appending a row.
+
+Two things nobody tells you, both of which will make you think Zep forgot:
+
+  1. INGESTION IS ASYNCHRONOUS. graph.add returns in ~0.2s with
+     processed=False. Query immediately and you get nothing. This script waits.
+  2. SEARCH RETURNS ZEP'S RENDERING of an edge or node, not the sentence you
+     sent. The answers read differently from every other backend here even
+     when they are equally correct.
+
+Nothing here imports waku.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+from dotenv import load_dotenv
+from zep_cloud import Zep
+
+load_dotenv()  # your .env at the repo root, same keys waku uses
+
+USER = os.environ.get("ZEP_QUICKSTART_USER", "quickstart-zep")
+
+# The same three sentences in all four quickstarts. The third CONTRADICTS the
+# second -- that is the whole test.
+FACTS = [
+    "I met Yuki at the Lisbon AI meetup in March. She runs a robotics startup.",
+    "Our product launch is scheduled for May.",
+    "Actually, the launch moved to June.",
+]
+
+QUESTIONS = [
+    ("exact     ", "When is the product launch?"),
+    ("paraphrase", "What date did we push the ship date to?"),
+    ("chinese   ", "发布会是什么时候?"),
+]
+
+MAX_WAIT_SECONDS = int(os.environ.get("ZEP_MAX_WAIT_SECONDS", "120"))
+
+
+def main() -> None:
+    client = Zep(api_key=os.environ["ZEP_API_KEY"])
+    print(f"user      : {USER}\n")
+
+    try:
+        client.user.add(user_id=USER)
+    except Exception:
+        pass  # already exists
+
+    # 1. WRITE, then WAIT. The wait is not politeness, it is correctness --
+    #    this is the step whose absence makes benchmarks score Zep as having
+    #    forgotten something it was still filing.
+    print("-- telling it three things ------------------------------------")
+    for fact in FACTS:
+        episode = client.graph.add(user_id=USER, type="text", data=fact)
+        print(f"  said : {fact}")
+        print(f"         (accepted, processed={getattr(episode, 'processed', None)})")
+        _wait_until_processed(client, episode)
+
+    # 2. READ BACK RAW -- as nodes, because that is what Zep made of you.
+    #    Compare these against the three sentences. They are not a subset of
+    #    your words; they are entities Zep decided exist.
+    print("\n-- what it actually built -------------------------------------")
+    for node in client.graph.node.get_by_user_id(user_id=USER, limit=50) or []:
+        summary = getattr(node, "summary", "") or ""
+        print(f"  node : {getattr(node, 'name', '?')} -- {summary[:90]}")
+
+    # 3. SEARCH, three ways.
+    print("\n-- asking ------------------------------------------------------")
+    for label, question in QUESTIONS:
+        found = client.graph.search(query=question, user_id=USER, limit=3)
+        print(f"  {label} : {question}\n              -> {_first(found)}")
+
+    # 4. THE CONTRADICTION -- the reason to care about Zep at all.
+    #    Look for an edge carrying an `invalid_at` (or `expired_at`) timestamp.
+    #    In a row store, "launch is in May" just sits there forever, equally
+    #    retrievable. Here it should be marked superseded AT a point in time.
+    print("\n-- the superseded fact ----------------------------------------")
+    edges = getattr(client.graph.search(query="product launch date", user_id=USER,
+                                        limit=10, scope="edges"), "edges", None) or []
+    if not edges:
+        print("  (no edges returned -- try re-running; ingestion may still be settling)")
+    for edge in edges:
+        invalid = getattr(edge, "invalid_at", None) or getattr(edge, "expired_at", None)
+        state = f"INVALID from {invalid}" if invalid else "still valid"
+        print(f"  {getattr(edge, 'fact', '?')}\n      -> {state}")
+
+    # 5. WHERE TO LOOK.
+    print("\n-- see it yourself --------------------------------------------")
+    print(f"  https://app.getzep.com -> your project -> Users -> {USER}")
+    print("  'Graph' for the picture, 'Episodes' for the raw text you sent.")
+    print("  The graph view is the thing worth putting on screen.")
+
+
+def _wait_until_processed(client, episode) -> None:
+    """Poll until Zep says it has filed what we just sent.
+
+    Without this the next read is a coin flip, and a fast machine loses it
+    more often than a slow one.
+    """
+    uuid = getattr(episode, "uuid_", None) or getattr(episode, "uuid", None)
+    if not uuid:
+        time.sleep(3)
+        return
+    deadline = time.time() + MAX_WAIT_SECONDS
+    while time.time() < deadline:
+        try:
+            found = client.graph.episode.get_by_user_id(user_id=USER, lastn=20)
+            for ep in getattr(found, "episodes", found) or []:
+                same = (getattr(ep, "uuid_", None) or getattr(ep, "uuid", None)) == uuid
+                if same and getattr(ep, "processed", False):
+                    print(f"         (processed after {int(time.time() - deadline + MAX_WAIT_SECONDS)}s)")
+                    return
+        except Exception:
+            pass
+        time.sleep(2)
+    print(f"         (gave up waiting after {MAX_WAIT_SECONDS}s -- results may be incomplete)")
+
+
+def _first(found) -> str:
+    for attr in ("edges", "nodes", "episodes"):
+        rows = getattr(found, attr, None) or []
+        if rows:
+            row = rows[0]
+            return getattr(row, "fact", None) or getattr(row, "summary", None) or str(row)[:90]
+    return "(nothing found)"
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The Arena races mem0, Zep, LangMem and pgvector through one FactStore
contract so it can score them fairly. That contract is also why the Arena
cannot show you what any of them actually is. The sharpest case: the
contract says a write must always store what it was given, so the mem0
adapter passes infer=False -- which switches off the single feature mem0 is
known for. We have been measuring its retrieval and calling it mem0.

So these four run first, before any comparison is drawn. No waku, no
framework, no shared interface: each one uses its own product's documented
idiom, in about sixty lines.

Same five beats in every file so two can sit side by side: connect, write
three sentences, read back RAW, ask three ways (exact / paraphrase / the
same question in Chinese), then say where to go look. The three sentences
are rigged -- the third contradicts the second -- because what a store does
with a correction is where these four stop being interchangeable.

Running langmem_native.py live already corrected an assumption I had
written down as fact. I had the contradiction handling as Zep's alone.
LangMem's manager reads the WHOLE conversation before storing anything, so
three sentences became two memories and the launch one came back as "June
(updated from May - date was moved)". That is consolidation done properly,
in a library with no server, and it would not have survived being drawn
from the docs. The diagram work this feeds is now waiting on the other
three for the same reason.

Two things the live run also caught: examples import no waku, so they saw
none of the repo's keys and died on a missing OPENAI_API_KEY -- each file
now calls load_dotenv() (python-dotenv is already a core dep, not a new
one). And LangMem returns ExtractedMemory(content=Memory(content=...)),
two layers deep, so the obvious getattr printed content='...' instead of a
sentence. Fine in a REPL, embarrassing on a slide.

mem0, Zep and Supabase are written but deliberately NOT run: the first two
write to Sean's hosted accounts and the third needs a project and a table.
Their headers say so in the words the CLAUDE.md rule asks for, naming the
installed SDK version, and they write to quickstart-* partitions so they
can never land in the `waku` partition the real assistant uses.

Verified: ruff clean, all four compile, langmem_native.py runs end to end,
and nothing under evals/, Makefile or .github references this folder -- a
breaking SDK release upstream cannot turn our CI red.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
