### PR TITLE
arena: isolate the hosted half too, then a Clean button that can be trusted

### DIFF
--- a/evals/deterministic/test_memory_arena.py
+++ b/evals/deterministic/test_memory_arena.py
@@ -18,6 +18,7 @@ a legal probe where the deadline was never given.
 from __future__ import annotations
 
 import json
+import os
 from typing import ClassVar
 
 import pytest
@@ -714,3 +715,62 @@ def test_without_a_track_the_panel_still_falls_back_to_the_live_store():
     rows = arena.store_contents()
     sqlite = next(r for r in rows if r["store"] == "sqlite")
     assert sqlite["kind"] == "live", sqlite["kind"]
+
+
+def test_a_race_writes_to_its_own_hosted_partition_not_the_live_one(monkeypatch):
+    """The hosted half had no isolation, and the consequence was concrete.
+
+    mem0 and Zep read MEM0_USER_ID / ZEP_USER_ID with a default of "waku" — the
+    SAME partition the live agent uses — so every race wrote its benchmark seed
+    into the operator's real memory, and every probe set wrote into the same
+    place as every other one. A working-week race read back `wedding party
+    ballroom` and `guest in room 402` from the business track, because there
+    was only ever one drawer.
+    """
+    monkeypatch.delenv("MEM0_USER_ID", raising=False)
+    monkeypatch.delenv("ZEP_USER_ID", raising=False)
+    with arena.arena_partition_env("t", ["fact one"], "m:1") as partition:
+        assert partition.startswith("waku-arena-"), partition
+        assert os.environ["MEM0_USER_ID"] == partition
+        assert os.environ["ZEP_USER_ID"] == partition
+    # Leaking this would move the LIVE agent's memory to a benchmark partition
+    # — worse than the bug it fixes.
+    assert "MEM0_USER_ID" not in os.environ
+    assert "ZEP_USER_ID" not in os.environ
+
+
+def test_a_different_track_gets_a_different_partition():
+    """This is the whole point: one drawer per question set, so a race cannot
+    read back facts it was never told."""
+    a = arena.arena_partition("dinner", ["fact one"], "m:1")
+    b = arena.arena_partition("business", ["fact one"], "m:1")
+    c = arena.arena_partition("dinner", ["fact one"], "m:2")
+    assert a != b, "different tracks must not share a partition"
+    assert a != c, "a different model reseeds, so it must not share either"
+
+
+def test_clean_refuses_when_it_cannot_name_what_it_would_delete():
+    """No track means no seed, no key, and therefore no partition name. A
+    cleanup that cannot name its target must do nothing at all — the failure
+    mode of guessing here is deleting the live agent's memory."""
+    out = arena.clean_stores(track="", model="m:1")
+    assert out.get("error"), out
+    assert "nothing is deleted" in out["error"]
+
+
+def test_a_partition_that_was_already_gone_is_not_an_error():
+    """Zep 404s when the partition does not exist, which is the NORMAL case:
+    cleaning twice, or cleaning a race that only ever ran locally. The first
+    live run of Clean reported a wall of Cloudflare headers as an error for
+    exactly this.
+
+    Reporting "already gone" as failure trains you to ignore the error line —
+    and the day it says something real, you ignore that too."""
+    class _Gone(Exception):
+        status_code = 404
+
+    assert arena._absent(_Gone("message='not found'"))
+    assert arena._absent(Exception("status_code: 404, body: not found"))
+    assert not arena._absent(Exception("401 unauthorized — check your API key")), (
+        "an auth failure is not 'already deleted' and must still surface"
+    )

