### PR TITLE
arena: spare the waku partition only when it is actually the assistant's

### DIFF
--- a/examples/memory-native/langmem_native.py
+++ b/examples/memory-native/langmem_native.py
@@ -33,7 +33,7 @@ load_dotenv()  # your .env at the repo root, same keys waku uses
 # The same three sentences in all four quickstarts. The third CONTRADICTS the
 # second -- that is the whole test.
 FACTS = [
-    "I met Yuki at the Lisbon AI meetup in March. She runs a robotics startup.",
+    "I met Alex at the Lisbon AI meetup in March. He runs a robotics startup.",
     "Our product launch is scheduled for May.",
     "Actually, the launch moved to June.",
 ]

--- a/examples/memory-native/mem0_native.py
+++ b/examples/memory-native/mem0_native.py
@@ -27,6 +27,7 @@ Nothing here imports waku.
 from __future__ import annotations
 
 import os
+import time
 
 from dotenv import load_dotenv
 from mem0 import MemoryClient
@@ -61,6 +62,7 @@ def main() -> None:
     for fact in FACTS:
         client.add(messages=[{"role": "user", "content": fact}], user_id=USER)
         print(f"  said : {fact}")
+    _settle(client, len(FACTS))
 
     # 2. READ BACK RAW. The money shot: compare this list against the list
     #    above. The wording will not match, and the count usually will not
@@ -104,6 +106,28 @@ def main() -> None:
     print("\n-- see it yourself --------------------------------------------")
     print(f"  https://app.mem0.ai -> Memories -> filter user = {USER}")
     print("  Compare 'said' against 'kept' there. The diff is the whole product.")
+
+
+def _settle(client, expected: int, max_wait: int = 60) -> None:
+    """Wait for extraction to finish before reading.
+
+    add() returns before the memory exists. Against an account that already
+    had rows this is invisible -- you read the OLD ones and everything looks
+    fine. Against a freshly wiped account it is brutal: every read comes back
+    empty and the store looks broken.
+
+    Zep documents this loudly. mem0 does not, which makes it the more
+    dangerous of the two, because the failure only shows up on a clean run --
+    exactly the run a benchmark does.
+    """
+    started = time.time()
+    while time.time() - started < max_wait:
+        found = len(_rows(client.get_all(filters={"user_id": USER}, version="v2")))
+        if found >= expected:
+            print(f"  (settled: {found} memories after {int(time.time() - started)}s)")
+            return
+        time.sleep(2)
+    print(f"  (gave up after {max_wait}s -- results below may be incomplete)")
 
 
 _FULL: dict[str, dict] = {}

--- a/examples/memory-native/supabase_native.py
+++ b/examples/memory-native/supabase_native.py
@@ -67,7 +67,7 @@ EMBED_MODEL = "text-embedding-3-small"
 # The same three sentences in all four quickstarts. The third CONTRADICTS the
 # second -- that is the whole test.
 FACTS = [
-    "I met Yuki at the Lisbon AI meetup in March. She runs a robotics startup.",
+    "I met Alex at the Lisbon AI meetup in March. He runs a robotics startup.",
     "Our product launch is scheduled for May.",
     "Actually, the launch moved to June.",
 ]

--- a/examples/memory-native/zep_native.py
+++ b/examples/memory-native/zep_native.py
@@ -43,7 +43,7 @@ USER = os.environ.get("ZEP_QUICKSTART_USER", "quickstart-zep")
 # The same three sentences in all four quickstarts. The third CONTRADICTS the
 # second -- that is the whole test.
 FACTS = [
-    "I met Yuki at the Lisbon AI meetup in March. She runs a robotics startup.",
+    "I met Alex at the Lisbon AI meetup in March. He runs a robotics startup.",
     "Our product launch is scheduled for May.",
     "Actually, the launch moved to June.",
 ]

--- a/scripts/arena_clean.py
+++ b/scripts/arena_clean.py
@@ -74,9 +74,25 @@ def zep_users() -> tuple[object, list[str]]:
     return client, sorted(users)
 
 
