### PR TITLE
arena: a wipe script, and stop hiding mem0's supersession flag

### DIFF
--- a/examples/memory-native/mem0_native.py
+++ b/examples/memory-native/mem0_native.py
@@ -39,7 +39,7 @@ USER = os.environ.get("MEM0_QUICKSTART_USER", "quickstart-mem0")
 # The same three sentences in all four quickstarts, so the files are
 # comparable. The third one CONTRADICTS the second -- that is the whole test.
 FACTS = [
-    "I met Yuki at the Lisbon AI meetup in March. She runs a robotics startup.",
+    "I met Alex at the Lisbon AI meetup in March. He runs a robotics startup.",
     "Our product launch is scheduled for May.",
     "Actually, the launch moved to June.",
 ]
@@ -66,31 +66,67 @@ def main() -> None:
     #    above. The wording will not match, and the count usually will not
     #    either -- mem0 merges, rewrites, and drops what it judges disposable.
     print("\n-- what it actually kept --------------------------------------")
-    for row in _rows(client.get_all(filters={"user_id": USER}, version="v2")):
-        print(f"  kept : {row.get('memory')}")
+    rows = _rows(client.get_all(filters={"user_id": USER}, version="v2"))
+    for row in rows:
+        print(f"  kept : {row.get('memory')}  [{_state(client, row)}]")
 
-    # 3. SEARCH, three ways. The paraphrase and the Chinese question are the
-    #    ones a keyword index (like waku's FTS5) struggles with.
+    # 3. SEARCH, three ways -- and watch the scores, not just the winner.
     print("\n-- asking ------------------------------------------------------")
     for label, question in QUESTIONS:
         hits = _rows(client.search(question, filters={"user_id": USER}, version="v2"))
-        top = hits[0].get("memory") if hits else "(nothing found)"
-        print(f"  {label} : {question}\n              -> {top}")
+        print(f"  {label} : {question}")
+        for i, hit in enumerate(hits[:2]):
+            arrow = "->" if i == 0 else "  "
+            print(f"           {arrow} {hit.get('score'):.4f}  [{_state(client, hit):10}]"
+                  f"  {hit.get('memory')}")
 
-    # 4. THE CONTRADICTION. Two facts went in about the launch, one replacing
-    #    the other. Did the old one survive? A row store usually keeps both and
-    #    lets ranking decide; watch whether "May" is still in there anywhere.
-    stale = [r for r in _rows(client.get_all(filters={"user_id": USER}, version="v2"))
-             if "may" in str(r.get("memory", "")).lower()]
+    # 4. THE CONTRADICTION -- and the trap.
+    #
+    #    mem0 DOES resolve this. The May row gets lifecycle_state="superseded"
+    #    and replaced_by=<the June row's id>. But get_all() returns NEITHER
+    #    field, so reading the list above tells you nothing is wrong. You only
+    #    see it by fetching a row on its own, which is what _state() does.
+    #
+    #    Worse: search() returns the superseded row anyway, and on a real run
+    #    it scored HIGHER than the live one (0.3338 vs 0.3307). Which answer
+    #    you get is scoring noise. Ask twice, get two answers, same language.
     print("\n-- the superseded fact ----------------------------------------")
-    print(f"  rows still mentioning May: {len(stale)}")
-    for row in stale:
-        print(f"    {row.get('memory')}")
+    for row in rows:
+        state = _state(client, row)
+        if state == "superseded":
+            print(f"  {row.get('memory')}")
+            print(f"      -> superseded, replaced by {_full(client, row).get('replaced_by')}")
+    print("  A plain search still returns it. If you do not read lifecycle_state,")
+    print("  a store that resolved the contradiction correctly will still hand")
+    print("  you the dead fact with a straight face.")
 
     # 5. WHERE TO LOOK.
     print("\n-- see it yourself --------------------------------------------")
     print(f"  https://app.mem0.ai -> Memories -> filter user = {USER}")
     print("  Compare 'said' against 'kept' there. The diff is the whole product.")