--- a/evals/deterministic/test_static_js_parses.py
+++ b/evals/deterministic/test_static_js_parses.py
@@ -1,0 +1,52 @@
+"""DETERMINISTIC EVAL — the dashboard's JavaScript actually parses.
+
+Written the moment it was needed. A `title=` attribute added to a button
+contained the word waku wrapped in backticks, inside a template literal:
+
+    title="... the `waku` partition is never named ..."
+
+The backticks closed the template literal early and the file stopped parsing.
+Not the button, not the panel — the WHOLE file. Every view compare.js renders
+went blank, and the only symptom was a page that looked like it had not
+reloaded. It cost a full round of "is the browser caching?" before anyone
+checked the console.
+
+Python has ruff and 580 tests standing between a typo and a broken dashboard.
+The JavaScript, which is most of what a user actually touches, had nothing.
+`node --check` is a syntax check and no more — it will not catch a wrong
+selector or a bad fetch — but this class of bug turns the entire page off,
+which is the loudest possible failure for the cheapest possible test.
+
+Skips when node is absent rather than failing: a contributor without node
+should still get a green suite, and CI has it.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import shutil
+import subprocess
+
+import pytest
+
+JS_DIR = pathlib.Path(__file__).resolve().parents[2] / "waku" / "ops" / "static" / "js"
+SCRIPTS = sorted(JS_DIR.glob("*.js"))
+
+
+def test_there_are_scripts_to_check():
+    """A guard whose glob silently matches nothing passes forever and protects
+    nothing. If the frontend moves, this fails and says so."""
+    assert SCRIPTS, f"no .js found under {JS_DIR} — did the frontend move?"
+
+
+@pytest.mark.skipif(not shutil.which("node"), reason="node not installed")
+@pytest.mark.parametrize("script", SCRIPTS, ids=[s.name for s in SCRIPTS])
+def test_every_dashboard_script_parses(script: pathlib.Path):
+    result = subprocess.run(  # noqa: S603 — fixed argv, path from our own glob
+        [shutil.which("node"), "--check", str(script)],
+        capture_output=True, text=True, timeout=30, check=False,
+    )
+    assert result.returncode == 0, (
+        f"{script.name} does not parse — the dashboard will render nothing.\n"
+        f"{result.stderr.strip()}"
+    )

--- a/waku/ops/dashboard.py
+++ b/waku/ops/dashboard.py
@@ -1040,6 +1040,28 @@ class Handler(BaseHTTPRequestHandler):
         # /api/memory-arena/stream — same shape as the model race above, one dial
         # over: every contestant is the same agent on the same model, and only
         # the semantic store changes.
+        if self.path == "/api/memory-arena/clean":
+            # Deletes only what a race wrote: the .waku-arena homes for this
+            # seed and the waku-arena-<key> partition. It cannot reach the live
+            # store or the `waku` partition because it never asks for them by
+            # name. Same probe-set validation as the race — a browser-supplied
+            # path must never reach the filesystem.
+            from pathlib import Path as _P
+
+            from waku.ops import memory_arena
+
+            payload = json.loads(self.rfile.read(length) or "{}")
+            wanted = (payload.get("probes") or "").strip()
+            hit = next((s for s in memory_arena.probe_sets() if s["id"] == wanted), None)
+            fixture = memory_arena.load_fixture(_P(hit["path"])) if hit else None
+            track = hit["track"] if hit else (payload.get("track") or "")
+            try:
+                out = memory_arena.clean_stores(
+                    track=track, model=(payload.get("model") or "").strip(), fixture=fixture)
+            except Exception as exc:
+                out = {"error": f"{type(exc).__name__}: {exc}"}
+            self._send(json.dumps(out).encode(), "application/json")
+            return
         if self.path == "/api/memory-arena/stream":
             payload = json.loads(self.rfile.read(length) or "{}")
             self.send_response(200)

--- a/waku/ops/memory_arena.py
+++ b/waku/ops/memory_arena.py
@@ -38,6 +38,7 @@ costs money, and it is deliberately thin.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 from pathlib import Path
@@ -331,14 +332,60 @@ def arena_home(backend: str, track: str, seed: list[str], model: str) -> Path:
     — the glob that exists because a second agent home's SOUL.md and usage
     ledger are the files you least want pushed.
     """
-    import hashlib
-
     from waku.config import load_settings
 
-    key = hashlib.sha256("\n".join([track, model, *seed]).encode()).hexdigest()[:12]
-    home = load_settings().home.parent / ".waku-arena" / f"{backend}-{key}"
+    home = (load_settings().home.parent / ".waku-arena"
+            / f"{backend}-{arena_key(track, seed, model)}")
     home.mkdir(parents=True, exist_ok=True)
     return home
