### PR TITLE
arena: run contestants in parallel, and stop repeating the telling status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,9 +35,14 @@ for its own sake is not.
   *immediately before each run*. Permission never carries over from a previous run.
   The script backs up first, but restoring is a hassle — ask, wait for a clear yes,
   then run. It refuses to do anything without the `--yes` flag for this reason.
+- **Commit messages are about the CODE, not the conversation.** Subject = what
+  changed, under ~70 chars. Body = why, in a few tight lines. Then stop.
+  No narrating who asked for it, no "Sean caught", no story of what I tried
+  first, no re-deriving the reasoning. This is a public repo — a stranger
+  reading `git log` wants the change, not a diary. If the reasoning is worth
+  keeping, it belongs in a code comment next to the code it explains.
 - **Version control — commit AND ship every milestone, same turn.** The moment a change
-  works (tests pass / verified live), commit it with a detailed message (subject = what,
-  body = WHY + what it survived) and get it onto GitHub before moving on. Never end a
+  works (tests pass / verified live), commit it and get it onto GitHub before moving on. Never end a
   turn or session with working changes left uncommitted — the repo must always be traceable
   from GitHub, and uncommitted work has been lost to branch switches before. Use the `/ship`
   skill. If several milestones land in one session, commit each as its own logical commit.

--- a/evals/deterministic/test_memory_arena.py
+++ b/evals/deterministic/test_memory_arena.py
@@ -806,3 +806,58 @@ def test_the_panel_reads_the_races_hosted_partition_too(monkeypatch):
     assert rows[0]["kind"] == "arena", rows[0]["kind"]
     # And it must not leak: the live agent has to keep its own partition.
     assert "MEM0_USER_ID" not in os.environ
+
+
+def test_contestants_run_in_parallel(tmp_path, monkeypatch):
+    """Sequential meant a race took the SUM of every contestant, and Zep alone
+    waits minutes for graph ingestion. Contestants share nothing but the emit
+    stream and the results list, both locked."""
+    import threading
+    import time as _t
+
+    import waku.app
+
+    fx = _arena_fixture(tmp_path)
+    overlap = {"max": 0, "live": 0}
+    guard = threading.Lock()
+    original = _FakeWaku.respond
+
+    def slow(self, message, source="cli", observer=None, **kw):
+        with guard:
+            overlap["live"] += 1
+            overlap["max"] = max(overlap["max"], overlap["live"])
+        _t.sleep(0.05)
+        with guard:
+            overlap["live"] -= 1
+        return original(self, message, source=source, observer=observer, **kw)
+
+    monkeypatch.setattr(_FakeWaku, "respond", slow)
+    _FakeWaku.script = {"q1?": "alpha", "q2?": "new"}
+    _FakeWaku.gate = True
+    _FakeWaku.built = []
+    _FakeWaku.settles = True
+    monkeypatch.setattr(waku.app, "Waku", _FakeWaku)
+    _offline(monkeypatch)
+    arena.run_arena(["sqlite", "mem0", "langmem"], "t", lambda k, e: None, fixture=fx)
+
+    assert overlap["max"] > 1, (
+        f"contestants must overlap in time; peak concurrency was {overlap['max']}"
+    )
+
+
+def test_the_partition_is_restored_after_a_parallel_race(tmp_path, monkeypatch):
+    """Set once around the whole race, not per contestant. Per-contestant
+    scoping would have the first thread to finish restore the old value while
+    the others were still writing — pointing them at the live agent's memory."""
+    import waku.app
+
+    fx = _arena_fixture(tmp_path)
+    _FakeWaku.script = {"q1?": "alpha", "q2?": "new"}
+    _FakeWaku.gate = True
+    _FakeWaku.built = []
+    _FakeWaku.settles = True
+    monkeypatch.setattr(waku.app, "Waku", _FakeWaku)
+    _offline(monkeypatch)
+    monkeypatch.setenv("MEM0_USER_ID", "the-live-one")
+    arena.run_arena(["sqlite", "mem0"], "t", lambda k, e: None, fixture=fx)
+    assert os.environ["MEM0_USER_ID"] == "the-live-one"

