### PR TITLE
memory: make the store say when it is actually searchable

### DIFF
--- a/evals/deterministic/test_fact_store_conformance.py
+++ b/evals/deterministic/test_fact_store_conformance.py
@@ -165,6 +165,33 @@ def test_non_ascii_round_trips_on_every_backend(store):
     assert store.search("Сергей") != [], "a Cyrillic fact stored but not findable"
 
 
+def test_settle_reports_readiness_and_never_raises(store):
+    """settle() answers "is what I wrote actually searchable yet".
+
+    Every backend in this suite is local, so all of them must return True
+    immediately — a sleep on the local path would be pure cost. The hosted two
+    are the reason the method exists: mem0 has no readiness signal at all and
+    measured 14s from add() to queryable, and Zep's per-add `processed` flag
+    reported done while the graph derived from those episodes still held zero
+    matching nodes.
+
+    The contract that matters is the pairing asserted below. settle() returning
+    True while a just-written fact is not findable would be worse than having
+    no method: the caller would have a green light and a wrong answer, and
+    would blame the store's memory rather than its clock.
+    """
+    store.add("alex", "runs a robotics startup")
+    assert store.settle() is True, "a local backend has nothing to wait for"
+    assert store.search("robotics") != [], "settled must mean searchable, not merely written"
+
+
+def test_settle_is_safe_to_call_on_an_empty_store(store):
+    """Called before anything is written — the arena's control contestant seeds
+    nothing at all. Waiting for a count to stabilise must not hang or throw on
+    a store where the count is legitimately zero forever."""
+    assert store.settle(timeout=5.0) is True
+
+
 # --- the suite keeps itself honest -------------------------------------------
 
 def _protocol_methods() -> list[str]:

--- a/evals/deterministic/test_memory_arena.py
+++ b/evals/deterministic/test_memory_arena.py
@@ -247,6 +247,7 @@ class _FakeWaku:
     same usage.jsonl the real app does — so token accounting is exercised too."""
 
     built: ClassVar[list] = []   # every instance a run created, so a test can inspect it
+    settles: ClassVar[bool] = True   # what facts.settle() reports back
 
     def __init__(self, settings=None, **kw):
         from types import SimpleNamespace
@@ -260,7 +261,13 @@ class _FakeWaku:
         # probing, so a seeded fact can only be reached through the store. A
         # fake that cannot do that would let the real thing regress silently —
         # which is the whole reason the bypass survived until a live race.
-        self.memory = SimpleNamespace(conn=object(), facts=object(), episodes=object())
+        # A store that reports readiness, and records WHEN it was asked. The
+        # runner must ask after the last seed and before the first probe;
+        # anywhere else and it is timing the network instead of the memory.
+        self.settled_after: list[int] = []
+        facts = SimpleNamespace(settle=lambda timeout=120.0: (
+            self.settled_after.append(len(self.seen)) or _FakeWaku.settles))
+        self.memory = SimpleNamespace(conn=object(), facts=facts, episodes=object())
         self.cleared_after: list[int] = []
         self.session = SimpleNamespace(
             start_new=lambda sid: self.cleared_after.append(len(self.seen)))
@@ -503,3 +510,78 @@ def test_probes_designed_to_need_no_memory_are_not_called_leaks(monkeypatch, tmp
         "only the probe that asserts recalled content is a leak; the arithmetic "
         f"and refusal probes are designed to pass without memory — got {done['leaked']}"
     )
+
+
+def test_store_is_asked_to_settle_between_seeding_and_probing(tmp_path, monkeypatch):
+    """The runner must wait for the store to become searchable, and must do it
+    AFTER the last seed and BEFORE the first probe.
+
+    Both hosted backends are eventually consistent and both understate it:
+    mem0 offers no readiness signal at all (measured 14s from add() to
+    queryable), and Zep's per-add `processed` flag went green while the graph
+    derived from those episodes still held zero matching nodes. Probe in that
+    window and the store answers a question about a fact it is still filing —
+    which scores as MISS. The benchmark then reports amnesia and is measuring
+    the network.
+
+    Ordering is the whole assertion. Settling before the seeds finish waits for
+    nothing; settling after the probes is decoration.
+    """
+    import waku.app
+
+    fx = _arena_fixture(tmp_path)          # 2 seed lines, 2 probes
+    _FakeWaku.script = {"q1?": "alpha", "q2?": "new"}
+    _FakeWaku.gate = True
+    _FakeWaku.built = []
+    _FakeWaku.settles = True
+    monkeypatch.setattr(waku.app, "Waku", _FakeWaku)
+    _offline(monkeypatch)
+    arena.run_arena(["sqlite"], "t", lambda k, e: None, fixture=fx)
+
+    app = _FakeWaku.built[0]
+    assert app.settled_after == [2], (
+        "settle() must be called exactly once, after both seed lines and before "
+        f"the first probe — got {app.settled_after} (2 seeds, 2 probes)"
+    )
+
+
+def test_a_store_that_never_settles_says_so_instead_of_scoring_silently(tmp_path, monkeypatch):
+    """A timeout must reach the screen.
+
+    If settle() gives up, every MISS after it is suspect — the contestant may
+    know the answer perfectly well and simply not be queryable yet. Scoring
+    that as memory failure, with nothing in the output to say the store never
+    confirmed readiness, is the confident-silence bug this whole benchmark
+    keeps rediscovering. Cheaper to say "I could not confirm" than to publish
+    a number that looks like a verdict.
+    """
+    import waku.app
+
+    fx = _arena_fixture(tmp_path)
+    _FakeWaku.script = {"q1?": "alpha", "q2?": "new"}
+    _FakeWaku.gate = True
+    _FakeWaku.built = []
+    _FakeWaku.settles = False            # the store never confirms
+    monkeypatch.setattr(waku.app, "Waku", _FakeWaku)
+    _offline(monkeypatch)
+    events = []
+    arena.run_arena(["sqlite"], "t", lambda k, e: events.append((k, e)), fixture=fx)
+    _FakeWaku.settles = True             # do not leak the flag into other tests
+
+    warnings = [e for k, e in events if k == "warn"]
+    assert warnings, "a store that never confirmed readiness must emit a warning"
+    assert "readiness" in warnings[0]["message"], warnings[0]
+
+
+def test_local_stores_settle_instantly(tmp_path):
+    """sqlite writes the row and its FTS5 index in one transaction, so there is
+    nothing to wait for. This exists so nobody 'helpfully' adds a sleep to the
+    local path to match the hosted ones — the difference is the point, and it
+    is one of the few places where the simplest backend genuinely wins."""
+    from waku.db import connect
+    from waku.memory.semantic.store import SqliteFactStore
+
+    store = SqliteFactStore(connect(tmp_path))
+    store.add("alex", "runs a robotics startup")
+    assert store.settle() is True
+    assert store.search("robotics"), "settled means searchable, not merely written"

--- a/waku/memory/semantic/base.py
+++ b/waku/memory/semantic/base.py
@@ -107,3 +107,33 @@ class FactStore(Protocol):
         """Forget a fact. True if a row went away, False if `fact_id` is
         unknown."""
         ...
+
+    def settle(self, timeout: float = 120.0) -> bool:
+        """Block until everything already written is actually SEARCHABLE.
+
+        A local store returns True immediately — for sqlite the write and the
+        index are the same transaction. The hosted ones are eventually
+        consistent, and both of them mislead you about it:
+
+          - mem0 has no readiness signal at all. add() returns in under a
+            second; a live measurement put the row 14s away from being
+            queryable.
+          - Zep exposes Episode.processed, which is necessary and NOT
+            sufficient. Every episode reported processed while the graph
+            derived from them still had zero matching nodes, so a search for
+            a just-written fact returned an unrelated one.
+
+        Nothing in either API tells you the thing you need to know, so both
+        implementations wait for the row/node count to STOP CHANGING rather
+        than for a flag or a target count. A target is wrong too: a store that
+        infers decides for itself how many memories your sentences become.
+
+        Who needs this: bulk writers who read straight back — the arena seeds
+        a conversation and immediately probes it. The live agent does not call
+        this; a user's next turn is seconds away and pays no such penalty.
+
+        Returns True if it settled, False on timeout. Never raises: a backend
+        that cannot confirm readiness should degrade to a slower answer, not
+        take the caller down.
+        """
+        ...

--- a/waku/memory/semantic/langmem_store.py
+++ b/waku/memory/semantic/langmem_store.py
@@ -98,6 +98,12 @@ class LangMemFactStore:
         self.store.delete(_NAMESPACE, str(fact_id))
         return True
 
+    def settle(self, timeout: float = 120.0) -> bool:
+        """Already settled. The store is in this process — InMemoryStore is a
+        dict, PostgresStore is a synchronous write. There is no queue to drain
+        because there is no server."""
+        return True
+
     @staticmethod
     def _row(item) -> dict:
         value = getattr(item, "value", None) or {}

--- a/waku/memory/semantic/mem0_store.py
+++ b/waku/memory/semantic/mem0_store.py
@@ -97,6 +97,35 @@ class Mem0FactStore:
             return False   # unknown id — False, never an exception (base.py)
         return True
 
+    def settle(self, timeout: float = 120.0) -> bool:
+        """Wait for extraction to go quiet. mem0 gives you no signal at all.
+
+        add() returns in under a second and the row is not queryable yet — a
+        live run measured 14s. There is no `processed` flag to poll and no
+        count to wait for either: infer=True means mem0 decides how many
+        memories your sentences become, so "wait for N rows" stops one row
+        early and reads a half-written store. Three seeded sentences became
+        four memories in testing, and waiting for three returned the instant
+        before the correction landed.
+
+        So: poll until the count stops moving. Cheap when already settled.
+        """
+        import time
+
+        started, last, stable = time.monotonic(), -1, 0
+        while time.monotonic() - started < timeout:
+            try:
+                found = len(self._rows(self.client.get_all(
+                    filters={"user_id": self.user_id}, version="v2")))
+            except Exception:
+                return False
+            stable = stable + 1 if found == last and found > 0 else 0
+            last = found
+            if stable >= 3:
+                return True
+            time.sleep(2)
+        return False
+
     def delete(self, fact_id: int | str) -> bool:
         try:
             self.client.delete(memory_id=str(fact_id))

--- a/waku/memory/semantic/store.py
+++ b/waku/memory/semantic/store.py
@@ -121,3 +121,9 @@ class SqliteFactStore:
         cur = self.conn.execute("DELETE FROM facts WHERE id=?", (fact_id,))
         self.conn.commit()
         return cur.rowcount > 0
+
+    def settle(self, timeout: float = 120.0) -> bool:
+        """Already settled. The row and its FTS5 index land in one transaction,
+        so a fact is searchable the instant add() returns. The hosted backends
+        have to work for this."""
+        return True

--- a/waku/memory/semantic/supabase_store.py
+++ b/waku/memory/semantic/supabase_store.py
@@ -159,3 +159,9 @@ class SupabaseFactStore:
             .execute()
         )
         return bool(result.data)
+
+    def settle(self, timeout: float = 120.0) -> bool:
+        """Already settled. The embedding is computed before the INSERT, so the
+        row is searchable as soon as Postgres commits it. Nothing is inferred
+        here and nothing happens later — that is the trade this backend makes."""
+        return True

--- a/waku/memory/semantic/zep_store.py
+++ b/waku/memory/semantic/zep_store.py
@@ -118,6 +118,39 @@ class ZepFactStore:
             time.sleep(_POLL_EVERY)
         return False
 
+    def settle(self, timeout: float = 120.0) -> bool:
+        """Wait until the GRAPH has stopped growing, not until the episodes say
+        they are done.
+
+        `_wait_processed` above already blocks per add(), and it is not enough.
+        A live run on a clean project had every episode reporting
+        processed=True while the launch facts had produced no nodes at all, so
+        asking "when is the launch?" returned an unrelated fact about a meetup.
+        `processed` describes the EPISODE; the nodes and edges derived from it
+        arrive afterwards, and nothing announces them.
+
+        A benchmark that seeds and immediately probes needs the second event,
+        so: every episode processed AND a node count that has held still.
+        """
+        started, last, stable = time.monotonic(), -1, 0
+        while time.monotonic() - started < timeout:
+            try:
+                found = self.client.graph.episode.get_by_user_id(
+                    user_id=self.user_id, lastn=50)
+                episodes = getattr(found, "episodes", None) or []
+                done = bool(episodes) and all(
+                    getattr(ep, "processed", False) for ep in episodes)
+                nodes = len(self.client.graph.node.get_by_user_id(
+                    user_id=self.user_id, limit=200) or [])
+            except Exception:  # noqa: S110 — transient; the deadline is the real bound
+                nodes, done = -1, False
+            stable = stable + 1 if done and nodes == last and nodes > 0 else 0
+            last = nodes
+            if stable >= 3:
+                return True
+            time.sleep(_POLL_EVERY)
+        return False
+
     def search(self, query: str, top_k: int = 4) -> list[str]:
         return [row["content"] for row in self._search_rows(query, top_k)]
 

--- a/waku/ops/memory_arena.py
+++ b/waku/ops/memory_arena.py
@@ -401,6 +401,21 @@ def run_arena(backends: list[str], track: str, emit, fixture: dict | None = None
             consolidation.consolidate_if_due(app.memory.conn, app.client,
                                              app.settings.small_model, 1,
                                              app.memory.facts, app.memory.episodes)
+
+            # 3. WAIT FOR THE STORE TO BECOME SEARCHABLE. sqlite and LangMem
+            #    return instantly; the hosted two are eventually consistent and
+            #    both understate it. mem0 has no readiness signal and measured
+            #    14s to queryable; Zep's per-add `processed` wait was passing
+            #    while the graph still held zero matching nodes. Probing there
+            #    scores the network, and it scores it as amnesia — the store
+            #    answers a question about a fact it is still filing, so the
+            #    verdict is MISS and nothing on screen says why.
+            settled = app.memory.facts.settle()
+            if not settled:
+                emit("warn", {"contestant": backend,
+                              "message": "store did not confirm readiness before probing; "
+                                         "results for this contestant may understate it"})
+
             app.session.start_new("probes")
 
             # The ledger is cumulative, so each probe's cost is the DELTA. Storing


### PR DESCRIPTION
The arena seeds a conversation and immediately probes it. Both hosted
backends are eventually consistent, both understate it, and until now the
runner believed them.

mem0 has no readiness signal whatsoever. add() returns in under a second and
a live measurement put the row 14s from queryable. The arena's mem0 adapter
did not wait at all, so a race would have seeded eight facts and asked about
them while the store was still empty -- scoring mem0 near zero and calling it
memory failure.

Zep looked safe and was not. Its adapter already polls Episode.processed per
add(), which sounds sufficient and is not: on a clean project every episode
reported processed while the graph derived from them held zero matching
nodes, so "when is the launch?" came back with an unrelated fact about a
meetup. `processed` describes the EPISODE. The nodes and edges arrive
afterwards and nothing announces them.

So FactStore grows a sixth method. settle() blocks until what you already
wrote is searchable, returns True/False rather than raising, and the arena
calls it once after the consolidation flush and before the first probe. Once
per race, not once per fact -- the live agent never calls it, because a
user's next turn is seconds away and should not pay for this.

sqlite, Supabase and LangMem return True immediately and say why in one line
each: the row and its FTS5 index are one transaction, the embedding is
computed before the INSERT, the store is a dict in this process. That
asymmetry is worth stating out loud rather than hiding behind a uniform
interface.

Both hosted implementations wait for the count to STOP CHANGING rather than
for a flag or a target. A target is the tempting version and it is wrong: a
store that infers decides for itself how many memories your sentences become.
Three seeded sentences produced four memories in testing, and waiting for
three returned the instant before the correction landed -- a read showing the
superseded value as active with the correction nowhere, seconds before a
search returned it happily.

A settle() that times out now emits a warn event instead of scoring in
silence, because every MISS after a timeout is suspect: the contestant may
know the answer and simply not be reachable yet.

Four tests, and the two that guard the wiring were confirmed to bite -- with
the settle call disabled, both go red. Ordering is the real assertion: settle
after the last seed and before the first probe. Settling early waits for
nothing, settling late is decoration.

The conformance suite caught its own gap here, exactly as designed -- adding
a method to the Protocol without covering it failed
test_every_method_on_the_contract_is_actually_exercised_here before I had
written a line of coverage for it.

Gate: ruff clean, 575 passed, 59 skipped.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