+
+
+def arena_key(track: str, seed: list[str], model: str) -> str:
+    """The one hash. Names the local home AND the hosted partition."""
+    import hashlib
+
+    return hashlib.sha256("\n".join([track, model, *seed]).encode()).hexdigest()[:12]
+
+
+def arena_partition(track: str, seed: list[str], model: str) -> str:
+    """The user id the hosted stores write under during a race.
+
+    Local isolation was solved by naming the home. The hosted half had no
+    equivalent, and the consequence was concrete: mem0 and Zep read
+    MEM0_USER_ID / ZEP_USER_ID with a default of "waku" — the SAME partition
+    the live agent uses. So every race wrote its benchmark seed into the
+    operator's real memory, and every probe set wrote into the same place as
+    every other one. A working-week race read back `wedding party ballroom` and
+    `guest in room 402` from the business track, because there was only ever
+    one drawer.
+
+    Same key as the home, so a race is isolated on both sides by construction
+    and "clean up after this race" can name exactly what it means.
+    """
+    return f"waku-arena-{arena_key(track, seed, model)}"
+
+
+@contextlib.contextmanager
+def arena_partition_env(track: str, seed: list[str], model: str):
+    """Point the hosted stores at this race's partition, then put it back.
+
+    The stores read their user id from the environment at construction, so this
+    has to wrap the Waku() call rather than be passed as a setting. Restoring
+    matters more than setting: leaking MEM0_USER_ID into the process would move
+    the LIVE agent's memory to a benchmark partition, which is the one failure
+    worse than the bug this fixes.
+    """
+    partition = arena_partition(track, seed, model)
+    before = {k: os.environ.get(k) for k in ("MEM0_USER_ID", "ZEP_USER_ID")}
+    os.environ["MEM0_USER_ID"] = os.environ["ZEP_USER_ID"] = partition
+    try:
+        yield partition
+    finally:
+        for k, v in before.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
 
 
 def _is_seeded(home: Path) -> bool:
