### PR TITLE
examples: run mem0 and Zep for real, and fix what running them exposed

### DIFF
--- a/examples/memory-native/README.md
+++ b/examples/memory-native/README.md
@@ -70,6 +70,64 @@ to the `waku` partition your real assistant uses.
   nothing in it ever decides a fact stopped being true, so both launch dates
   sit there as neighbours forever. That gap is the argument for the other three.
 
+## What actually happened when we ran them (2026-08-12)
+
+Same three sentences, same three questions, three different stores. None of
+this is from the docs.
+
+**mem0** kept the contradiction as two separate rows and never resolved it:
+
+```
+kept : User's product launch is scheduled for May 2026
+kept : User's product launch is scheduled for June 2026
+```
+
+It also inferred a year we never said. And the same question in three languages
+did not get the same answer — English returned June, **中文 returned the
+superseded May**:
+
+```
+exact      : When is the product launch?   -> ...scheduled for June 2026
+chinese    : 发布会是什么时候?              -> ...scheduled for May 2026
+```
+
+**LangMem** resolved the contradiction before storing anything — three
+sentences in, two memories out:
+
+```
+kept : User's product launch is scheduled for June (updated from May - date was moved).
+```
+
+**Zep** did the thing it is built for, and marked the old fact invalid at a
+timestamp rather than out-ranking it:
+
+```
+The product launch is scheduled for May.  ->  INVALID from 2026-08-12T21:24:47Z
+The launch moved to June.                 ->  still valid
+```
+
+Worth noting: a plain `graph.search` still returned the May fact for "When is
+the product launch?". The invalidity lives on the edge, so you have to read the
+interval — retrieval alone will hand you a superseded fact with a straight face.
+
+### Two open questions, stated as open
+
+- **A fresh Zep `user_id` does not appear to give you a fresh graph.** Two
+  brand-new users, told only the three sentences above, both came back with
+  nodes like `brand deal`, `contract`, `rough cut`, `CTR` and `retention rate`
+  — entities from an entirely different dataset on the same project. Whether
+  that is cross-user entity resolution, a project-level graph, or a quirk of
+  how `node.get_by_user_id` scopes its listing, we do not know yet. It matters,
+  because it means partitioning the Arena by `ZEP_USER_ID` would not actually
+  isolate a run.
+- **A third user, given one unrelated sentence, reported zero episodes** even
+  after several minutes, while its `graph.add()` returned without error. Not
+  explained yet either.
+
+Neither is a criticism of Zep — both could as easily be our misreading of the
+API. They are written down here because an unexplained result you keep quiet
+about is how a benchmark ends up lying.
+
 ## Adding another one
 
 Keep the five beats and the same three sentences, or it stops being

--- a/examples/memory-native/mem0_native.py
+++ b/examples/memory-native/mem0_native.py
@@ -4,9 +4,11 @@
     export MEM0_API_KEY=...
     python examples/memory-native/mem0_native.py
 
-SDK: mem0ai 2.0.17. Written 2026-08-12, NOT YET RUN LIVE -- it writes to a
-hosted account, so it waits for a deliberate go-ahead. Update this line the
-first time it runs clean.
+SDK: mem0ai 2.0.17. Verified live 2026-08-12.
+
+Note the reads below pass `filters={"user_id": ...}, version="v2"`. Passing
+`user_id=` top-level works for add() and raises on get_all() -- the SDK is
+explicit about it, but only once you run it.
 
 WHY THIS FILE EXISTS
 
@@ -64,21 +66,21 @@ def main() -> None:
     #    above. The wording will not match, and the count usually will not
     #    either -- mem0 merges, rewrites, and drops what it judges disposable.
     print("\n-- what it actually kept --------------------------------------")
-    for row in _rows(client.get_all(user_id=USER)):
+    for row in _rows(client.get_all(filters={"user_id": USER}, version="v2")):
         print(f"  kept : {row.get('memory')}")
 
     # 3. SEARCH, three ways. The paraphrase and the Chinese question are the
     #    ones a keyword index (like waku's FTS5) struggles with.
     print("\n-- asking ------------------------------------------------------")
     for label, question in QUESTIONS:
-        hits = _rows(client.search(question, user_id=USER))
+        hits = _rows(client.search(question, filters={"user_id": USER}, version="v2"))
         top = hits[0].get("memory") if hits else "(nothing found)"
         print(f"  {label} : {question}\n              -> {top}")
 
     # 4. THE CONTRADICTION. Two facts went in about the launch, one replacing
     #    the other. Did the old one survive? A row store usually keeps both and
     #    lets ranking decide; watch whether "May" is still in there anywhere.
