### PR TITLE
arena: Questions and Model are one decision, so put them on one line

### DIFF
--- a/waku/ops/static/js/compare.js
+++ b/waku/ops/static/js/compare.js
@@ -681,7 +681,7 @@ function memoryArenaView(){
   // the filename told you less than the track label already did.
   const sets = (memoryArenaFixture.sets || []);
   const chosen = maFile || memoryArenaFixture.chosen || (sets[0] && sets[0].id);
-  const picker = `<div class="ma-race" style="margin-bottom:10px">
+  const picker = `<div class="ma-race ma-pickers" style="margin-bottom:10px">
       <label class="fld" style="margin:0">Questions
         <select onchange="pickProbeFile(this.value)">
           ${sets.map(s=>`<option value="${esc(s.id)}" ${s.id===chosen?"selected":""}>${

--- a/waku/ops/static/style.css
+++ b/waku/ops/static/style.css
@@ -604,6 +604,16 @@ details.subterm > summary.subterm-h::-webkit-details-marker{ display:none; }
 .ma-source{margin-top:10px;padding:8px 10px;border-radius:6px;background:var(--accent-soft);
            color:var(--ink2);font-size:12px;line-height:1.6}
 .ma-race{display:flex;align-items:center;gap:12px;flex-wrap:wrap;margin-top:12px}
+/* Questions and Model are ONE setup decision, so they belong on one line. They
+   were wrapping to a line each: a bare <select> sizes itself to its longest
+   option, and these carry text like "Example — a working week — 5 facts, 4
+   questions", which is wider than half the card. flex-basis lets them share the
+   row and min-width:0 is what actually permits the shrink — a flex item refuses
+   to go below its content width without it, which is the whole reason the
+   wrapping looked like a gap problem rather than a width one. */
+.ma-pickers .fld{margin-bottom:0;flex:1 1 260px;min-width:0}
+.ma-pickers .fld select{width:100%}
+.ma-pickers .meta{flex:1 1 100%}
 .ma-ans{font-size:11px;color:var(--ink3);margin-top:4px;max-width:280px;line-height:1.45}
 /* Equal-height cards. `align-items:stretch` is the grid default, so every card
    already spans its row — the cards were ragged because each one sized to its


### PR DESCRIPTION
They were already inside the same flex row and still wrapped to a line each,
which made one setup step look like two.

A bare <select> sizes itself to its longest option, and these carry text like
"Example — a working week — 5 facts, 4 questions" and
"kimi:kimi-k2.7-code-highspeed — $1.9/$8 per M". Wider than half the card
each, so flex-wrap did exactly what it was told.

flex-basis lets them share the row, and min-width:0 is the part that actually
permits the shrink -- a flex item will not go below its content width without
it. That is why this read as a gap or padding problem rather than a width
one. Same lesson as the store cards earlier: flex:1 needs min-width:0.

The "Drop a JSON file" hint takes flex-basis:100% so it sits under the pair
rather than competing with them for the row.

Verified live, and worth recording: the first check said the class was not in
the DOM at all. The server was serving the new file -- curl confirmed both the
JS and the CSS -- and the browser was holding a cached compare.js. A
cache-busted reload showed both labels sharing top:188 at 338px each. A
frontend change that "did not work" is worth one look at what the server
actually sent before touching the CSS again.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
