### PR TITLE
arena: show the questions before the verdict, not after it

### DIFF
--- a/waku/ops/memory_arena.py
+++ b/waku/ops/memory_arena.py
@@ -550,9 +550,13 @@ def store_contents(limit: int = 8, only: str = "") -> list[dict]:
         # only ever received what the arena wrote to it. Side by side without
         # saying so, "53 vs 17" reads as "waku remembers more", when it only
         # means waku has been used and the others were connected yesterday.
+        # Three kinds, not two. "connected account" is a lie about the control
+        # — it has no account, no service and no rows, and printing that line
+        # above a note that says "told nothing by design" makes the card argue
+        # with itself.
+        kind = "live" if key == "sqlite" else "control" if key == CONTROL else "connected"
         row = {"store": key, "count": 0, "facts": [], "error": "", "span": "",
-               "kind": "live" if key == "sqlite" else "connected",
-               "note": _store_note(key)}
+               "kind": kind, "note": _store_note(key)}
         if row["note"]:
             out.append(row)   # nothing meaningful to read — say why, don't report 0
             continue

--- a/waku/ops/static/js/compare.js
+++ b/waku/ops/static/js/compare.js
@@ -603,7 +603,10 @@ function maResultsHtml(){
     if (!maRun.running) return `<td class="meta">—</td>`;
     const seeded = (maRun.seeded || {})[n];
     if (seeded === undefined) return `<td class="meta">queued</td>`;
-    if (seeded < seedTotal) return `<td class="meta">seeding ${seeded}/${seedTotal}<span class="caret"></span></td>`;
+    // "seeding 4/8" reads like a progress bar for something the viewer has not
+    // been shown. "told 4 of 8" names the actual event: this store has now been
+    // told four of the eight facts it is about to be questioned on.
+    if (seeded < seedTotal) return `<td class="meta">told ${seeded} of ${seedTotal}<span class="caret"></span></td>`;
     return `<td class="meta">asking<span class="caret"></span></td>`;
   };
   const board = maRun.board ? `<div class="card" style="padding:4px 8px"><div class="tablescroll"><table>
@@ -695,7 +698,16 @@ function memoryArenaView(){
            Every store runs in its own throwaway copy — your real memory is never touched.`}</span>
     </div>
     <div class="cmp-picks">${chips}</div></div>`;
-  return race + maResultsHtml() + maStoresHtml() + maAsksHtml(track);
+  // ORDER MATTERS, and it used to be wrong: race, results, stores, asks. The
+  // questions were dead last, so you could start a race — and film one —
+  // without ever having seen what the stores get told or asked. A benchmark
+  // whose questions arrive after its verdict is asking you to take the verdict
+  // on trust, which is the one thing this page exists not to do.
+  //
+  // Pick, then see what they'll be told and asked, then the verdict, then the
+  // contents. Store cards go last on purpose: they are the slowest to read and
+  // the only part that needs a button press.
+  return race + maAsksHtml(track) + maResultsHtml() + maStoresHtml();
 }
 
 // --- what each store is holding, right now ----------------------------------
@@ -726,6 +738,8 @@ function maStoresHtml(){
                   : `<span class="meta">${s.count} fact${s.count===1?"":"s"}</span>`}</div>
       <div class="ma-prov">${s.kind === "live"
         ? `your live agent &middot; <code>.waku/state.db</code>`
+        : s.kind === "control"
+        ? `not a store &middot; the integrity check`
         : `connected account &middot; only what waku wrote`}${
         s.span ? ` &middot; ${esc(s.span)}` : ""}</div>
       ${s.error ? `<div class="ma-ans">${esc(s.error)}</div>`


### PR DESCRIPTION
The memory tab rendered race, results, stores, asks -- questions dead last,
below five store cards. You could start a race, and film one, without ever
having seen what the stores get told or asked. A benchmark whose questions
arrive after its verdict is asking you to take the verdict on trust, which is
the one thing this page exists not to do.

Now: pick, see what they'll be told and asked, then the verdict, then the
contents. Store cards stay last on purpose -- they are the slowest to read
and the only part gated behind a button.

"seeding 4/8" becomes "told 4 of 8". The old label read like a progress bar
for something the viewer had not been shown; the new one names the event.
This store has now been told four of the eight facts it is about to be
questioned on.

And the control card stopped arguing with itself. It printed "connected
account - only what waku wrote" directly above a note saying it is told
nothing by design and has no store behind it. Both cannot be true. There are
three kinds here, not two -- live, connected, and a control that is not a
store at all -- so it now reads "not a store - the integrity check".

Verified live, not from the diff: restarted, reloaded, and read
/api/memory-arena/stores back. sqlite kind=live 53, mem0/langmem/zep
kind=connected, control kind=control with no error. The reorder is visible on
one screen -- the questions and the Race button no longer need a scroll
between them.

One change is NOT verified in the browser: "told N of M" only renders while a
race is running, and a race costs real tokens against a metered account. The
string is a one-line change in the same cell that already rendered the old
label, and it will be seen the first time Sean races.

Gate: ruff clean, 576 passed, 59 skipped.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
