### PR TITLE
arena: count telling against the track being raced, not the first one in the file

### DIFF
--- a/evals/deterministic/test_memory_arena.py
+++ b/evals/deterministic/test_memory_arena.py
@@ -861,3 +861,31 @@ def test_the_partition_is_restored_after_a_parallel_race(tmp_path, monkeypatch):
     monkeypatch.setenv("MEM0_USER_ID", "the-live-one")
     arena.run_arena(["sqlite", "mem0"], "t", lambda k, e: None, fixture=fx)
     assert os.environ["MEM0_USER_ID"] == "the-live-one"
+
+
+def test_an_already_told_store_emits_one_cached_event_not_a_fake_count(tmp_path, monkeypatch):
+    """Faking len(seed) 'seeded' events made a store that needed no telling
+    animate through a telling phase it was not doing."""
+    import waku.app
+
+    fx = _arena_fixture(tmp_path)          # 2 seed lines
+    home = tmp_path / "pinned"
+    _FakeWaku.script = {"q1?": "alpha", "q2?": "new"}
+    _FakeWaku.gate = True
+    _FakeWaku.settles = True
+    monkeypatch.setattr(waku.app, "Waku", _FakeWaku)
+    _offline(monkeypatch)
+    monkeypatch.setattr(arena, "arena_home", lambda *a, **k: home)
+
+    _FakeWaku.built = []
+    arena.run_arena(["sqlite"], "t", lambda k, e: None, fixture=fx)   # first: seeds
+
+    events = []
+    _FakeWaku.built = []
+    arena.run_arena(["sqlite"], "t", lambda k, e: events.append((k, e)), fixture=fx)
+
+    seeded = [e for k, e in events if k == "seeded"]
+    cached = [e for k, e in events if k == "cached"]
+    assert not seeded, f"an already-told store must not re-emit seeded events: {seeded}"
+    assert len(cached) == 1, f"exactly one cached event, got {cached}"
+    assert cached[0]["facts"] == 2, cached[0]

--- a/waku/ops/memory_arena.py
+++ b/waku/ops/memory_arena.py
@@ -476,11 +476,10 @@ def run_arena(backends: list[str], track: str, emit, fixture: dict | None = None
             # that already holds this exact seed is not re-told. Racing is now
             # the cheap half: seed once, ask many times.
             if already:
-                emit("seeded", {"contestant": backend,
-                                "line": f"already told {len(seeding)} — reusing",
-                                "cached": True})
-                for _ in seeding[1:]:
-                    emit("seeded", {"contestant": backend, "line": "", "cached": True})
+                # One event, not len(seeding) phantom "seeded" ones. Faking the
+                # count made a store that needed no telling still animate
+                # through a telling phase it was not doing.
+                emit("cached", {"contestant": backend, "facts": len(seeding)})
             for line in [] if already else seeding:
                 app.respond(line, source="memory-arena")
                 emit("seeded", {"contestant": backend, "line": line})

--- a/waku/ops/static/js/compare.js
+++ b/waku/ops/static/js/compare.js
@@ -508,6 +508,7 @@ async function runMemoryArena(seedOnly){
   // only the cells are pending.
   maRun = {running:true, rows:[], board:null, log:"telling…", error:null,
            backends: maPicks(), probes: fx.tracks[track].probes.map(p=>p.id),
+           seedTotal: (fx.tracks[track].seed || []).length,
            seeded: {}, seedOnly: !!seedOnly};
   editing = false; render();
   try {
@@ -527,8 +528,10 @@ async function runMemoryArena(seedOnly){
         const ev = JSON.parse(c.slice(6));
         if (ev.kind === "start"){ maRun.log = `${ev.contestant}: telling…`;
                                   maRun.seeded[ev.contestant] = 0; }
-        // A store told earlier is not re-told; the run reports it as reused so
-        // "instant" reads as cached rather than as skipped.
+        // Told in an earlier race — nothing to re-tell, so jump straight to
+        // asking rather than animating a telling phase that is not happening.
+        if (ev.kind === "cached"){ maRun.seeded[ev.contestant] = maRun.seedTotal;
+                                   maRun.log = `${ev.contestant}: already told ${ev.facts}`; }
         if (ev.kind === "seed-done"){ maRun.log = `${ev.contestant}: ${
                                         ev.reused ? "already told" : "told"} ${ev.facts}`; }
         if (ev.kind === "seeded"){ maRun.log = `${ev.contestant}: ${ev.line}`;
@@ -596,8 +599,11 @@ function maResultsHtml(){
   // column and row is on screen from the first second, and each cell says
   // whether it is seeding, queued, or done. An empty table under a "running"
   // heading is indistinguishable from a broken one.
-  const seedTotal = (memoryArenaFixture && memoryArenaFixture.tracks
-    ? (Object.values(memoryArenaFixture.tracks)[0].seed || []).length : 0);
+  // From the track being RACED, recorded when the race started. It used to read
+  // Object.values(tracks)[0] — always the first track in the file, whichever one
+  // you picked. Racing the 6-fact business track against the 8-fact dinner
+  // track's total stuck the cell at "told 6 of 8" and it never reached "asking".
+  const seedTotal = maRun.seedTotal || 0;
   const names = maRun.backends || [...new Set(maRun.rows.map(r => r.contestant))];
   const probes = maRun.probes || [...new Set(maRun.rows.map(r => r.probe))];
   // `first` because telling is per CONTESTANT, not per question. Repeating


### PR DESCRIPTION
seedTotal read Object.values(tracks)[0] — always the first track in the probe
file, whichever one you picked. Racing the 6-fact business track against the
8-fact dinner track's total left the cell stuck at "told 6 of 8", never
reaching "asking". It now comes from the track the race started with.

An already-told store also emitted len(seed) phantom "seeded" events purely to
fill that counter, so a store that needed no telling still animated through a
telling phase it was not doing. One "cached" event now, and the UI jumps
straight to asking.

Gate: ruff clean, 599 passed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
