### PR TITLE
docs: a README you can read in an afternoon, for a repo that promises one

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,100 +342,11 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 make run
 
 Langfuse cloud speaks the same OTel toggle.
 
-## Recording a clean demo
+## Connect it to your life
 
-```bash
-python scripts/demo_seed.py --yes      # resets .waku to a tidy, curated state (--yes required)
-```
-
-It backs up your current `.waku` first, then seeds a few clean facts, one episode, and one
-event — Sergey's standing **Saturday 5 PM swim**. The chat log and traces start **empty**, so
-when you type live the Loop, traces, and Gateway inbox fill up in front of the viewer. The
-memory/Data/Tools tabs already have tidy content to explain. Edit the seed lists at the top of
-the script to taste.
-
-## Talk to it
-
-```bash
-uv pip install -e '.[voice]'
-waku voice        # hands-free: always-listening for "waku waku"
-```
-
-**Hands-free by default.** `waku voice` listens for the wake word **"waku waku"** — a tiny
-Whisper model scans the mic; when it hears the phrase, the big model takes over for your
-command and speaks the reply. Change or disable it:
-
-```bash
-WAKU_WAKE_WORD="hey waku"  waku voice     # any phrase, no training
-WAKU_WAKE_WORD=""          waku voice     # push-to-talk instead (Enter, speak, Enter)
-```
-
-The matcher is ~15 transparent lines with a deterministic eval; it accepts cross-script
-variants (`"waku waku,わくわく"`). A trained openWakeWord model is the efficient v2 upgrade.
-
-**A beautiful voice.** Out of the box it uses macOS `say` — and Waku auto-picks the nicest
-voice you have, preferring a downloaded Premium/Enhanced one (System Settings ▸ Accessibility
-▸ Spoken Content ▸ System Voice) over the robotic built-ins. For the real neural upgrade,
-install [Kokoro](https://github.com/hexgrad/kokoro) — a fully local, offline British-butler
-voice that's picked up automatically, no env var needed:
-
-```bash
-uv pip install '.[voice-neural]'          # neural Kokoro (bm_george); pulls torch (~2GB)
-```
-
-Override either engine with `WAKU_VOICE` (a `say` voice name, or a Kokoro voice like `bf_emma`).
-
-## Phone to laptop
-
-```bash
-pip install -e '.[telegram]'
-# message @BotFather, /newbot, put the token in .env, then:
-make telegram
-```
-
-Text your bot from anywhere and your laptop runs the turn — long-polling, so no
-public URL or webhook. Set `TELEGRAM_ALLOWED_USER` to lock it to just you.
-
-## Brief me on my week (Apple Calendar + Mail)
-
-```bash
-WAKU_APPLE_TOOLS=1 make brief      # macOS; grant the permission prompts once
-```
-
-Waku reads your **real** Calendar.app (including events invited by email) and
-recent Apple Mail, cross-references your memory, and writes a focus-first briefing
-with clickable `message://` links. Cron it for a morning greeting:
-
-```
-30 7 * * *  cd ~/waku-agent && make brief
-```
-
-It runs through the normal harness, so it animates on the dashboard like any turn.
-
-## Mirror created events to Google Calendar
-
-The local SQLite database and `calendar.ics` stay authoritative. To also write
-`create_event` results to Google Calendar, install the opt-in extra and configure
-[Application Default Credentials](https://cloud.google.com/docs/authentication/provide-credentials-adc):
-
-```bash
-pip install -e '.[gcal]'
-# Keep the downloaded client file OUTSIDE the repo — it is only an input to
-# gcloud, which stores the resulting credentials in ~/.config/gcloud/.
-gcloud auth application-default login \
-  --client-id-file=~/.config/waku/gcal-client.json \
-  --scopes=https://www.googleapis.com/auth/calendar.events
-WAKU_GOOGLE_CALENDAR=1 waku
-```
-
-Nothing secret ever needs to live in the repo: the client file is read once by
-`gcloud`, and the credentials it mints land in `~/.config/gcloud/`. (`.gitignore`
-also blocks `credentials.json` and `*token*.json` as a second line of defence.)
-
-The target defaults to the signed-in user's `primary` calendar; set
-`WAKU_GOOGLE_CALENDAR_ID` for another calendar. `list_events` still reads the
-local database. Google failures never roll back the local event, and attendee
-notifications are suppressed (`sendUpdates=none`).
+Voice, Telegram, Apple Calendar and Mail, Google Calendar, MCP servers — each
+one is opt-in, behind its own extra, and none of them change the loop. Setup
+for all of them: **[docs/integrations.md](docs/integrations.md)**.
 
 ## It manages its own memory
 
@@ -448,29 +359,6 @@ The agent has tools to keep itself useful — no black box:
 You can also edit any of this by hand on the dashboard's Memory tab (edit/delete
 facts, rewrite `SOUL.md`) or in Settings (switch provider/model, paste keys — BYOK,
 kept in your local `.env`, never sent to the browser).
-
-## Connect MCP servers
-
-```bash
-pip install -e '.[mcp]'
-```
-
-Create `.waku/mcp.json` and any Model Context Protocol server's tools appear to
-the agent, namespaced `<server>_<tool>` (and in the dashboard's Tools ▸ MCP tab):
-
-```json
-{"servers": [{"name": "fs", "command": "npx",
-  "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]}]}
-```
-
-**Node-free demo** — a tiny self-contained Python MCP server ships in the repo:
-
-```bash
-cp examples/mcp.demo.json .waku/mcp.json   # points at examples/mcp_demo_server.py
-make dashboard                               # demo_word_count / demo_reverse_text appear in Tools
-```
-
-Same pattern scales to any server, yours or a vendor's — no changes to Waku's code.
 
 ## Add skills — yours or the community's
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Twelve files with no order is a folder nobody reads. Three groups.
 | [agent-graphs-design.md](agent-graphs-design.md) | the graph engine's design and its fail-open rule |
 | [memory-backends-playbook.md](memory-backends-playbook.md) | seeing your memories in each provider's own console |
 | [benchmarks.md](benchmarks.md) | what has been measured, and how |
+| [integrations.md](integrations.md) | voice, Telegram, Apple, Google Calendar, MCP — all opt-in |
 
 ## Write-ups — one topic, explained
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,0 +1,115 @@
+# Connect it to your life
+
+Everything here is opt-in and behind its own extra. None of it changes the
+loop — a gateway moves text in and out, an integration is a tool the agent
+may call. The four pillars work with none of this installed.
+
+Moved out of the README, which had grown to 569 lines for a project whose
+promise is that you can read it in an afternoon. Nothing was rewritten.
+
+## Talk to it
+
+```bash
+uv pip install -e '.[voice]'
+waku voice        # hands-free: always-listening for "waku waku"
+```
+
+**Hands-free by default.** `waku voice` listens for the wake word **"waku waku"** — a tiny
+Whisper model scans the mic; when it hears the phrase, the big model takes over for your
+command and speaks the reply. Change or disable it:
+
+```bash
+WAKU_WAKE_WORD="hey waku"  waku voice     # any phrase, no training
+WAKU_WAKE_WORD=""          waku voice     # push-to-talk instead (Enter, speak, Enter)
+```
+
+The matcher is ~15 transparent lines with a deterministic eval; it accepts cross-script
+variants (`"waku waku,わくわく"`). A trained openWakeWord model is the efficient v2 upgrade.
+
+**A beautiful voice.** Out of the box it uses macOS `say` — and Waku auto-picks the nicest
+voice you have, preferring a downloaded Premium/Enhanced one (System Settings ▸ Accessibility
+▸ Spoken Content ▸ System Voice) over the robotic built-ins. For the real neural upgrade,
+install [Kokoro](https://github.com/hexgrad/kokoro) — a fully local, offline British-butler
+voice that's picked up automatically, no env var needed:
+
+```bash
+uv pip install '.[voice-neural]'          # neural Kokoro (bm_george); pulls torch (~2GB)
+```
+
+Override either engine with `WAKU_VOICE` (a `say` voice name, or a Kokoro voice like `bf_emma`).
+
+## Phone to laptop
+
+```bash
+pip install -e '.[telegram]'
+# message @BotFather, /newbot, put the token in .env, then:
+make telegram
+```
+
+Text your bot from anywhere and your laptop runs the turn — long-polling, so no
+public URL or webhook. Set `TELEGRAM_ALLOWED_USER` to lock it to just you.
+
+## Brief me on my week (Apple Calendar + Mail)
+
+```bash
+WAKU_APPLE_TOOLS=1 make brief      # macOS; grant the permission prompts once
+```
+
+Waku reads your **real** Calendar.app (including events invited by email) and
+recent Apple Mail, cross-references your memory, and writes a focus-first briefing
+with clickable `message://` links. Cron it for a morning greeting:
+
+```
+30 7 * * *  cd ~/waku-agent && make brief
+```
+
+It runs through the normal harness, so it animates on the dashboard like any turn.
+
+## Mirror created events to Google Calendar
+
+The local SQLite database and `calendar.ics` stay authoritative. To also write
+`create_event` results to Google Calendar, install the opt-in extra and configure
+[Application Default Credentials](https://cloud.google.com/docs/authentication/provide-credentials-adc):
+
+```bash
+pip install -e '.[gcal]'
+# Keep the downloaded client file OUTSIDE the repo — it is only an input to
+# gcloud, which stores the resulting credentials in ~/.config/gcloud/.
+gcloud auth application-default login \
+  --client-id-file=~/.config/waku/gcal-client.json \
+  --scopes=https://www.googleapis.com/auth/calendar.events
+WAKU_GOOGLE_CALENDAR=1 waku
+```
+
+Nothing secret ever needs to live in the repo: the client file is read once by
+`gcloud`, and the credentials it mints land in `~/.config/gcloud/`. (`.gitignore`
+also blocks `credentials.json` and `*token*.json` as a second line of defence.)
+
+The target defaults to the signed-in user's `primary` calendar; set
+`WAKU_GOOGLE_CALENDAR_ID` for another calendar. `list_events` still reads the
+local database. Google failures never roll back the local event, and attendee
+notifications are suppressed (`sendUpdates=none`).
+
+## Connect MCP servers
+
+```bash
+pip install -e '.[mcp]'
+```
+
+Create `.waku/mcp.json` and any Model Context Protocol server's tools appear to
+the agent, namespaced `<server>_<tool>` (and in the dashboard's Tools ▸ MCP tab):
+
+```json
+{"servers": [{"name": "fs", "command": "npx",
+  "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]}]}
+```
+
+**Node-free demo** — a tiny self-contained Python MCP server ships in the repo:
+
+```bash
+cp examples/mcp.demo.json .waku/mcp.json   # points at examples/mcp_demo_server.py
+make dashboard                               # demo_word_count / demo_reverse_text appear in Tools
+```
+
+Same pattern scales to any server, yours or a vendor's — no changes to Waku's code.
+

--- a/docs/notes/recording-a-clean-demo.md
+++ b/docs/notes/recording-a-clean-demo.md
@@ -1,0 +1,16 @@
+# Recording a clean demo
+
+A working note, not reference. Moved out of the README.
+
+## Recording a clean demo
+
+```bash
+python scripts/demo_seed.py --yes      # resets .waku to a tidy, curated state (--yes required)
+```
+
+It backs up your current `.waku` first, then seeds a few clean facts, one episode, and one
+event — Sergey's standing **Saturday 5 PM swim**. The chat log and traces start **empty**, so
+when you type live the Loop, traces, and Gateway inbox fill up in front of the viewer. The
+memory/Data/Tools tabs already have tidy content to explain. Edit the seed lists at the top of
+the script to taste.
+


### PR DESCRIPTION
569 lines and 24 top-level sections, for a project whose entire pitch is that
you can read it in an afternoon. The README was the one file contradicting the
claim it was making.

Five how-to sections moved to docs/integrations.md — voice, Telegram, Apple
Calendar and Mail, Google Calendar, MCP servers — and "recording a clean demo"
to docs/notes/, where the other working material already lives. 569 -> 457
lines, 24 -> 19 sections, and one pointer where five walkthroughs used to be.

Every word was MOVED, not rewritten. That is deliberate. The sections that
remain are the pitch and the four pillars, which are written in Sean's voice
and are the reason people star this repo; editing those is his call, not a
tidy-up job to be done while he is asleep. This change is mechanical and
entirely reversible.

The five that left share a property: each is opt-in, behind its own extra, and
none of them change the loop. A reader deciding whether this project is for
them does not need WhatsApp setup instructions to find out — and a reader who
wants WhatsApp finds it faster in a file about integrations than three
quarters of the way down a front page.

Still long at 457, and knowingly so. The remaining candidates — the whiteboard
walkthrough, the loop explainer, the graph section — are teaching material
rather than reference, and trimming them is an editorial decision.

Gate: ruff clean, 595 passed, 59 skipped.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