-    stale = [r for r in _rows(client.get_all(user_id=USER))
+    stale = [r for r in _rows(client.get_all(filters={"user_id": USER}, version="v2"))
              if "may" in str(r.get("memory", "")).lower()]
     print("\n-- the superseded fact ----------------------------------------")
     print(f"  rows still mentioning May: {len(stale)}")

--- a/examples/memory-native/supabase_native.py
+++ b/examples/memory-native/supabase_native.py
@@ -4,8 +4,11 @@
     export SUPABASE_URL=... SUPABASE_KEY=... OPENAI_API_KEY=...
     python examples/memory-native/supabase_native.py
 
-SDK: supabase-py 2.x + openai 2.51.0. Written 2026-08-12, NOT YET RUN LIVE --
-needs a Supabase project and the table below. Update this line once it runs.
+SDK: supabase-py 2.x + openai 2.51.0. NOT RUN BY US, and deliberately so: the
+only Supabase project on this account is a production database, and a demo
+table does not belong in one. Kept because plenty of readers already have a
+spare project, and this is the honest baseline the other three are measured
+against. Run it yourself and the header should say so.
 
 WHY THIS FILE EXISTS
 

--- a/examples/memory-native/zep_native.py
+++ b/examples/memory-native/zep_native.py
@@ -4,9 +4,7 @@
     export ZEP_API_KEY=...
     python examples/memory-native/zep_native.py
 
-SDK: zep-cloud 3.27.0. Written 2026-08-12, NOT YET RUN LIVE -- it writes to a
-hosted account, so it waits for a deliberate go-ahead. Update this line the
-first time it runs clean.
+SDK: zep-cloud 3.27.0. Verified live 2026-08-12.
 
 WHY THIS FILE EXISTS
 
@@ -76,7 +74,7 @@ def main() -> None:
         episode = client.graph.add(user_id=USER, type="text", data=fact)
         print(f"  said : {fact}")
         print(f"         (accepted, processed={getattr(episode, 'processed', None)})")
-        _wait_until_processed(client, episode)
+        _wait_until_processed(client)
 
     # 2. READ BACK RAW -- as nodes, because that is what Zep made of you.
     #    Compare these against the three sentences. They are not a subset of
@@ -113,25 +111,28 @@ def main() -> None:
     print("  The graph view is the thing worth putting on screen.")
 
 
-def _wait_until_processed(client, episode) -> None:
-    """Poll until Zep says it has filed what we just sent.
+def _wait_until_processed(client) -> None:
+    """Poll until Zep says it has filed everything we have sent so far.
 
     Without this the next read is a coin flip, and a fast machine loses it
     more often than a slow one.
+
+    The first version of this waited on the uuid that graph.add() returned,
+    which never matched anything episode.get_by_user_id() came back with, so
+    it burned the full timeout on every call and then read the graph early.
+    The result looked exactly like Zep having forgotten the third sentence --
+    the precise failure this file's docstring warns about, reproduced by the
+    file itself. Waiting on "are all recent episodes processed" needs no id
+    and cannot silently miss.
     """
-    uuid = getattr(episode, "uuid_", None) or getattr(episode, "uuid", None)
-    if not uuid:
-        time.sleep(3)
-        return
-    deadline = time.time() + MAX_WAIT_SECONDS
-    while time.time() < deadline:
+    started = time.time()
+    while time.time() - started < MAX_WAIT_SECONDS:
         try:
             found = client.graph.episode.get_by_user_id(user_id=USER, lastn=20)
-            for ep in getattr(found, "episodes", found) or []:
-                same = (getattr(ep, "uuid_", None) or getattr(ep, "uuid", None)) == uuid
-                if same and getattr(ep, "processed", False):
-                    print(f"         (processed after {int(time.time() - deadline + MAX_WAIT_SECONDS)}s)")
-                    return
+            episodes = getattr(found, "episodes", found) or []
+            if episodes and all(getattr(e, "processed", False) for e in episodes):
+                print(f"         (processed after {int(time.time() - started)}s)")
+                return
         except Exception:
             pass
         time.sleep(2)


### PR DESCRIPTION
Three scripts went in unverified. Two are now verified live, and both of
them broke first -- which is the entire argument for running an example
before shipping it as teaching material.

mem0: get_all(user_id=...) raises. The v2 API wants
filters={"user_id": ...}, version="v2" on reads while add() still takes
user_id top-level. Our own arena adapter already knew this; I wrote the
quickstart from the docs instead of from the code that works, and the docs
lost.

Zep: the wait loop was the bug, not Zep. It polled for the uuid that
graph.add() returns, which never matches anything episode.get_by_user_id()
comes back with, so it burned the full 120s timeout on every sentence and
then read the graph early. The output looked exactly like Zep having
forgotten the third sentence -- the precise failure this file's own
docstring warns readers about, reproduced by the file itself. Waiting on
"are all recent episodes processed" needs no id and cannot silently miss.
With that fixed, ingestion settles in 6-8s and Zep does the thing it is
built for:

    The product launch is scheduled for May.  ->  INVALID from 2026-08-12T21:24:47Z
    The launch moved to June.                 ->  still valid

The README now carries what the three runs actually produced. The findings
are better than the pitch. mem0 kept both launch dates as separate rows,
invented a year nobody said, and answered the SAME question differently by
language -- English got June, Chinese got the superseded May. LangMem
resolved the contradiction before storing, three sentences in and two
memories out. Zep marked the old edge invalid at a timestamp, though a
plain search still returns it, so retrieval alone will hand you a
superseded fact with a straight face.

Two results are written down as unexplained rather than smoothed over: two
brand-new Zep users came back carrying entities from a completely
different dataset on the same project, and a third user reported zero
episodes after a clean graph.add(). Either could be our misreading of the
API. The first one matters beyond this folder -- if a fresh user_id is not
a fresh graph, partitioning the Arena by ZEP_USER_ID does not isolate a
run, and that was the plan.

Supabase stays unrun on purpose: the only project on this account is a
production database, and a demo table does not belong in one. Its header
says so plainly instead of implying it was verified.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
