### PR TITLE
arena: Clean said it worked and the cards did not move, because three drawers

### DIFF
--- a/evals/deterministic/test_memory_arena.py
+++ b/evals/deterministic/test_memory_arena.py
@@ -774,3 +774,35 @@ def test_a_partition_that_was_already_gone_is_not_an_error():
     assert not arena._absent(Exception("401 unauthorized — check your API key")), (
         "an auth failure is not 'already deleted' and must still surface"
     )
+
+
+def test_the_panel_reads_the_races_hosted_partition_too(monkeypatch):
+    """Scoping the panel to a race has to mean ALL of it, not just the local half.
+
+    The first version scoped sqlite and left mem0/Zep reading their default
+    partition — which is `waku`, the LIVE agent's. Three different drawers were
+    then in play: the race wrote to waku-arena-<key>, the panel read `waku`, and
+    Clean deleted waku-arena-<key>. Clean reported success, the cards never
+    changed, and the panel had been showing the operator's real hosted memory
+    the whole time.
+    """
+    seen = {}
+
+    class _Store:
+        def list(self, limit=200):
+            seen["partition"] = os.environ.get("MEM0_USER_ID")
+            return []
+
+    monkeypatch.setattr(arena, "_available_backends", lambda: ["mem0"])
+    monkeypatch.setattr("waku.memory.Memory._make_fact_store",
+                        staticmethod(lambda conn, settings: _Store()))
+    monkeypatch.delenv("MEM0_USER_ID", raising=False)
+
+    rows = arena.store_contents(track="example", model="test:model")
+    assert seen.get("partition", "").startswith("waku-arena-"), (
+        f"the panel must read this race's partition, not the default — got "
+        f"{seen.get('partition')!r}"
+    )
+    assert rows[0]["kind"] == "arena", rows[0]["kind"]
+    # And it must not leak: the live agent has to keep its own partition.
+    assert "MEM0_USER_ID" not in os.environ

--- a/waku/ops/memory_arena.py
+++ b/waku/ops/memory_arena.py
@@ -686,10 +686,17 @@ def store_contents(limit: int = 8, only: str = "", track: str = "",
         # — it has no account, no service and no rows, and printing that line
         # above a note that says "told nothing by design" makes the card argue
         # with itself.
-        arena_copy = bool(seed) and key in ("sqlite", CONTROL)
-        kind = ("arena" if arena_copy else
-                "live" if key == "sqlite" else
-                "control" if key == CONTROL else "connected")
+        # Scoped to a race means ALL of it, not just the local half. The first
+        # version scoped sqlite and left the hosted stores reading their
+        # default partition — which is `waku`, the live agent's. So the race
+        # wrote to waku-arena-<key>, the panel read `waku`, and Clean deleted
+        # waku-arena-<key>: three different drawers, and the cards never
+        # changed no matter what you cleaned. Worse, the panel was showing the
+        # operator's REAL hosted memory the whole time.
+        arena_copy = bool(seed)
+        kind = ("control" if key == CONTROL else
+                "arena" if arena_copy else
+                "live" if key == "sqlite" else "connected")
         row = {"store": key, "count": 0, "facts": [], "error": "", "span": "",
                "kind": kind, "note": _store_note(key)}
         if row["note"]:
@@ -703,8 +710,13 @@ def store_contents(limit: int = 8, only: str = "", track: str = "",
                     else load_settings().home)
             store = "sqlite" if key == CONTROL else key
             settings = Settings(home=home, semantic_store=store)
-            facts = Memory._make_fact_store(_conn_for(store, settings), settings)
-            rows = facts.list(200)
+            # The hosted stores read their partition from the environment at
+            # construction, exactly as they do during a race — so the read has
+            # to be wrapped the same way the write was.
+            with (arena_partition_env(track, seed, model) if arena_copy
+                  else contextlib.nullcontext()):
+                facts = Memory._make_fact_store(_conn_for(store, settings), settings)
+                rows = facts.list(200)
             row["count"] = len(rows)
             row["span"] = _span(rows)
             row["facts"] = [{"subject": r.get("subject", ""), "content": r.get("content", "")}


### PR DESCRIPTION
Sean pressed Clean. It reported "cleaned 2 — sqlite-c5d1c92f38ea,
mem0:waku-arena-c5d1c92f38ea". sqlite went to 0. mem0 stayed at 5 and Zep at
7. He said the button was not working. The button was fine; the panel was
lying.

Scoping the read to a race was done for sqlite and not for the hosted stores,
which kept reading their default partition. That default is `waku` — the LIVE
agent's. So three different drawers were in play at once:

    race writes  ->  waku-arena-<key>
    panel reads  ->  waku            (the operator's real memory)
    Clean deletes ->  waku-arena-<key>

Clean was deleting exactly what it said, and the cards were describing
something else entirely. It also means the panel had been showing Sean's real
hosted memory the whole time — which is the privacy problem I thought I had
fixed two PRs ago when I fixed it for sqlite alone. Half a fix reads as a
whole one until someone presses the button.

The hosted stores read their partition from the environment at construction,
exactly as they do during a race, so the read now wraps the same way the write
does. All five cards describe the same drawer.

Verified live, both halves. The panel now returns kind=arena for every store
with sqlite 0, mem0 0, langmem 0, zep 1 (its user node), control 0 — Clean's
effect finally visible. And the check that matters more: mem0 still holds
['waku', 'quickstart-mem0'], and the `waku` partition still has its 5
memories. Nothing of Sean's was deleted; it had merely been on screen where it
did not belong.

The regression test asserts what the store actually saw — MEM0_USER_ID at the
moment list() was called — rather than the label on the card, because a label
is what was wrong here. It also asserts the env does not leak, since pointing
the live agent at a benchmark partition is worse than the bug.

Gate: ruff clean, 596 passed, 59 skipped.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
