### PR TITLE
examples: the foreign entities were the project ontology all along

### DIFF
--- a/examples/memory-native/README.md
+++ b/examples/memory-native/README.md
@@ -110,23 +110,67 @@ Worth noting: a plain `graph.search` still returned the May fact for "When is
 the product launch?". The invalidity lives on the edge, so you have to read the
 interval — retrieval alone will hand you a superseded fact with a straight face.
 
-### Two open questions, stated as open
+### Solved: the "foreign entities" were never a leak
 
-- **A fresh Zep `user_id` does not appear to give you a fresh graph.** Two
-  brand-new users, told only the three sentences above, both came back with
-  nodes like `brand deal`, `contract`, `rough cut`, `CTR` and `retention rate`
-  — entities from an entirely different dataset on the same project. Whether
-  that is cross-user entity resolution, a project-level graph, or a quirk of
-  how `node.get_by_user_id` scopes its listing, we do not know yet. It matters,
-  because it means partitioning the Arena by `ZEP_USER_ID` would not actually
-  isolate a run.
-- **A third user, given one unrelated sentence, reported zero episodes** even
-  after several minutes, while its `graph.add()` returned without error. Not
-  explained yet either.
+Earlier runs kept producing entities nobody had mentioned — `CTR`, `brand
+deal`, `contract`, `rough cut`, `retention rate` — in brand-new Zep users told
+nothing but the three sentences above. The first guess was cross-user bleed.
+Then the vendor's onboarding sandbox looked like the source. Both were wrong.
 
-Neither is a criticism of Zep — both could as easily be our misreading of the
-API. They are written down here because an unexplained result you keep quiet
-about is how a benchmark ends up lying.
+We deleted **every user in the project** and verified zero remained. A fresh
+user, on a verifiably empty project, came back with:
+
+```
+node : CTR
+node : brand deal -- A brand deal has a priority associated with May.
+node : retention rate -- Retention rate is the percentage of viewers watching until...
+node : rough cut -- A rough cut is an unpolished initial video edit.
+```
+
+Nothing was left to leak from. **It is the project-wide ontology.** Zep's
+onboarding wizard sets one — visible on the project page under *Project Wide
+Customization*, and ticked off as "Set your ontology" in Getting Started — and
+every user in that project inherits those entity definitions forever.
+
+This is not a bug and not a leak. It is a configured schema doing exactly what
+it says. But three consequences matter if you are benchmarking:
+
+- **Deleting users does not clean a Zep project.** The ontology outlives them.
+- A clean comparison needs the ontology reset, or a **fresh project**.
+- The ontology **shapes what the graph is willing to learn.** In the run above,
+  `Our product launch is scheduled for May` and `Actually, the launch moved to
+  June` produced a `May` node and no `June` node at all — and every question
+  about the launch still answered "May", with the superseded edge never marked.
+  Whether that is the ontology constraining extraction or ingestion still
+  settling, we have not yet separated.
+
+The general lesson is the one worth filming: **a schema you agreed to once, in
+a setup wizard, quietly decides what your agent is capable of remembering.**
+
+### One open question, stated as open
+
+- **A user given one unrelated sentence reported zero episodes** several
+  minutes after a `graph.add()` that returned without error. Not explained.
+
+### "Ingested" and "queryable" are different events
+
+Both hosted stores made us learn this the hard way, and neither reports the
+event you actually care about.
+
+- **Zep** exposes `processed` on an episode. It is necessary and not
+  sufficient: on a clean project every episode reported processed while the
+  launch facts had produced no nodes at all, so the graph answered *"when is
+  the launch?"* with the Lisbon meetup. A benchmark stopping there publishes
+  "Zep forgot a fact" about a fact it was mid-way through filing.
+- **mem0** has no flag at all, and `add()` returns early. The obvious fix —
+  wait for `len(FACTS)` rows — is also wrong, because an inferring store
+  decides for itself how many memories your sentences become. Three sentences
+  became four here, and waiting for three returned the instant *before* "moved
+  to June" landed.
+
+Both scripts now wait for the count to **stop changing** rather than for a
+signal or a target. If you benchmark any store that infers, do the same, or
+you are timing your own race conditions and calling it recall.
 
 ## Adding another one
 

--- a/examples/memory-native/mem0_native.py
+++ b/examples/memory-native/mem0_native.py
@@ -62,7 +62,7 @@ def main() -> None:
     for fact in FACTS:
         client.add(messages=[{"role": "user", "content": fact}], user_id=USER)
         print(f"  said : {fact}")
-    _settle(client, len(FACTS))
+    _settle(client)
 
     # 2. READ BACK RAW. The money shot: compare this list against the list
     #    above. The wording will not match, and the count usually will not
@@ -108,23 +108,35 @@ def main() -> None:
     print("  Compare 'said' against 'kept' there. The diff is the whole product.")
 
 
-def _settle(client, expected: int, max_wait: int = 60) -> None:
-    """Wait for extraction to finish before reading.
+def _settle(client, quiet_for: int = 3, max_wait: int = 120) -> None:
+    """Wait for extraction to go QUIET, not for a count.
 
     add() returns before the memory exists. Against an account that already
     had rows this is invisible -- you read the OLD ones and everything looks
     fine. Against a freshly wiped account it is brutal: every read comes back
-    empty and the store looks broken.
+    empty and the store looks broken. Zep documents this loudly; mem0 does
+    not, and has no processed flag, which makes it the more dangerous of the
+    two -- the failure only appears on a clean run, which is exactly the run
+    a benchmark starts from.
 