--- a/waku/ops/memory_arena.py
+++ b/waku/ops/memory_arena.py
@@ -41,6 +41,8 @@ from __future__ import annotations
 import contextlib
 import json
 import os
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 # The shipped fixture is four dull probes whose only job is to document the
@@ -438,8 +440,17 @@ def run_arena(backends: list[str], track: str, emit, fixture: dict | None = None
         return
     spec = fixture["tracks"][track]
     results: list[dict] = []
+    lock = threading.Lock()
+    raw_emit = emit
 
-    for backend in backends:
+    def emit(kind, ev):
+        # One SSE stream, several threads. Concurrent writes interleave mid-line
+        # and corrupt the framing, which shows up as a UI that silently stops
+        # updating rather than as an error.
+        with lock:
+            raw_emit(kind, ev)
+
+    def one(backend):
         emit("start", {"contestant": backend})
         # THE CONTROL. A contestant that is told nothing, then asked everything.
         # It should fail every probe — and any probe it PASSES is not a memory
@@ -457,14 +468,10 @@ def run_arena(backends: list[str], track: str, emit, fixture: dict | None = None
         already = _is_seeded(home)
         try:
             opts = {"provider": prov, "model": mod} if prov and mod else {}
-            # The hosted stores read their partition from the environment at
-            # construction, so this wraps the whole contestant rather than
-            # being passed as a setting.
-            with arena_partition_env(track, seeding, model):
-                app = Waku(settings=Settings(home=home, semantic_store=store,
-                                             apple_calendar=False, google_calendar=False,
-                                             apple_tools=False, graph_workflows=False,
-                                             **opts))
+            # Partition env is set once around the whole race, below.
+            app = Waku(settings=Settings(home=home, semantic_store=store,
+                                         apple_calendar=False, google_calendar=False,
+                                         apple_tools=False, graph_workflows=False, **opts))
             # Seeding is 53% of a race and perfectly deterministic, so a home
             # that already holds this exact seed is not re-told. Racing is now
             # the cheap half: seed once, ask many times.
@@ -528,7 +535,7 @@ def run_arena(backends: list[str], track: str, emit, fixture: dict | None = None
             if seed_only:
                 emit("seed-done", {"contestant": backend, "home": str(home),
                                    "facts": len(seeding), "reused": already})
-                continue
+                return
 
             app.session.start_new("probes")
 
@@ -582,13 +589,29 @@ def run_arena(backends: list[str], track: str, emit, fixture: dict | None = None
                        "calls": calls_now - calls_at,
                        "ms": int((time.perf_counter() - t0) * 1000)}
                 spent, calls_at = after, calls_now
-                results.append(row)
+                with lock:
+                    results.append(row)
                 emit("probe", row)
         except Exception as exc:
             # One backend failing must not lose the other's results — a missing
             # key or a service outage is a fact about that contestant, not a
             # reason to abandon the run.
             emit("failed", {"contestant": backend, "error": f"{type(exc).__name__}: {exc}"})
+
+    # Contestants are independent: separate homes, separate partitions, and the
+    # only shared state is the emit stream and `results`, both locked above.
+    # Sequential meant the race took the SUM of every contestant, and Zep alone
+    # waits minutes for graph ingestion. In parallel it takes the slowest one.
+    #
+    # The partition env is set ONCE around the whole race rather than per
+    # contestant. It is process-global, every contestant in a race shares the
+    # same partition anyway, and per-contestant scoping would have the first
+    # thread to finish restore the old value while the others were still
+    # writing — sending them at the live agent's memory.
+    seed_lines = [] if not backends else (spec.get("seed") or [])
+    with (arena_partition_env(track, seed_lines, model),
+          ThreadPoolExecutor(max_workers=min(len(backends) or 1, 6)) as pool):
+        list(pool.map(one, backends))
 
     # Name the leaks explicitly rather than leaving them to be noticed. A probe
     # the control passed did not test memory in THIS run, whatever the other

--- a/waku/ops/static/js/compare.js
+++ b/waku/ops/static/js/compare.js
@@ -600,7 +600,11 @@ function maResultsHtml(){
     ? (Object.values(memoryArenaFixture.tracks)[0].seed || []).length : 0);
   const names = maRun.backends || [...new Set(maRun.rows.map(r => r.contestant))];
   const probes = maRun.probes || [...new Set(maRun.rows.map(r => r.probe))];
-  const cell = (p, n) => {
+  // `first` because telling is per CONTESTANT, not per question. Repeating
+  // "told 2 of 8" down every probe row made it look like all four questions
+  // were already being asked in parallel — they are not; the contestant has
+  // not been asked anything yet.
+  const cell = (p, n, first) => {
     const r = maRun.rows.find(x => x.probe === p && x.contestant === n);
     if (r) return `<td>${OUTCOME_CELL(r)}
       <div class="ma-facts-meta">${(r.ms/1000).toFixed(1)}s &middot; ${r.tokens} tok${
@@ -613,8 +617,11 @@ function maResultsHtml(){
     // "seeding 4/8" reads like a progress bar for something the viewer has not
     // been shown. "told 4 of 8" names the actual event: this store has now been
     // told four of the eight facts it is about to be questioned on.
-    if (seeded < seedTotal) return `<td class="meta">told ${seeded} of ${seedTotal}<span class="caret"></span></td>`;
-    return `<td class="meta">asking<span class="caret"></span></td>`;
+    if (seeded < seedTotal) return first
+      ? `<td class="meta">being told ${seeded} of ${seedTotal}<span class="caret"></span></td>`
+      : `<td class="meta"></td>`;
+    return first ? `<td class="meta">asking<span class="caret"></span></td>`
+                 : `<td class="meta">waiting</td>`;
   };
   const board = maRun.board ? `<div class="card" style="padding:4px 8px"><div class="tablescroll"><table>
       <tr><th>store</th><th>pass</th><th>stale</th><th>invented</th><th>miss</th><th>tokens</th></tr>
@@ -627,7 +634,7 @@ function maResultsHtml(){
     ${board}
     <div class="card" style="padding:4px 8px"><div class="tablescroll"><table>
       <tr><th>probe</th>${names.map(n=>`<th>${esc(n)}</th>`).join("")}</tr>
-      ${probes.map(p=>{
+      ${probes.map((p, i)=>{
         const any = maRun.rows.find(x => x.probe === p);
         const fx = maProbe(p);
         const leaked = (maRun.leaked || []).includes(p);
@@ -638,7 +645,7 @@ function maResultsHtml(){
             <div class="ma-facts-meta">${fx ? (fx.expect_refusal
                 ? "must decline" : "wants: " + esc((fx.expect_any||[]).join(" / "))) : ""}${
               fx && (fx.stale_any||[]).length ? " &middot; not: " + esc(fx.stale_any.join(" / ")) : ""}</div>
-          </td>${names.map(n=>cell(p,n)).join("")}</tr>`;}).join("")}
+          </td>${names.map(n=>cell(p, n, i === 0)).join("")}</tr>`;}).join("")}
     </table></div></div>`;
 }
 


### PR DESCRIPTION
A race took the sum of every contestant; Zep alone waits minutes for graph
ingestion. Contestants share nothing but the emit stream and the results
list, so they now run in a thread pool and the race takes the slowest one.

Two things had to move to make that safe:

- emit() is wrapped in a lock. Concurrent writes to one SSE stream interleave
  mid-line and corrupt the framing, which shows up as a UI that silently
  stops updating.
- the partition env is set once around the whole race instead of per
  contestant. It is process-global and every contestant shares the same
  partition, so per-contestant scoping would let the first thread to finish
  restore the old value while the others were still writing.

Separately: "told 2 of 8" was rendered in every probe row, which read as all
four questions being asked at once. Telling is per contestant, so it now
shows on the first row only.

Also adds the commit-message rule to CLAUDE.md: subject, a few tight lines
of why, then stop.

Gate: ruff clean, 598 passed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