+
+
+_FULL: dict[str, dict] = {}
+
+
+def _full(client, row: dict) -> dict:
+    """Fetch a row on its own, because the list view is not the whole row.
+
+    get_all() and search() both omit `lifecycle_state` and `replaced_by`.
+    get(memory_id) returns them. Cached so a demo does not make one HTTP call
+    per row per print.
+    """
+    mid = str(row.get("id", ""))
+    if mid not in _FULL:
+        try:
+            _FULL[mid] = client.get(mid) or {}
+        except Exception:
+            _FULL[mid] = {}
+    return _FULL[mid]
+
+
+def _state(client, row: dict) -> str:
+    return str(_full(client, row).get("lifecycle_state") or "active")
 
 
 def _rows(payload) -> list[dict]:

--- a/scripts/arena_clean.py
+++ b/scripts/arena_clean.py
@@ -1,0 +1,141 @@
+"""Wipe the hosted memory partitions the Arena and the quickstarts write to.
+
+    python scripts/arena_clean.py              # dry run: lists, deletes nothing
+    python scripts/arena_clean.py --yes        # actually delete
+
+WHY THIS EXISTS
+
+sqlite and LangMem need no cleanup. Every Arena contestant runs in a throwaway
+temp home, so a race never opens `.waku/`, and LangMem's default store is a
+dict that dies with the process. Both start clean whether you ask them to or
+not.
+
+The hosted two do not. mem0 and Zep are keyed by a user id on YOUR account, so
+every race and every quickstart run piles up in the same place, and by the
+third session you cannot tell your results from last week's -- or from the
+demo data the vendor seeded when you signed up.
+
+That ambiguity is not cosmetic. Zep builds ONE graph per project and dedupes
+entities into it, so a brand-new user id inherits concepts nobody ever told it:
+a fresh `quickstart-zep` came back knowing about `brand deal`, `rough cut`,
+`CTR` and `retention rate`, all of which trace to Zep's own onboarding sandbox.
+mem0 does not do this -- rows carry a user_id and the wall holds -- which is
+the difference between a row store and a graph in one sentence.
+
+The consequence for benchmarking: giving each race a fresh user id DOES NOT
+isolate it. You have to empty the project first. Hence this script, and hence
+`--yes`, following the same rule as scripts/demo_seed.py -- nothing
+irreversible happens because a script ran, only because a human typed --yes.
+
+WHAT IT WILL NOT TOUCH
+
+Your `.waku/` home. Your real assistant's memories live under the `waku` user
+on the hosted services too, so that partition is listed but NEVER deleted
+without --include-waku. Read the dry run before you trust the flag.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# Partitions this repo is known to write to. `waku` is deliberately absent --
+# it is the real assistant's, and it takes an extra flag.
+ARENA_PREFIXES = ("quickstart-", "waku-arena-", "waku-latency-", "iso-test-")
+REAL = "waku"
+
+
+def mem0_users() -> tuple[object, list[str]]:
+    from mem0 import MemoryClient
+
+    client = MemoryClient()
+    # get_all(filters={}) is a 400 -- mem0 requires a non-empty filter. users()
+    # is the enumeration endpoint, and it flags vendor playground entities.
+    payload = client.users()
+    rows = payload.get("results", payload) if isinstance(payload, dict) else payload
+    users = sorted(
+        (r.get("name"), bool(r.get("is_playground")))
+        for r in rows or [] if isinstance(r, dict) and r.get("name")
+    )
+    return client, users
+
+
+def zep_users() -> tuple[object, list[str]]:
+    from zep_cloud import Zep
+
+    client = Zep(api_key=os.environ["ZEP_API_KEY"])
+    found = client.user.list_ordered()
+    users = [(u.user_id, False) for u in (getattr(found, "users", found) or [])
+             if getattr(u, "user_id", None)]
+    return client, sorted(users)
+
+
+def classify(user: str, playground: bool, include_waku: bool) -> tuple[bool, str]:
+    """(delete?, why) -- said out loud so a dry run is readable."""
+    if user == REAL:
+        return (include_waku, "your real assistant's partition"
+                + ("" if include_waku else " -- kept, pass --include-waku to remove"))
+    if user.startswith(ARENA_PREFIXES):
+        return (True, "written by this repo (arena or quickstart)")
+    if playground:
+        return (True, "vendor playground data -- never written by this repo")
+    # Zep's onboarding sandbox is the documented source of the cross-user
+    # entity bleed, so leaving it in place defeats the whole cleanup.
+    return (True, "not written by this repo -- vendor demo/sandbox data")
+
+
+def main(apply: bool, include_waku: bool) -> None:
+    plan: list[tuple[str, str, str, str]] = []  # (service, user, verdict, why)
+
+    for name, fetch in (("mem0", mem0_users), ("zep", zep_users)):
+        try:
+            client, users = fetch()
+        except Exception as ex:
+            print(f"{name}: skipped -- {type(ex).__name__}: {ex}")
+            continue
+        for user, playground in users:
+            do, why = classify(user, playground, include_waku)
+            plan.append((name, user, "DELETE" if do else "keep", why))
+        globals()[f"_{name}_client"] = client
+
+    if not plan:
+        print("nothing found on either service.")
+        return
+
+    print(f"{'service':8} {'verdict':7} {'user':28} why")
+    print("-" * 92)
+    for service, user, verdict, why in plan:
+        print(f"{service:8} {verdict:7} {user:28} {why}")
+
+    doomed = [(s, u) for s, u, v, _ in plan if v == "DELETE"]
+    print(f"\n{len(doomed)} partition(s) would be deleted.")
+
+    if not apply:
+        print("\nDry run -- nothing was deleted. This is irreversible; if you mean it:")
+        print("    python scripts/arena_clean.py --yes")
+        return
+
+    for service, user in doomed:
+        client = globals()[f"_{service}_client"]
+        try:
+            if service == "mem0":
+                client.delete_all(user_id=user)
+            else:
+                client.user.delete(user_id=user)
+            print(f"deleted {service}:{user}")
+        except Exception as ex:
+            print(f"FAILED {service}:{user} -- {type(ex).__name__}: {ex}")
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser(description="Wipe hosted memory partitions (mem0, Zep).")
+    p.add_argument("--yes", "-y", action="store_true",
+                   help="actually delete. Without it this only lists what it would do.")
+    p.add_argument("--include-waku", action="store_true",
+                   help="also delete the `waku` partition -- your real assistant's memories.")
+    args = p.parse_args()
+    main(apply=args.yes, include_waku=args.include_waku)


### PR DESCRIPTION
I reported that mem0 keeps a contradiction as two live rows and never
resolves it. That was wrong, and the console screenshot proved it: the
Lifecycle column said Superseded while my script said nothing was amiss.

get_all() and search() both omit `lifecycle_state` and `replaced_by`.
get(memory_id) returns them. So mem0 had resolved the contradiction
correctly all along -- May carries lifecycle_state="superseded" and
replaced_by pointing at the June row -- and the list view I was reading
simply does not carry the field. The quickstart now fetches each row on its
own and prints the state next to the text.

The corrected finding is better than the wrong one, and it makes mem0 and
Zep the same story rather than opposite ones. Both mark the dead fact dead.
Both hand it back from a plain search anyway:

    exact   : When is the product launch?
           -> 0.3429  [active    ]  ...scheduled for June 2026
              0.3474  [superseded]  ...scheduled for May 2026
    chinese : 发布会是什么时候?
           -> 0.1788  [superseded]  ...scheduled for May 2026
              0.1787  [active    ]  ...scheduled for June 2026

That is a gap of 0.0001. The "mem0 is bad at Chinese" result I reported was
never about language -- the two rows sit on top of each other and which one
wins is noise. Ask twice in the same language and you can get both. The
lesson is one line: every store here will hand you a stale fact unless you
read the lifecycle field, and nothing about the default API encourages you
to.

scripts/arena_clean.py is the cleanup this needs. sqlite and LangMem require
none -- arena contestants run in throwaway temp homes and LangMem's store
dies with the process -- but mem0 and Zep accumulate on a real account until
you cannot tell this week's results from last week's or from the vendor's
own onboarding data. Two live discoveries shaped it: get_all(filters={}) is
a 400 (users() is the enumeration endpoint, and it flags playground
entities), and Zep's cross-user entity bleed traces to its sandbox user, so
a cleanup that spares vendor demo data accomplishes nothing.

It follows demo_seed.py's rule -- dry run by default, destructive only on an
explicit --yes -- and never touches the `waku` partition without a second
flag, because that one is the real assistant's.

Dry run verified against both services: 8 partitions listed for deletion, 2
kept, correct reasons printed for each.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