-    Zep documents this loudly. mem0 does not, which makes it the more
-    dangerous of the two, because the failure only shows up on a clean run --
-    exactly the run a benchmark does.
+    The obvious fix is to wait for len(FACTS) rows. That is wrong, and it
+    cost a whole run to learn why: an inferring store decides for itself how
+    many memories your sentences become. Three sentences here became four,
+    and waiting for three returned the instant BEFORE "moved to June" landed
+    -- so the read showed May as active with no June anywhere, while a search
+    seconds later happily returned June. A benchmark that stopped there would
+    have published "mem0 lost the correction".
+
+    You cannot predict the count. So wait for the count to stop CHANGING.
     """
-    started = time.time()
+    started, last, stable = time.time(), -1, 0
     while time.time() - started < max_wait:
         found = len(_rows(client.get_all(filters={"user_id": USER}, version="v2")))
-        if found >= expected:
-            print(f"  (settled: {found} memories after {int(time.time() - started)}s)")
+        stable = stable + 1 if found == last and found > 0 else 0
+        last = found
+        if stable >= quiet_for:
+            print(f"  (settled: {found} memories, stable for {quiet_for} checks, "
+                  f"{int(time.time() - started)}s)")
             return
         time.sleep(2)
     print(f"  (gave up after {max_wait}s -- results below may be incomplete)")

--- a/examples/memory-native/zep_native.py
+++ b/examples/memory-native/zep_native.py
@@ -117,21 +117,39 @@ def _wait_until_processed(client) -> None:
     Without this the next read is a coin flip, and a fast machine loses it
     more often than a slow one.
 
-    The first version of this waited on the uuid that graph.add() returned,
-    which never matched anything episode.get_by_user_id() came back with, so
-    it burned the full timeout on every call and then read the graph early.
-    The result looked exactly like Zep having forgotten the third sentence --
-    the precise failure this file's docstring warns about, reproduced by the
-    file itself. Waiting on "are all recent episodes processed" needs no id
-    and cannot silently miss.
+    Two wrong versions preceded this one, and both produced the same lie.
+
+    The first waited on the uuid that graph.add() returned, which never
+    matches anything episode.get_by_user_id() comes back with, so it burned
+    the full timeout every call and then read the graph early.
+
+    The second waited for every episode to report processed=True. That looked
+    obviously correct and is still not enough: on a clean project the episodes
+    all said processed while the launch facts had produced NO nodes at all, so
+    the graph answered "when is the launch?" with the Lisbon meetup and a
+    benchmark would have scored Zep as having forgotten a fact it was
+    mid-way through filing. `processed` describes the EPISODE, not the graph
+    derived from it.
+
+    So: processed on every episode, AND a node count that has stopped moving.
+    mem0 needs the same treatment for the same reason and offers no flag at
+    all. The lesson generalises past both of them -- on any store that infers,
+    "ingested" and "queryable" are different events, and only one of them is
+    reported to you.
     """
-    started = time.time()
+    started, last, stable = time.time(), -1, 0
     while time.time() - started < MAX_WAIT_SECONDS:
         try:
             found = client.graph.episode.get_by_user_id(user_id=USER, lastn=20)
             episodes = getattr(found, "episodes", found) or []
-            if episodes and all(getattr(e, "processed", False) for e in episodes):
-                print(f"         (processed after {int(time.time() - started)}s)")
+            done = bool(episodes) and all(getattr(e, "processed", False) for e in episodes)
+            # processed=True is necessary and NOT sufficient -- see docstring.
+            nodes = len(client.graph.node.get_by_user_id(user_id=USER, limit=100) or [])
+            stable = stable + 1 if done and nodes == last and nodes > 0 else 0
+            last = nodes
+            if stable >= 3:
+                print(f"         (processed, {nodes} nodes, settled after "
+                      f"{int(time.time() - started)}s)")
                 return
         except Exception:
             pass


### PR DESCRIPTION
Three explanations for those unexplained Zep nodes, in order: cross-user
entity bleed, then the vendor's onboarding sandbox, then -- finally, with
evidence -- neither.

We deleted every user in the project and confirmed zero remained. A brand new
user, on a verifiably empty project, told nothing but our three sentences,
came back holding CTR, brand deal, contract, rough cut, retention rate and
"percentage of viewers watching until a specific timestamp". There was
nothing left to leak from.

It is the project-wide ontology, set by Zep's onboarding wizard and visible
on the project page under Project Wide Customization. Every user in the
project inherits those entity definitions, and deleting users never touches
them. Not a bug, not a leak -- a configured schema doing exactly what it
says. But it means deleting users does not clean a Zep project, a clean
comparison needs the ontology reset or a fresh project, and #35 as written
would have "isolated" races that were never isolated.

It may also constrain what the graph will learn. In that run, "launch is
scheduled for May" produced a May node and "the launch moved to June"
produced no June node at all, with every launch question still answering May
and the superseded edge never marked. Ontology or ingestion still settling --
not separated yet, and the README says so rather than guessing.

Both settle loops rewritten, because both were timing race conditions and
calling the result recall.

Zep's `processed` flag is necessary and not sufficient: every episode
reported processed while the launch facts had produced zero nodes, so the
graph answered "when is the launch?" with the Lisbon meetup. It describes the
episode, not the graph derived from it. Now: processed on every episode AND a
node count that has stopped moving.

mem0 has no flag, and my first fix waited for len(FACTS) rows -- wrong for a
reason worth the run it cost. An inferring store decides for itself how many
memories your sentences become; three became four, and waiting for three
returned the instant before "moved to June" landed. The read showed May
active with no June anywhere while a search seconds later returned June
happily. Now it waits for the count to stop changing.

The general form is the thing to film: on any store that infers, "ingested"
and "queryable" are different events and only one of them is reported to you.

Verified: mem0 settles at 4 memories, Zep at 17 nodes, both stable across
consecutive checks. LangMem unchanged and still resolves the contradiction
before storing.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
