### PR TITLE
arena: tell once, ask many times — and stop leaking a directory per race

### DIFF
--- a/evals/deterministic/test_memory_arena.py
+++ b/evals/deterministic/test_memory_arena.py
@@ -300,10 +300,22 @@ def _offline(monkeypatch, declined=None):
     """No network. The consolidation flush and the referee are both real calls
     in run_arena now; `declined=None` is the adjudicator's own "judge
     unreachable" answer, which must leave the heuristic verdict untouched."""
+    import tempfile
+    from pathlib import Path
+
     from waku.memory import consolidation
 
     monkeypatch.setattr(consolidation, "consolidate_if_due", lambda *a, **k: 0)
     monkeypatch.setattr(arena, "adjudicate_refusal", lambda *a, **k: declined)
+    # Arena homes are now NAMED for their seed, so a real run reuses one and
+    # skips re-telling. That is the point of them — and it would make these
+    # tests depend on whether an earlier run left a `.seeded` marker behind,
+    # which is a suite that passes only on a machine that has never raced.
+    # A fresh directory per call restores isolation; the reuse behaviour gets
+    # its own test below, where the home is pinned deliberately.
+    monkeypatch.setattr(arena, "arena_home",
+                        lambda backend, track, seed, model:
+                        Path(tempfile.mkdtemp(prefix=f"arena-test-{backend}-")))
 
 
 def _run(monkeypatch, tmp_path, script, gate=False, backends=("sqlite",)):
@@ -608,3 +620,62 @@ def test_the_control_reports_why_it_is_empty_instead_of_crashing():
         f"the control must not report an error: {control[0]['error']}"
     )
     assert "by design" in control[0]["note"], control[0]["note"]
+
+
+def test_a_store_already_told_is_not_told_again(tmp_path, monkeypatch):
+    """Telling is 53% of a race and perfectly deterministic. Doing it twice is
+    the single biggest waste in the arena, and on camera it is the difference
+    between a 40-second take and a 90-second one.
+
+    Homes are now NAMED for what they hold — a hash of the track, the model and
+    the seed lines — so the second run addresses the same directory and finds a
+    `.seeded` marker. That naming is also the staleness guard, for free: change
+    the probe set, the track or the model and you address a DIFFERENT directory,
+    so a race can never quietly probe a store seeded for another question.
+    """
+    import waku.app
+
+    fx = _arena_fixture(tmp_path)          # 2 seed lines, 2 probes
+    home = tmp_path / "pinned"
+    _FakeWaku.script = {"q1?": "alpha", "q2?": "new"}
+    _FakeWaku.gate = True
+    _FakeWaku.settles = True
+    monkeypatch.setattr(waku.app, "Waku", _FakeWaku)
+    _offline(monkeypatch)
+    monkeypatch.setattr(arena, "arena_home", lambda *a, **k: home)
+
+    _FakeWaku.built = []
+    arena.run_arena(["sqlite"], "t", lambda k, e: None, fixture=fx)
+    first = list(_FakeWaku.built[0].seen)
+    assert first[:2] == ["fact one", "fact two"], f"first run must seed: {first}"
+    assert (home / ".seeded").exists(), "a settled home must record that it is ready"
+
+    _FakeWaku.built = []
+    arena.run_arena(["sqlite"], "t", lambda k, e: None, fixture=fx)
+    second = list(_FakeWaku.built[0].seen)
+    assert "fact one" not in second, f"already told — must not re-tell: {second}"
+    assert "q1?" in second, "it must still ask, it just should not re-tell"
+
+
+def test_a_home_is_only_marked_ready_once_the_store_confirms_it_is_searchable(
+        tmp_path, monkeypatch):
+    """The marker goes last, after settle(). A home marked ready while the store
+    was still filing would be reused by the NEXT race and probed mid-ingest —
+    turning one race condition into a permanent, cached one."""
+    import waku.app
+
+    fx = _arena_fixture(tmp_path)
+    home = tmp_path / "never-settles"
+    _FakeWaku.script = {"q1?": "alpha", "q2?": "new"}
+    _FakeWaku.gate = True
+    _FakeWaku.built = []
+    _FakeWaku.settles = False            # the store never confirms
+    monkeypatch.setattr(waku.app, "Waku", _FakeWaku)
+    _offline(monkeypatch)
+    monkeypatch.setattr(arena, "arena_home", lambda *a, **k: home)
+    arena.run_arena(["sqlite"], "t", lambda k, e: None, fixture=fx)
+    _FakeWaku.settles = True
+
+    assert not (home / ".seeded").exists(), (
+        "a store that never confirmed readiness must not be cached as ready"
+    )

