### PR TITLE
arena: a whole card to hold one button was the most expensive thing on screen

### DIFF
--- a/waku/ops/static/js/compare.js
+++ b/waku/ops/static/js/compare.js
@@ -755,11 +755,13 @@ async function loadMemoryStores(){
 function maStoresHtml(){
   const btn = `<button class="save ghost" onclick="loadMemoryStores()"
     ${maStores === "loading" ? "disabled" : ""}>${maStores === "loading" ? "reading…" : "Read stores"}</button>`;
-  if (!Array.isArray(maStores)){
-    return `<div class="card"><div class="ma-race">${btn}
-      <span class="meta">Show what every connected memory store is holding right now.
-        Each one is a live call, so it only runs when you ask.</span></div></div>`;
-  }
+  // The heading carries the button. This used to be a whole card wrapping one
+  // control and a paragraph — a card's worth of vertical space to say "press
+  // this". On a page where the useful content is five store cards further
+  // down, that is the most expensive furniture on screen.
+  const head = `<h2 class="ma-head">What each store is holding ${btn}
+    <span class="meta">what each made of the SAME facts &middot; live call, on demand</span></h2>`;
+  if (!Array.isArray(maStores)) return head;
   const cards = maStores.map(s => `<div class="card ma-store">
       <div class="ma-store-h"><code>${esc(s.store)}</code>
         ${s.error ? `<span class="ma-o ma-invented">error</span>`
@@ -792,12 +794,7 @@ function maStoresHtml(){
   // sqlite now reads the race's OWN copy, so every card describes the same
   // seeding and the comparison is real. What is left to say is the one thing
   // still worth saying — this is a live read, and it costs a round trip.
-  return `<h2>What each store is holding</h2>
-    <div class="card"><div class="ma-race">${btn}
-      <span class="meta">What each store made of the SAME facts — read-only, and a live
-        call per store, so it only runs when you ask. Your own agent's memory lives on the
-        Memory page; it is not a contestant.</span></div></div>
-    <div class="ma-stores">${cards}</div>`;
+  return head + `<div class="ma-stores">${cards}</div>`;
 }
 
 // --- what they get asked ----------------------------------------------------

--- a/waku/ops/static/style.css
+++ b/waku/ops/static/style.css
@@ -611,6 +611,12 @@ details.subterm > summary.subterm-h::-webkit-details-marker{ display:none; }
    row and min-width:0 is what actually permits the shrink — a flex item refuses
    to go below its content width without it, which is the whole reason the
    wrapping looked like a gap problem rather than a width one. */
+/* Heading, its button and its one-line note on a single baseline. Vertical
+   space on this page belongs to the store cards, not to the furniture that
+   introduces them. */
+.ma-head{display:flex;align-items:center;gap:12px;flex-wrap:wrap}
+.ma-head .save{font-size:12px;padding:5px 12px}
+.ma-head .meta{font-weight:400}
 .ma-pickers .fld{margin-bottom:0;flex:1 1 260px;min-width:0}
 .ma-pickers .fld select{width:100%}
 .ma-pickers .meta{flex:1 1 100%}


### PR DESCRIPTION
"Read stores" sat inside its own card with a three-line paragraph beside it.
On a page whose useful content is five store cards further down, a card's
worth of vertical space to say "press this" is furniture charging rent.

The heading carries the button now, with a one-line note on the same
baseline: 64px total, replacing a heading plus a card. The paragraph it
replaced was mostly explaining that the live store is not a contestant —
which the cards themselves now say, one each, in their own subtitle.

Verified live: .ma-head found, contains the button, 64px tall, and the store
cards sit directly under it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
