### PR TITLE
dashboard: the Arena gets its own section, and both races get a name

### DIFF
--- a/waku/ops/static/index.html
+++ b/waku/ops/static/index.html
@@ -14,13 +14,17 @@
   <a href="#tools" data-v="tools">Tools <span class="n" id="n-tools"></span></a>
   <a href="#database" data-v="database">Database <span class="n" id="n-db"></span></a>
   <a href="#ops" data-v="ops">Ops <span class="n" id="n-ops"></span></a>
-  <!-- Arena belongs to System: like every row above it, it is a place you WATCH
-       something run — models racing through the real loop rather than one turn.
-       It gets no header of its own because a header over a single row reads as
-       broken navigation, and because its Models / Memory split belongs in
-       sub-tabs inside the page, the way Memory holds semantic / episodic /
-       skills / soul. -->
-  <a href="#compare" data-v="compare">Arena</a>
+  <!-- Arena gets its own section. It was one row under System with the two
+       races behind sub-tabs, on the reasoning that "Models" must not appear
+       twice in the nav. It appears twice now, on purpose, because the two
+       things are not the same word: SETUP > Models picks the model your agent
+       USES, and ARENA > Model race puts ten of them through the loop and
+       scores them. "race" carries that difference in one syllable, and hiding
+       a whole half of the page behind a sub-tab cost more than the repetition
+       ever did. -->
+  <div class="grp">Arena</div>
+  <a href="#compare/models" data-v="compare" data-sub="models">Model race</a>
+  <a href="#compare/memory" data-v="compare" data-sub="memory">Memory race</a>
   <div class="grp">Setup</div>
   <a href="#models" data-v="models">Models</a>
   <a href="#connections" data-v="connections">Connections</a>

--- a/waku/ops/static/js/compare.js
+++ b/waku/ops/static/js/compare.js
@@ -341,9 +341,10 @@ function compareCol(res){
 // (once as a race, once as configuration) — the same reason Memory keeps
 // semantic / episodic / skills behind tabs instead of four sidebar entries.
 VIEWS.compare = function(d, sub){
+  // No sub-tab bar any more: the sidebar names both races directly, and a row
+  // of tabs repeating what the highlighted nav entry already says is furniture.
   sub = sub === "memory" ? "memory" : "models";
-  const bar = subtabBar("compare", [["models","Models"],["memory","Memory"]], sub);
-  return bar + (sub === "memory" ? memoryArenaView() : modelArenaView(d));
+  return sub === "memory" ? memoryArenaView() : modelArenaView(d);
 };
 
 function modelArenaView(d){

--- a/waku/ops/static/js/main.js
+++ b/waku/ops/static/js/main.js
@@ -10,11 +10,13 @@ let activeView = null, activeSub = null;
 // which is a behaviour, not a setting.
 const TITLES = {chat:"Chat & watch", ops:"LLM Ops",
                 graph:"Graph workflows — structure around the loop",
-                // Covers both sub-tabs. TITLES is keyed by view, not by view+sub,
-                // so a models-only title sat above the Memory race and read as a
-                // mislabel; one honest sentence beats teaching the router about
-                // sub-tabs for a single page.
+                // Keyed by view AND sub for the Arena, now that the sidebar
+                // names the two races separately. A single title covering both
+                // was right while they hid behind sub-tabs; with two nav rows
+                // it reads as a page that does not know which one you clicked.
                 compare:"Arena — race models and memory through the same loop",
+                "compare/models":"Model race — ten brains, one harness",
+                "compare/memory":"Memory race — one brain, five places to put facts",
                 settings:"Behaviour — how a turn runs",
                 database:"Database — everything Waku stores (state.db)"};
 function render(){
@@ -23,8 +25,14 @@ function render(){
   const sub = subRaw || null;
   const view = VIEWS[v] ? v : "overview";
   const subChanged = sub !== activeSub || view !== activeView;
-  document.querySelectorAll("nav a").forEach(a=>a.classList.toggle("on", a.dataset.v===view));
-  document.getElementById("title").textContent = TITLES[view] || view[0].toUpperCase()+view.slice(1);
+  // Two nav rows can share a view, so a row that names a sub only lights up
+  // for that sub. Without the fallback, landing on bare #compare would light
+  // NEITHER race and the sidebar would show no current page at all.
+  const effSub = sub || (view === "compare" ? "models" : null);
+  document.querySelectorAll("nav a").forEach(a=>a.classList.toggle("on",
+    a.dataset.v === view && (!a.dataset.sub || a.dataset.sub === effSub)));
+  document.getElementById("title").textContent =
+    TITLES[`${view}/${effSub}`] || TITLES[view] || view[0].toUpperCase()+view.slice(1);
   if (view === "overview" || view === "graph"){
     // don't rebuild mid-animation or the glowing SVG gets wiped
     if (activeView !== view || !animating){ document.getElementById("view").innerHTML = VIEWS[view](D); }


### PR DESCRIPTION
Arena was one row under System with its two races behind sub-tabs. The
reasoning written next to it was that "Models" must not appear twice in the
nav. It appears twice now, deliberately, because those are not the same word:

    SETUP  > Models      picks the model your agent USES
    ARENA  > Model race  puts ten of them through the loop and scores them

"race" carries that difference in one syllable, and hiding half a page behind
a sub-tab cost more than the repetition ever did. Both races are now one click
from anywhere instead of two, and the sub-tab bar is gone — a row of tabs
repeating what the highlighted nav entry already says is furniture.

Two nav rows sharing a view needed the highlighter taught about subs. A row
that names a sub lights only for that sub, and bare #compare falls back to
models — without that fallback it would light NEITHER race and the sidebar
would show no current page at all.

Titles are keyed by view/sub now. One title covering both was right while they
hid behind tabs; with two nav rows it reads as a page that does not know which
one you clicked.

Verified live across all three routes: #compare/models and bare #compare both
give "Model race — ten brains, one harness" with Model race lit, #compare/memory
gives "Memory race — one brain, five places to put facts" with Memory race lit,
and #models still lights Setup's own Models. Zero sub-tab bars rendered.

Gate: ruff clean, 596 passed, both scripts parse.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