@@ -410,9 +457,14 @@ def run_arena(backends: list[str], track: str, emit, fixture: dict | None = None
         already = _is_seeded(home)
         try:
             opts = {"provider": prov, "model": mod} if prov and mod else {}
-            app = Waku(settings=Settings(home=home, semantic_store=store,
-                                         apple_calendar=False, google_calendar=False,
-                                         apple_tools=False, graph_workflows=False, **opts))
+            # The hosted stores read their partition from the environment at
+            # construction, so this wraps the whole contestant rather than
+            # being passed as a setting.
+            with arena_partition_env(track, seeding, model):
+                app = Waku(settings=Settings(home=home, semantic_store=store,
+                                             apple_calendar=False, google_calendar=False,
+                                             apple_tools=False, graph_workflows=False,
+                                             **opts))
             # Seeding is 53% of a race and perfectly deterministic, so a home
             # that already holds this exact seed is not re-told. Racing is now
             # the cheap half: seed once, ask many times.
@@ -661,6 +713,89 @@ def store_contents(limit: int = 8, only: str = "", track: str = "",
             row["error"] = f"{type(exc).__name__}: {exc}"[:160]
         out.append(row)
     return out
+
+
+def clean_stores(track: str = "", model: str = "", fixture: dict | None = None) -> dict:
+    """Delete everything THIS race wrote, and nothing else.
+
+    Safe only because of arena_partition. Before that, the arena wrote its seed
+    into MEM0_USER_ID / ZEP_USER_ID's default of "waku" — the live agent's own
+    partition — so "clean the stores" would have deleted the operator's real
+    memory. A cleanup button is exactly as safe as the isolation underneath it,
+    and there was none.
+
+    Now every race owns a partition named for its own key, so this can name
+    precisely what it means: the `.waku-arena/` homes for this seed, and the
+    hosted partition with the matching name. It never touches `.waku/state.db`
+    and never touches the `waku` partition, because it does not know their
+    names — it only ever asks for `waku-arena-<key>`.
+
+    Reports per store rather than raising: a cleanup that half-worked and said
+    nothing is how you end up racing against data you believe is gone.
+    """
+    import shutil
+
+    from waku.config import load_settings
+
+    spec = ((fixture or load_fixture()).get("tracks") or {}).get(track) or {}
+    seed = spec.get("seed") or []
+    if not seed:
+        return {"error": "no track chosen — nothing can be named, so nothing is deleted"}
+
+    key, partition = arena_key(track, seed, model), arena_partition(track, seed, model)
+    out: dict = {"partition": partition, "removed": [], "errors": []}
+
+    base = load_settings().home.parent / ".waku-arena"
+    for home in sorted(base.glob(f"*-{key}")) if base.exists() else []:
+        try:
+            shutil.rmtree(home)
+            out["removed"].append(home.name)
+        except Exception as exc:
+            out["errors"].append(f"{home.name}: {type(exc).__name__}: {exc}")
+
+    for store, wipe in (("mem0", _wipe_mem0), ("zep", _wipe_zep)):
+        try:
+            if wipe(partition):
+                out["removed"].append(f"{store}:{partition}")
+        except Exception as exc:
+            out["errors"].append(f"{store}: {type(exc).__name__}: {exc}")
+    return out
+
+
+def _absent(exc: Exception) -> bool:
+    """Did this delete fail because the thing was already gone?
+
+    Zep 404s when the partition does not exist, which is the NORMAL case:
+    cleaning twice, or cleaning a race that only ever ran locally. Reporting
+    that as an error trains you to ignore the error line, and the day it says
+    something real you will ignore that too.
+    """
+    text = f"{getattr(exc, 'status_code', '')} {exc}".lower()
+    return "404" in text or "not found" in text or "not_found" in text
+
+
+def _wipe_mem0(partition: str) -> bool:
+    from mem0 import MemoryClient
+
+    try:
+        MemoryClient().delete_all(user_id=partition)
+    except Exception as exc:
+        if not _absent(exc):
+            raise
+        return False
+    return True
+
+
+def _wipe_zep(partition: str) -> bool:
+    from zep_cloud import Zep
+
+    try:
+        Zep(api_key=os.environ["ZEP_API_KEY"]).user.delete(user_id=partition)
+    except Exception as exc:
+        if not _absent(exc):
+            raise
+        return False
+    return True
 
 
 def _span(rows: list[dict]) -> str:

--- a/waku/ops/static/js/compare.js
+++ b/waku/ops/static/js/compare.js
@@ -736,16 +736,39 @@ let maStores;   // undefined = not fetched, [] = fetched and empty
 // to know which .waku-arena home to open, and falls back to the live agent's
 // store — which is exactly the incomparable card this panel used to apologise
 // for in a paragraph above itself.
-function maStoreQuery(){
-  // Same fallback chain the picker uses. maFile is empty until you CHANGE the
-  // dropdown, so reading it raw would send "" for the default set — and the
-  // server, given no probe set, cannot name a home and quietly falls back to
-  // the live store. The bug would only appear for people who never touched
-  // the dropdown, which is most of them.
+// Same fallback chain the picker uses. maFile is empty until you CHANGE the
+// dropdown, so reading it raw sends "" for the default set — and the server,
+// given no probe set, can name neither a home nor a partition. Reads would
+// quietly fall back to the live store and Clean would refuse. The bug would
+// only appear for people who never touched the dropdown, which is most of them.
+function maChosenSet(){
   const fx = memoryArenaFixture || {};
   const sets = fx.sets || [];
-  const chosen = maFile || fx.chosen || (sets[0] && sets[0].id) || "";
-  return `probes=${encodeURIComponent(chosen)}&model=${encodeURIComponent(maModelSpec())}`;
+  return maFile || fx.chosen || (sets[0] && sets[0].id) || "";
+}
+
+function maStoreQuery(){
+  return `probes=${encodeURIComponent(maChosenSet())}&model=${encodeURIComponent(maModelSpec())}`;
+}
+
+let maClean = "";   // what the last clean did, shown where the hint normally sits
+
+// Deliberately NOT behind a confirm dialog: it can only reach this race's own
+// scratch. The dangerous version of this button was the one that existed
+// before per-race partitions, when "the stores" included the live agent's.
+async function cleanMemoryStores(){
+  maClean = "cleaning…"; editing = false; render();
+  try {
+    const r = await fetch("/api/memory-arena/clean", {
+      method:"POST", headers:{"Content-Type":"application/json"},
+      body: JSON.stringify({probes: maChosenSet(), model: maModelSpec()})});
+    const out = await r.json();
+    maClean = out.error ? `clean failed — ${out.error}`
+      : `cleaned ${(out.removed||[]).length} — ${(out.removed||[]).join(", ") || "nothing to remove"}`
+        + ((out.errors||[]).length ? ` &middot; ${out.errors.length} failed` : "");
+    maStores = undefined;              // the cards on screen now describe deleted data
+  } catch(e){ maClean = `clean failed — ${e}`; }
+  editing = false; render();
 }
 
 async function loadMemoryStores(){
@@ -764,7 +787,9 @@ function maStoresHtml(){
   // this". On a page where the useful content is five store cards further
   // down, that is the most expensive furniture on screen.
   const head = `<h2 class="ma-head">What each store is holding ${btn}
-    <span class="meta">what each made of the SAME facts &middot; live call, on demand</span></h2>`;
+    <button class="save ghost" onclick="cleanMemoryStores()"
+      title="Deletes only what this race wrote: its .waku-arena copies and its waku-arena partition. Your own memory and the waku partition are never named, so they cannot be reached.">Clean</button>
+    <span class="meta">${maClean || "what each made of the SAME facts &middot; live call, on demand"}</span></h2>`;
   if (!Array.isArray(maStores)) return head;
   const cards = maStores.map(s => `<div class="card ma-store">
       <div class="ma-store-h"><code>${esc(s.store)}</code>
@@ -808,12 +833,16 @@ function maStoresHtml(){
 function maAsksHtml(track){
   return `<h2 style="margin-top:22px">What they get asked
       <span class="meta" style="font-weight:400">— ${track.seed.length} facts in, ${track.probes.length} questions</span></h2>
+    ${/* ONE table, two sections. They were two cards, which read as two
+          unrelated lists — and they are the opposite of unrelated: the second
+          only means anything BECAUSE of the first. A section row inside a
+          single table says "same subject, two halves" in a way two cards with
+          a gap between them cannot, and it saves a card's worth of height on
+          a page where that is the scarce resource. */""}
     <div class="card" style="padding:4px 8px"><div class="tablescroll"><table>
-      <tr><th>told</th></tr>
-      ${track.seed.map(s=>`<tr><td class="meta">${esc(s)}</td></tr>`).join("")}
-    </table></div></div>
-    <div class="card" style="padding:4px 8px"><div class="tablescroll"><table>
-      <tr><th>asked</th><th>right answer</th><th>wrong answer</th></tr>
+      <tr><th>told</th><th></th><th></th></tr>
+      ${track.seed.map(s=>`<tr><td class="meta" colspan="3">${esc(s)}</td></tr>`).join("")}
+      <tr><th>then asked</th><th>right answer</th><th>wrong answer</th></tr>
       ${track.probes.map(p=>`<tr title="${esc(p.note||"")}">
         <td>${esc(p.question)}</td>
         <td><span class="ma-expect">${p.expect_refusal ? "must decline"


### PR DESCRIPTION
Sean asked for a Clean Stores button. Building it first would have handed him
a button that deleted his real memory, so this does the prerequisite in the
same change.

mem0 and Zep read MEM0_USER_ID / ZEP_USER_ID with a default of "waku" — the
SAME partition the live agent uses — and the arena never overrode it. Every
race wrote its benchmark seed into the operator's real memory, and every probe
set wrote into the same drawer as every other one. That was visible on screen
before it was understood: a working-week race read back "wedding party
ballroom booking" and "guest in room 402" from the business track.

Local isolation was already solved by naming the home. The same key now names
the hosted partition, so a race is isolated on both sides by construction and
"clean up after this race" can name exactly what it means. arena_partition_env
restores the previous values on the way out — leaking MEM0_USER_ID into the
process would move the LIVE agent's memory to a benchmark partition, which is
worse than the bug being fixed.

Clean deletes the .waku-arena homes for this seed and the waku-arena-<key>
partition. It cannot reach the live store or the `waku` partition because it
never asks for them by name, and it refuses outright when no track is chosen —
a cleanup that cannot name its target must do nothing, since the failure mode
of guessing is deleting someone's real memory.

Verified against the live account rather than argued: before, mem0 held
['waku', 'quickstart-mem0'] and ten arena homes existed. After, mem0 still
held ['waku', 'quickstart-mem0'], six homes survived, exactly the four
matching the key were gone, and .waku/state.db was untouched at 294912 bytes.

That run also showed Zep 404ing on a partition that had never existed, and
the panel reporting a wall of Cloudflare headers as a failure. "Already gone"
is the normal case — cleaning twice, or cleaning a race that only ran locally
— and reporting it as an error trains you to ignore the error line. An auth
failure still surfaces.

TOLD and ASKED became one table with a section row. They were two cards, which
read as two unrelated lists, and they are the opposite of unrelated: the
questions only mean anything BECAUSE of the facts above them.

And a new guard, written the moment it was needed. A title= attribute on the
Clean button contained the word waku in backticks, inside a template literal.
The backticks closed the literal early and compare.js stopped parsing —
not the button, the WHOLE file, every view blank, symptom indistinguishable
from a stale cache. Python has ruff and 595 tests between a typo and a broken
dashboard; the JavaScript had nothing. node --check is a syntax check and no
more, but this class of bug turns the entire page off, which is the loudest
failure for the cheapest test. Confirmed to bite by reintroducing the exact
backticks.

Gate: ruff clean, 595 passed, 59 skipped.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
