### PR TITLE
arena: the Tell button had no class, so the browser drew it

### DIFF
--- a/waku/ops/static/js/compare.js
+++ b/waku/ops/static/js/compare.js
@@ -697,7 +697,8 @@ function memoryArenaView(){
   const race = `<div class="card">
     ${picker}
     <div class="ma-race">
-      <button onclick="seedMemoryArena()" ${maRun.running||!picks.length?"disabled":""}>
+      <button class="save ghost" onclick="seedMemoryArena()"
+              ${maRun.running||!picks.length?"disabled":""}>
         ${maRun.running && maRun.seedOnly ? "Telling…"
           : `Tell ${picks.length} store${picks.length===1?"":"s"}`}</button>
       <button class="save" onclick="runMemoryArena()" ${maRun.running||!picks.length?"disabled":""}>


### PR DESCRIPTION
It rendered as a raw white box with square corners on a dark page, beside a
properly styled Ask button. Not a design decision -- I gave it no class at
all, so it fell through to the user-agent default.

.save.ghost already existed for exactly this: same padding, radius and
disabled treatment as .save, transparent background, muted text, hairline
border. Secondary action, same shape, no new CSS.

The hierarchy is deliberate now rather than accidental. Ask stays primary
because it is the button that always works -- it tells anything not yet told,
so it is never the wrong one to press. Tell is the optimisation you reach for
when you are about to ask several times.

Verified live during one of Sean's own races: both buttons share a shape, the
Tell button reads "Telling..." and greys out mid-run, and "told 0 of 5" is on
screen -- the one string I could not check when it shipped, because it only
renders while a race is running.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
