### PR TITLE
arena: the control holds nothing on purpose, so stop calling that an error

### DIFF
--- a/evals/deterministic/test_memory_arena.py
+++ b/evals/deterministic/test_memory_arena.py
@@ -585,3 +585,26 @@ def test_local_stores_settle_instantly(tmp_path):
     store.add("alex", "runs a robotics startup")
     assert store.settle() is True
     assert store.search("robotics"), "settled means searchable, not merely written"
+
+
+def test_the_control_reports_why_it_is_empty_instead_of_crashing():
+    """The control is a contestant, not a backend, and the read-stores page has
+    to say so.
+
+    It has no store behind it — that is the entire job. But _available_backends
+    lists it (correct for a race) and store_contents iterates the same list, so
+    it built a Settings(semantic_store="control"), got None from _conn_for, and
+    the sqlite path called .execute() on it. The card rendered
+    "AttributeError: 'NoneType' object has no attribute 'execute'", which reads
+    as a broken control contestant when holding nothing is the point.
+
+    A note, not an error, and not a bare "0 facts" either — this page exists
+    precisely because those three mean different things.
+    """
+    rows = arena.store_contents()
+    control = [r for r in rows if r["store"] == arena.CONTROL]
+    assert control, "the control must still appear — its emptiness is the lesson"
+    assert not control[0]["error"], (
+        f"the control must not report an error: {control[0]['error']}"
+    )
+    assert "by design" in control[0]["note"], control[0]["note"]

--- a/waku/ops/memory_arena.py
+++ b/waku/ops/memory_arena.py
@@ -589,6 +589,17 @@ def _store_note(key: str) -> str:
     false statement about an empty store rather than a true one about an
     unreadable one, and the difference is the whole point of this page.
     """
+    if key == CONTROL:
+        # The control is a contestant, not a backend. It is told nothing and
+        # asked everything, so there is no store behind it to read — and
+        # _conn_for returns None for anything that is not sqlite, which the
+        # sqlite path then calls .execute() on. That surfaced on the page as
+        # "AttributeError: 'NoneType' object has no attribute 'execute'", which
+        # reads as "your control contestant is broken" when the truth is that
+        # holding nothing is the entire job.
+        return ("told nothing, by design — there is no store behind this one. "
+                "It exists so a probe it still passes can be flagged as a "
+                "question that never needed memory.")
     if key == "langmem" and not os.getenv("WAKU_LANGMEM_POSTGRES", "").strip():
         return ("in-memory store — contents live inside the process that wrote them "
                 "and cannot be read back here. Set WAKU_LANGMEM_POSTGRES to persist.")


### PR DESCRIPTION
Sean opened Read stores and the control card came back with
"AttributeError: 'NoneType' object has no attribute 'execute'". It reads as
a broken control contestant. It is the opposite: holding nothing is the
entire job.

_available_backends() lists CONTROL, which is right for a race -- it is the
integrity check that runs alongside the real stores. store_contents()
iterates the same list, which is where it goes wrong. It built a
Settings(semantic_store="control"), _conn_for returned None because the key
is not "sqlite", and the sqlite fact store then called .execute() on None.

So the control now carries a note instead, next to LangMem's. That choice is
this file's own rule, already written in store_contents' docstring: a
backend that errors must not look like a backend that is empty, because "0
facts" and "I could not reach the service" mean opposite things. The control
is a third case again -- empty ON PURPOSE -- and flattening it into either of
the other two loses the one thing the card is there to teach. The note says
so in words: told nothing by design, and it exists so a probe it still
passes can be flagged as a question that never needed memory.

Verified live rather than from the diff: restarted the dashboard on this
code and read /api/memory-arena/stores back. control is now count 0, error
empty, note present. sqlite 53, mem0 0, zep 1, langmem noted as unreadable
-- every card saying the true thing for a different reason.

The regression test was confirmed to bite: disable the CONTROL branch and it
goes red on the error field.

Gate: ruff clean, 576 passed, 59 skipped.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