--- a/waku/ops/dashboard.py
+++ b/waku/ops/dashboard.py
@@ -1054,7 +1054,8 @@ class Handler(BaseHTTPRequestHandler):
                 track = hit["track"] if hit else (payload.get("track") or "example")
                 memory_arena.run_arena(payload.get("backends") or ["sqlite"],
                                        track, emit_mem, fixture=fixture,
-                                       model=(payload.get("model") or "").strip())
+                                       model=(payload.get("model") or "").strip(),
+                                       seed_only=bool(payload.get("seed_only")))
             except Exception as exc:
                 emit_mem("done", {"error": f"{type(exc).__name__}: {exc}"})
             return

--- a/waku/ops/memory_arena.py
+++ b/waku/ops/memory_arena.py
@@ -311,8 +311,49 @@ def render(rows: list[dict]) -> str:
 # through the thing that actually calls it — the gate decides whether to search
 # at all, and that decision is half of what separates these systems.
 
+def arena_home(backend: str, track: str, seed: list[str], model: str) -> Path:
+    """A home NAMED for what it holds, so seeding once can serve many races.
+
+    This replaced tempfile.mkdtemp, which was wrong twice over.
+
+    It leaked: nothing ever removed the directories, and 656 of them had piled
+    up by the time anyone counted. And it made seeding unrepeatable — a fresh
+    random path every run meant every race re-seeded from empty, which is 53%
+    of a race spent re-telling a store facts it was told a minute ago.
+
+    The name is a hash of everything the seeded state depends on: the track,
+    the model, and the seed lines themselves. That is the staleness guard, for
+    free and by construction. Change the probe set, the track or the model and
+    you address a different directory — so a race can never quietly probe a
+    store that was seeded for a different question.
+
+    Lives under `.waku-arena/`, which `.gitignore` already covers via `.waku-*/`
+    — the glob that exists because a second agent home's SOUL.md and usage
+    ledger are the files you least want pushed.
+    """
+    import hashlib
+
+    from waku.config import load_settings
+
+    key = hashlib.sha256("\n".join([track, model, *seed]).encode()).hexdigest()[:12]
+    home = load_settings().home.parent / ".waku-arena" / f"{backend}-{key}"
+    home.mkdir(parents=True, exist_ok=True)
+    return home
+
+
+def _is_seeded(home: Path) -> bool:
+    """Written only after seeding AND settle() both finished.
+
+    The marker goes last on purpose. A home that was half-filled when the
+    process died must look unseeded, because the alternative is racing against
+    a store holding four of eight facts and reporting the gaps as memory
+    failure.
+    """
+    return (home / ".seeded").exists()
+
+
 def run_arena(backends: list[str], track: str, emit, fixture: dict | None = None,
-              model: str = "") -> None:
+              model: str = "", seed_only: bool = False) -> None:
     """Seed the same conversation into each backend, ask the same probes, score.
 
     One agent, one model, one loop. The ONLY variable is `WAKU_SEMANTIC_STORE`.
@@ -331,9 +372,7 @@ def run_arena(backends: list[str], track: str, emit, fixture: dict | None = None
     stored, that is a finding about the harness, and it is the same harness for
     every contestant.
     """
-    import tempfile
     import time
-    from pathlib import Path
 
     from waku.app import Waku
     from waku.config import Settings
