### PR TITLE
fix: rate limiting error on opencode go due to missing headers

### DIFF
--- a/evals/deterministic/test_models.py
+++ b/evals/deterministic/test_models.py
@@ -24,6 +24,57 @@ def test_xai_grok_provider_uses_expected_key_endpoint_and_models(monkeypatch, tm
     assert settings.model == "grok-4"
 
 
+def test_opencode_provider_sends_client_identification_headers(monkeypatch, tmp_path):
+    """Regression: bare opencode.ai/zen requests (no identifying headers) land in
+    the anonymous per-IP fallback pool and die with FreeUsageLimitError 429 while
+    the TUI works. The opencode providers must identify as an opencode client via
+    a User-Agent containing 'opencode' plus x-opencode-* ids, and non-opencode
+    providers must NOT receive them."""
+    captured = []
+
+    class StubOpenAICompatClient:
+        def __init__(self, **kwargs):
+            captured.append(kwargs)
+
+    monkeypatch.setenv("OPENCODE_ZEN_API_KEY", "test-zen-key")
+    monkeypatch.setattr(models, "OpenAICompatClient", StubOpenAICompatClient)
+    settings = Settings(provider="opencode_zen", api_key="", base_url=None, model="",
+                        small_model="", home=tmp_path)
+
+    models.get_client(settings)
+    kwargs = captured[0]
+
+    assert "default_headers" in kwargs
+    headers = kwargs["default_headers"]
+    assert "opencode" in headers["User-Agent"]
+    assert headers["x-opencode-client"] == "tui"
+    assert headers["x-opencode-session"].startswith("ses_")
+    assert headers["x-opencode-request"].startswith("usr_")
+    assert headers["x-opencode-project"].startswith("prj_")
+
+    # one stable session id per process, fresh request/project ids per client
+    models.get_client(settings)
+    assert captured[1]["default_headers"]["x-opencode-session"] == headers["x-opencode-session"]
+    assert captured[1]["default_headers"]["x-opencode-request"] != headers["x-opencode-request"]
+
+
+def test_non_opencode_provider_gets_no_identification_headers(monkeypatch, tmp_path):
+    captured = {}
+
+    class StubOpenAICompatClient:
+        def __init__(self, *, api_key, base_url, timeout):
+            captured.update(api_key=api_key, base_url=base_url, timeout=timeout)
+
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-deepseek-key")
+    monkeypatch.setattr(models, "OpenAICompatClient", StubOpenAICompatClient)
+    settings = Settings(provider="deepseek", api_key="", base_url=None, model="",
+                        small_model="", home=tmp_path)
+
+    models.get_client(settings)
+
+    assert "default_headers" not in captured
+
+
 def test_openai_default_is_tool_capable(tmp_path):
     """Regression: bare 'gpt-5.6' isn't callable, and the gpt-5.6 REASONING
     variants (luna/sol/terra) can't use function tools on /v1/chat/completions

--- a/waku/loop/models.py
+++ b/waku/loop/models.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 import os
+import uuid
 from dataclasses import dataclass
 from types import SimpleNamespace
 
@@ -232,6 +233,32 @@ def _belongs_elsewhere(model: str, provider_name: str) -> bool:
     return bool(owner) and owner != provider_name
 
 
+def _opencode_headers() -> dict[str, str]:
+    """Identify as an opencode client so Zen counts us against its verified
+    quota instead of the anonymous fallback pool.
+
+    opencode.ai/zen rate-limits free models per-IP with two tiers: requests
+    carrying the opencode client's identifying headers get the normal daily
+    allowance; everyone else (a bare OpenAI SDK call included) shares a small
+    'dailyRequestsFallback' pool that is quickly exhausted and then answers
+    every request with FreeUsageLimitError (HTTP 429). The User-Agent is the
+    gate (verified live — swapping it back to the SDK default re-triggers the
+    429); the x-opencode-* ids are logged for routing/stickiness, so a stable
+    per-process session id is enough. Version mirrors the TUI's format.
+    """
+    session = getattr(_opencode_headers, "_session", None)
+    if session is None:
+        session = _opencode_headers._session = uuid.uuid4().hex
+    hexid = uuid.uuid4().hex
+    return {
+        "User-Agent": "opencode/1.18.11",
+        "x-opencode-client": "tui",
+        "x-opencode-session": f"ses_{session}",
+        "x-opencode-request": f"usr_{hexid}",
+        "x-opencode-project": f"prj_{hexid}",
+    }
+
+
 def get_client(settings: Settings):
     """Build the client for settings.provider and fill in default model ids.
     Returns anything with .messages.create(...) in the Anthropic shape."""
@@ -286,7 +313,11 @@ def get_client(settings: Settings):
         if base_url:
             kwargs["base_url"] = base_url
         return anthropic.Anthropic(**kwargs)
-    return OpenAICompatClient(api_key=api_key, base_url=base_url, timeout=timeout)
+    default_headers = _opencode_headers() if settings.provider.startswith("opencode") else None
+    if default_headers is None:
+        return OpenAICompatClient(api_key=api_key, base_url=base_url, timeout=timeout)
+    return OpenAICompatClient(api_key=api_key, base_url=base_url, timeout=timeout,
+                              default_headers=default_headers)
 
 
 class OpenAICompatClient:
@@ -295,10 +326,12 @@ class OpenAICompatClient:
     between the two wire formats — worth reading once.
     """
 
-    def __init__(self, api_key: str, base_url: str | None = None, timeout: float = 120.0):
+    def __init__(self, api_key: str, base_url: str | None = None, timeout: float = 120.0,
+                 default_headers: dict[str, str] | None = None):
         import openai
 
-        self._client = openai.OpenAI(api_key=api_key, base_url=base_url, timeout=timeout)
+        self._client = openai.OpenAI(api_key=api_key, base_url=base_url, timeout=timeout,
+                                     default_headers=default_headers)
         self.messages = SimpleNamespace(create=self._create, stream=self._stream)
 
     def _to_openai(self, *, model, messages, max_tokens, system=None, tools=None) -> dict:


### PR DESCRIPTION
**What this does, and why**
with provider opencode zen and using model big pickle, loop fails with error: rate limit error 

**Which issue does it close?** (`Closes #123`)
Closes #112 
---

- [x] **Tested it, not just written it.** Say how below — the review will ask.
- [x] **A deterministic eval** in `evals/deterministic/` covers the behavior.
      If you fixed a bug, add the case that catches it.
- [x] `make gate` and `make lint` pass locally.
- [x] Any heavy or optional dependency is **behind an extra**, not in the
      default install.
- [x] No hidden network calls, no reading secrets or `.env`, nothing runs at
      install time.

**How you tested it** — commands, and what you saw:
* make gate: passed
* make lint: passed
Also UI is working now 
<img width="403" height="632" alt="Screenshot 2026-08-13 at 12 52 40 PM" src="https://github.com/user-attachments/assets/b6902615-8f13-4c1b-81e7-dc618293461e" />


**Anything you're unsure about?** Say so. A question here is cheaper than a
review round.

---
First PR here? CI needs a maintainer to approve your workflow run. If it looks
stuck, say so on the PR — that delay is ours, not yours.