-def classify(user: str, playground: bool, include_waku: bool) -> tuple[bool, str]:
+def hosted_stores() -> set[str]:
+    """Which hosted backends is the REAL assistant configured to write to?
+
+    Without this the `waku` partition looks precious and gets spared forever.
+    On an install that runs sqlite -- the default -- a `waku` partition on
+    mem0 or Zep cannot contain anything but leftovers from past races, and
+    protecting it just means the contamination never actually goes away.
+    """
+    return {os.getenv("WAKU_SEMANTIC_STORE", "sqlite").strip().strip("'\"").lower(),
+            os.getenv("WAKU_EPISODIC_STORE", "sqlite").strip().strip("'\"").lower()}
+
+
+def classify(user: str, playground: bool, include_waku: bool,
+             service_is_live: bool = True) -> tuple[bool, str]:
     """(delete?, why) -- said out loud so a dry run is readable."""
     if user == REAL:
+        if not service_is_live:
+            return (True, ("arena leftovers -- your assistant is configured for "
+                           "sqlite, so nothing here is its memory"))
         return (include_waku, "your real assistant's partition"
                 + ("" if include_waku else " -- kept, pass --include-waku to remove"))
     if user.startswith(ARENA_PREFIXES):
@@ -90,6 +106,8 @@ def classify(user: str, playground: bool, include_waku: bool) -> tuple[bool, str
 
 def main(apply: bool, include_waku: bool) -> None:
     plan: list[tuple[str, str, str, str]] = []  # (service, user, verdict, why)
+    live = hosted_stores()
+    print(f"assistant is configured for: {', '.join(sorted(live))}\n")
 
     for name, fetch in (("mem0", mem0_users), ("zep", zep_users)):
         try:
@@ -98,7 +116,7 @@ def main(apply: bool, include_waku: bool) -> None:
             print(f"{name}: skipped -- {type(ex).__name__}: {ex}")
             continue
         for user, playground in users:
-            do, why = classify(user, playground, include_waku)
+            do, why = classify(user, playground, include_waku, service_is_live=name in live)
             plan.append((name, user, "DELETE" if do else "keep", why))
         globals()[f"_{name}_client"] = client
 


### PR DESCRIPTION
Retracting a claim first. I reported that mem0 may have fabricated a name --
we said "Yuki", a later read said "Alex". It fabricated nothing. Commit
da80ddb, mine, changed the FACTS constant in mem0_native.py from Yuki to
Alex while I was editing the file around it, so mem0 stored exactly what it
was handed. The three other quickstarts still said Yuki, which also meant
the four files had quietly stopped being comparable -- the one property the
whole folder depends on. All four now say Alex, per Sean's preference.

Worth noting what caught it: the claim was flagged as unverified pending a
clean-account run, and the clean-account run killed it in one line. It only
looked like fabrication because the account was polluted enough that nobody
could see the source text was the thing that changed.

Two real bugs behind it.

mem0's add() returns before extraction finishes, exactly like Zep's -- but
mem0 does not document it and has no processed flag to poll. Against an
account with existing rows the race is invisible: you read the OLD rows and
everything looks fine. Against a freshly wiped account every read comes back
empty and the store looks broken. That is the dangerous shape, because a
clean account is precisely what a benchmark starts from. Added _settle().

And the cleanup script was protecting the wrong thing. It spared the `waku`
partition on the grounds that it belongs to the real assistant. On this
install WAKU_SEMANTIC_STORE and WAKU_EPISODIC_STORE are both sqlite, so the
assistant has never written a byte to mem0 or Zep; those partitions held 57
rows and 31 nodes of pure arena leftovers, and sparing them meant the
contamination could never actually be cleared. The script now reads the
configured stores and only treats `waku` as precious on an install that
really routes there.

That mattered more than it looks. Zep's `waku` graph still contains CTR,
brand deal, contract and Creator operations AFTER the sandbox user that
introduced them was deleted. Deleting the source does not retract the
entities it merged into other users' graphs. So Zep's cross-user bleed is
confirmed, and it is stickier than "delete the offender" -- which is exactly
the kind of thing a benchmark needs to know before it publishes a number.

Verified: dry run reports 3 partitions, each with the right reason, and
correctly reports "assistant is configured for: sqlite" at the top.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