@@ -367,13 +406,23 @@ def run_arena(backends: list[str], track: str, emit, fixture: dict | None = None
         # questions require the thing under test is decoration.
         seeding = [] if backend == CONTROL else spec["seed"]
         store = "sqlite" if backend == CONTROL else backend
-        home = Path(tempfile.mkdtemp(prefix=f"memarena-{backend}-"))
+        home = arena_home(backend, track, seeding, model)
+        already = _is_seeded(home)
         try:
             opts = {"provider": prov, "model": mod} if prov and mod else {}
             app = Waku(settings=Settings(home=home, semantic_store=store,
                                          apple_calendar=False, google_calendar=False,
                                          apple_tools=False, graph_workflows=False, **opts))
-            for line in seeding:
+            # Seeding is 53% of a race and perfectly deterministic, so a home
+            # that already holds this exact seed is not re-told. Racing is now
+            # the cheap half: seed once, ask many times.
+            if already:
+                emit("seeded", {"contestant": backend,
+                                "line": f"already told {len(seeding)} — reusing",
+                                "cached": True})
+                for _ in seeding[1:]:
+                    emit("seeded", {"contestant": backend, "line": "", "cached": True})
+            for line in [] if already else seeding:
                 app.respond(line, source="memory-arena")
                 emit("seeded", {"contestant": backend, "line": line})
 
@@ -415,6 +464,19 @@ def run_arena(backends: list[str], track: str, emit, fixture: dict | None = None
                 emit("warn", {"contestant": backend,
                               "message": "store did not confirm readiness before probing; "
                                          "results for this contestant may understate it"})
+
+            # The marker goes here and nowhere earlier: after the seed lines,
+            # after the consolidation flush, after the store confirms it is
+            # searchable. A home marked ready before settle() would be reused
+            # by the next race and probed while still filing.
+            if settled and not already:
+                (home / ".seeded").write_text(f"{track}\n{model}\n{len(seeding)} lines\n",
+                                              encoding="utf-8")
+
+            if seed_only:
+                emit("seed-done", {"contestant": backend, "home": str(home),
+                                   "facts": len(seeding), "reused": already})
+                continue
 
             app.session.start_new("probes")
 

--- a/waku/ops/static/js/compare.js
+++ b/waku/ops/static/js/compare.js
@@ -494,7 +494,9 @@ function probeRow(p){
 // --- running it -------------------------------------------------------------
 let maRun = {running:false, rows:[], board:null, log:"", error:null};
 
-async function runMemoryArena(){
+async function seedMemoryArena(){ return runMemoryArena(true); }
+
+async function runMemoryArena(seedOnly){
   if (maRun.running) return;
   const fx = memoryArenaFixture;
   const track = (maTrack && fx.tracks[maTrack]) ? maTrack : Object.keys(fx.tracks)[0];
@@ -503,15 +505,15 @@ async function runMemoryArena(){
   // landed renders an empty header for that whole first minute, which reads as
   // broken rather than busy. Columns and rows are both known before we start;
   // only the cells are pending.
-  maRun = {running:true, rows:[], board:null, log:"seeding…", error:null,
+  maRun = {running:true, rows:[], board:null, log:"telling…", error:null,
            backends: maPicks(), probes: fx.tracks[track].probes.map(p=>p.id),
-           seeded: {}};
+           seeded: {}, seedOnly: !!seedOnly};
   editing = false; render();
   try {
     const res = await fetch("/api/memory-arena/stream", {
       method:"POST", headers:{"Content-Type":"application/json"},
       body: JSON.stringify({backends: maPicks(), track, probes: maFile || "",
-                            model: maModelSpec()})});
+                            model: maModelSpec(), seed_only: !!seedOnly})});
     const reader = res.body.getReader(), dec = new TextDecoder();
     let buf = "";
     for(;;){
@@ -522,8 +524,12 @@ async function runMemoryArena(){
       for (const c of chunks){
         if (!c.startsWith("data: ")) continue;
         const ev = JSON.parse(c.slice(6));
-        if (ev.kind === "start"){ maRun.log = `${ev.contestant}: seeding…`;
+        if (ev.kind === "start"){ maRun.log = `${ev.contestant}: telling…`;
                                   maRun.seeded[ev.contestant] = 0; }
+        // A store told earlier is not re-told; the run reports it as reused so
+        // "instant" reads as cached rather than as skipped.
+        if (ev.kind === "seed-done"){ maRun.log = `${ev.contestant}: ${
+                                        ev.reused ? "already told" : "told"} ${ev.facts}`; }
         if (ev.kind === "seeded"){ maRun.log = `${ev.contestant}: ${ev.line}`;
                                    maRun.seeded[ev.contestant] = (maRun.seeded[ev.contestant]||0) + 1; }
         if (ev.kind === "probe"){ maRun.rows.push(ev); maRun.log = `${ev.contestant}: ${ev.probe}`; }
@@ -691,11 +697,16 @@ function memoryArenaView(){
   const race = `<div class="card">
     ${picker}
     <div class="ma-race">
+      <button onclick="seedMemoryArena()" ${maRun.running||!picks.length?"disabled":""}>
+        ${maRun.running && maRun.seedOnly ? "Telling…"
+          : `Tell ${picks.length} store${picks.length===1?"":"s"}`}</button>
       <button class="save" onclick="runMemoryArena()" ${maRun.running||!picks.length?"disabled":""}>
-        ${maRun.running ? "Racing…" : `Race ${picks.length} store${picks.length===1?"":"s"}`}</button>
+        ${maRun.running && !maRun.seedOnly ? "Asking…"
+          : `Ask ${picks.length} store${picks.length===1?"":"s"}`}</button>
       <span class="meta">${maRun.running ? esc(maRun.log)
-        : `Tells each store the same facts, asks the same questions, scores the answers.
-           Every store runs in its own throwaway copy — your real memory is never touched.`}</span>
+        : `Telling is half a race and never changes, so it is its own button — do it
+           once and ask as many times as you like. Ask tells anything not yet told.
+           Every store runs in its own copy; your real memory is never touched.`}</span>
     </div>
     <div class="cmp-picks">${chips}</div></div>`;
   // ORDER MATTERS, and it used to be wrong: race, results, stores, asks. The


### PR DESCRIPTION
Sean asked for a seed button and a race button because racing takes too
long. He was right, and the fix turned out to solve a second problem nobody
had connected to it.

Seeding is 53% of a race and perfectly deterministic. It was also thrown away
every time: each contestant got a fresh tempfile.mkdtemp, so every race
re-told a store the same facts it had been told a minute earlier. And nothing
ever removed those directories — 656 of them had accumulated by the time
anyone counted. One wrong decision, two symptoms.

Homes are now NAMED for what they hold: a hash of the track, the model and
the seed lines, under .waku-arena/ (already gitignored by the .waku-*/ glob).
Same seed, same directory, so the second race finds a .seeded marker and
skips straight to asking. And the naming IS the staleness guard, for free —
change the probe set, the track or the model and you address a different
directory, so a race can never quietly probe a store that was seeded for a
different question. A bounded, reusable set replaces an unbounded random one.

The marker is written after settle(), never before. A home marked ready while
the store was still filing would be reused by the NEXT race too, which turns
one race condition into a permanent cached one.

Two buttons: "Tell N stores" and "Ask N stores". Not "Seed"/"Race" -- the page
already speaks plain English everywhere else ("Tells each store the same
facts, asks the same questions"), and the badge next to it now reads "told 4
of 8". Ask still tells anything not yet told, so it always works and is
simply fast when the telling is already done.

Two existing tests failed on this change and were right to. Named homes made
them depend on whether an earlier run had left a marker behind — a suite that
passes only on a machine that has never raced. _offline() now hands every
test a fresh directory, and the reuse behaviour gets two tests of its own
where the home is pinned deliberately: one that the second run does not
re-tell, one that a store which never confirms readiness is never cached as
ready. The first was confirmed to bite.

Gate: ruff clean, 578 passed, 59 skipped. Verified live: both buttons render
and bind, dashboard restarted on this code.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
