### PR TITLE
arena: the store panel now compares stores, instead of apologising for not

### DIFF
--- a/evals/deterministic/test_memory_arena.py
+++ b/evals/deterministic/test_memory_arena.py
@@ -679,3 +679,38 @@ def test_a_home_is_only_marked_ready_once_the_store_confirms_it_is_searchable(
     assert not (home / ".seeded").exists(), (
         "a store that never confirmed readiness must not be cached as ready"
     )
+
+
+def test_the_stores_panel_reads_the_races_own_sqlite_not_the_live_agent(monkeypatch):
+    """The panel sits under a benchmark that promises every store was told the
+    same thing. Reading the LIVE .waku/state.db for sqlite broke that promise:
+    the first card held months of real use next to stores that had seen one run,
+    which is why it needed a paragraph above it saying the counts were not a
+    comparison. Apologising for a comparison in prose is worse than not making
+    it — so sqlite now reads the arena's own copy.
+
+    It also stopped putting the operator's address, colleagues and work email
+    on a tab that gets filmed.
+    """
+    seen = {}
+
+    def fake_home(backend, track, seed, model):
+        seen["called"] = (backend, track, model)
+        return __import__("pathlib").Path(__import__("tempfile").mkdtemp())
+
+    monkeypatch.setattr(arena, "arena_home", fake_home)
+    rows = arena.store_contents(track="example", model="test:model")
+    sqlite = next(r for r in rows if r["store"] == "sqlite")
+    assert sqlite["kind"] == "arena", (
+        f"with a track and model, sqlite must be the race's copy — got {sqlite['kind']}"
+    )
+    assert seen.get("called"), "it must actually resolve an arena home, not just relabel"
+
+
+def test_without_a_track_the_panel_still_falls_back_to_the_live_store():
+    """No track means no seed, which means no home can be named. Falling back to
+    the live store is right — a blank panel would be a worse answer than an
+    honest one — but it must SAY 'live' so the card is not read as this race's."""
+    rows = arena.store_contents()
+    sqlite = next(r for r in rows if r["store"] == "sqlite")
+    assert sqlite["kind"] == "live", sqlite["kind"]

--- a/waku/ops/dashboard.py
+++ b/waku/ops/dashboard.py
@@ -913,8 +913,21 @@ class Handler(BaseHTTPRequestHandler):
                 # it under mem0 showed you waku's local facts and said nothing.
                 only = (q.get("store", [""])[0] or "").strip()
                 limit = 500 if only else 8
-                self._send(json.dumps(memory_arena.store_contents(limit, only)).encode(),
-                           "application/json")
+                # Track and model identify WHICH arena home to read for sqlite,
+                # so the cards compare the same seeding rather than putting the
+                # live agent's months of real use next to a benchmark run.
+                # Same path-safety rule as the race: only a probe set this
+                # server offered, never a browser-supplied path.
+                from pathlib import Path as _P
+
+                wanted = (q.get("probes", [""])[0] or "").strip()
+                hit = next((s for s in memory_arena.probe_sets() if s["id"] == wanted), None)
+                fixture = memory_arena.load_fixture(_P(hit["path"])) if hit else None
+                track = hit["track"] if hit else (q.get("track", [""])[0] or "").strip()
+                model = (q.get("model", [""])[0] or "").strip()
+                self._send(json.dumps(memory_arena.store_contents(
+                    limit, only, track=track, model=model, fixture=fixture)).encode(),
+                    "application/json")
             except Exception as exc:
                 self._send(json.dumps([{"store": "?", "error": f"{type(exc).__name__}: {exc}"}]).encode(),
                            "application/json")

--- a/waku/ops/memory_arena.py
+++ b/waku/ops/memory_arena.py
@@ -592,39 +592,66 @@ def _ledger(home) -> tuple[int, int]:
 # paid service, and a dashboard that quietly bills you for sitting on a tab is
 # not one anyone should ship.
 
-def store_contents(limit: int = 8, only: str = "") -> list[dict]:
+def store_contents(limit: int = 8, only: str = "", track: str = "",
+                   model: str = "", fixture: dict | None = None) -> list[dict]:
     """Per-backend: how many facts it holds and a sample of them.
 
     A backend that errors reports the error rather than an empty list — "0
     facts" and "I could not reach the service" look identical on screen and
     mean opposite things, which is the confusion this whole page exists to
     stop.
+
+    WHICH sqlite. Given a track and model, this reads the ARENA's own copy —
+    the same `.waku-arena/` home the race seeded — and not the live agent's
+    `.waku/state.db`.
+
+    It used to read the live one, with a paragraph above the cards explaining
+    that "53 vs 0" was not a comparison. That paragraph was the tell. The panel
+    sits under a benchmark whose entire promise is that every store was told
+    the same thing, and the first card was a store that had been told something
+    else entirely, for weeks. Apologising for a comparison in prose is worse
+    than not making it.
+
+    Two things fall out for free. The cards become genuinely comparable, so the
+    explanatory banner can go. And the page stops putting the operator's home
+    address, colleagues and work email on screen — which mattered, because this
+    tab gets filmed.
+
+    The live store is not hidden; it has its own page. It is just not a
+    contestant.
     """
     from waku.config import Settings, load_settings
     from waku.memory import Memory
+
+    spec = ((fixture or load_fixture()).get("tracks") or {}).get(track) or {}
+    seed = spec.get("seed") or []
 
     out = []
     for key in _available_backends():
         if only and key != only:
             continue
-        # `kind` is the label that stops this page misleading. sqlite here is the
-        # LIVE agent's store — months of real use — while a hosted backend has
-        # only ever received what the arena wrote to it. Side by side without
-        # saying so, "53 vs 17" reads as "waku remembers more", when it only
-        # means waku has been used and the others were connected yesterday.
         # Three kinds, not two. "connected account" is a lie about the control
         # — it has no account, no service and no rows, and printing that line
         # above a note that says "told nothing by design" makes the card argue
         # with itself.
-        kind = "live" if key == "sqlite" else "control" if key == CONTROL else "connected"
+        arena_copy = bool(seed) and key in ("sqlite", CONTROL)
+        kind = ("arena" if arena_copy else
+                "live" if key == "sqlite" else
+                "control" if key == CONTROL else "connected")
         row = {"store": key, "count": 0, "facts": [], "error": "", "span": "",
                "kind": kind, "note": _store_note(key)}
         if row["note"]:
             out.append(row)   # nothing meaningful to read — say why, don't report 0
             continue
         try:
-            settings = Settings(home=load_settings().home, semantic_store=key)
-            facts = Memory._make_fact_store(_conn_for(key, settings), settings)
+            # The control has no store of its own; the race gives it a sqlite
+            # in its own home and tells it nothing, so reading that home is
+            # what proves it really is empty rather than merely claimed to be.
+            home = (arena_home(key, track, seed, model) if arena_copy
+                    else load_settings().home)
+            store = "sqlite" if key == CONTROL else key
+            settings = Settings(home=home, semantic_store=store)
+            facts = Memory._make_fact_store(_conn_for(store, settings), settings)
             rows = facts.list(200)
             row["count"] = len(rows)
             row["span"] = _span(rows)

--- a/waku/ops/static/js/compare.js
+++ b/waku/ops/static/js/compare.js
@@ -649,7 +649,7 @@ async function maSeeAll(store){
   if (i < 0) return;
   cards[i] = Object.assign({}, cards[i], {loading: true}); render();
   try {
-    const r = await fetch(`/api/memory-arena/stores?store=${encodeURIComponent(store)}`);
+    const r = await fetch(`/api/memory-arena/stores?store=${encodeURIComponent(store)}&${maStoreQuery()}`);
     const full = (await r.json())[0];
     if (full) cards[i] = full;
   } catch (e){ cards[i].error = String(e); }
@@ -728,10 +728,26 @@ function memoryArenaView(){
 // Fetched on demand, never on the 5s poll.
 let maStores;   // undefined = not fetched, [] = fetched and empty
 
+// Which seeding the cards should describe. Without this the server has no way
+// to know which .waku-arena home to open, and falls back to the live agent's
+// store — which is exactly the incomparable card this panel used to apologise
+// for in a paragraph above itself.
+function maStoreQuery(){
+  // Same fallback chain the picker uses. maFile is empty until you CHANGE the
+  // dropdown, so reading it raw would send "" for the default set — and the
+  // server, given no probe set, cannot name a home and quietly falls back to
+  // the live store. The bug would only appear for people who never touched
+  // the dropdown, which is most of them.
+  const fx = memoryArenaFixture || {};
+  const sets = fx.sets || [];
+  const chosen = maFile || fx.chosen || (sets[0] && sets[0].id) || "";
+  return `probes=${encodeURIComponent(chosen)}&model=${encodeURIComponent(maModelSpec())}`;
+}
+
 async function loadMemoryStores(){
   maStores = "loading";
   editing = false; render();
-  try { maStores = await (await fetch("/api/memory-arena/stores")).json(); }
+  try { maStores = await (await fetch(`/api/memory-arena/stores?${maStoreQuery()}`)).json(); }
   catch(e){ maStores = [{store:"?", error:String(e)}]; }
   editing = false; render();
 }
@@ -748,7 +764,9 @@ function maStoresHtml(){
       <div class="ma-store-h"><code>${esc(s.store)}</code>
         ${s.error ? `<span class="ma-o ma-invented">error</span>`
                   : `<span class="meta">${s.count} fact${s.count===1?"":"s"}</span>`}</div>
-      <div class="ma-prov">${s.kind === "live"
+      <div class="ma-prov">${s.kind === "arena"
+        ? `this race's own copy &middot; <code>.waku-arena/</code>`
+        : s.kind === "live"
         ? `your live agent &middot; <code>.waku/state.db</code>`
         : s.kind === "control"
         ? `not a store &middot; the integrity check`
@@ -765,15 +783,20 @@ function maStoresHtml(){
                 : ""}`
           : `<div class="meta">empty</div>`}
     </div>`).join("");
-  // The warning matters more than the cards. A count next to a count invites
-  // "waku remembers more", when the only thing it shows is that one store has
-  // been lived in and the others were connected yesterday.
+  // This used to carry a warning that the counts were NOT a comparison —
+  // because sqlite was the live agent, with weeks of real use, sitting beside
+  // stores that had only ever seen one benchmark run. The warning was correct
+  // and the design was wrong: a panel under a benchmark should not need a
+  // paragraph explaining why its first card does not count.
+  //
+  // sqlite now reads the race's OWN copy, so every card describes the same
+  // seeding and the comparison is real. What is left to say is the one thing
+  // still worth saying — this is a live read, and it costs a round trip.
   return `<h2>What each store is holding</h2>
     <div class="card"><div class="ma-race">${btn}
-      <span class="meta">Live contents, read-only.</span></div>
-      <div class="ma-warn">These counts are <b>not</b> a comparison. sqlite is your real agent
-        with weeks of use behind it; the connected stores have only ever received what this
-        arena wrote to them. Read the dates, not the totals.</div></div>
+      <span class="meta">What each store made of the SAME facts — read-only, and a live
+        call per store, so it only runs when you ask. Your own agent's memory lives on the
+        Memory page; it is not a contestant.</span></div></div>
     <div class="ma-stores">${cards}</div>`;
 }
 


### PR DESCRIPTION
Sean asked whether the arena's sqlite is separate from his real one. Two
different things were being conflated, and one of them was wrong.

The RACE was always separate — contestants run in their own home and never
open .waku/state.db. But the "what each store is holding" panel deliberately
read the LIVE store for sqlite. So the first card showed 53 facts from weeks
of real use, beside stores that had seen exactly one benchmark run.

That is why the panel carried a paragraph explaining that its own numbers were
not a comparison. The paragraph was correct and the design was wrong: a panel
sitting under a benchmark whose entire promise is that every store was told
the same thing should not need prose explaining why its first card does not
count. Apologising for a comparison is worse than not making it.

sqlite now reads the race's own .waku-arena copy, addressed by the same
(track, model, seed) hash the race uses. The result the first live check gave:

    sqlite 5 · mem0 5 · zep 5 · langmem unreadable · control 0

Five, five, five. Comparable for the first time, and the warning banner is
gone because there is nothing left to warn about.

Two things fell out for free. The control's 0 is now PROVEN by reading the
home the race actually gave it, rather than asserted by a note. And the tab
stopped putting Sean's home address, his colleagues by name and his work
email on screen — which mattered, because this is the tab that gets filmed.

The live store is not hidden. It has its own page. It is just not a
contestant, and the panel now says so in one line instead of three.

One bug worth naming: maStoreQuery reads maFile, which is empty until you
CHANGE the dropdown. Sending "" would mean the server could not name a home
and would quietly fall back to the live store — a bug visible only to people
who never touched the picker, which is most of them. It uses the picker's own
fallback chain instead.

Two tests: that a track and model produce kind="arena" and actually resolve a
home, and that no track still falls back to "live" and SAYS so rather than
rendering blank.

Gate: ruff clean, 580 passed, 59 skipped.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
