### PR TITLE
docs: replace the expired Discord invite, and the dead AutoManus one

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: true
 contact_links:
   - name: Question or show-and-tell
-    url: https://discord.gg/7Ntxzm3eJ
+    url: https://discord.gg/ebbdvSCXqu
     about: Fastest place to ask something or share what you built.
   - name: Good first issues
     url: https://github.com/ShenSeanChen/waku-agent/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -18,7 +18,7 @@ answer them.
 - **No harassment, personal attacks, or demeaning comments** about anyone's
   experience level, background, identity, or English. Plenty of contributors
   here aren't writing in their first language.
-- **Don't derail.** Issues are for the work; the [Discord](https://discord.gg/7Ntxzm3eJ)
+- **Don't derail.** Issues are for the work; the [Discord](https://discord.gg/ebbdvSCXqu)
   is for everything else.
 - **Credit people.** If someone's idea shaped a change, say so in the PR.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,5 +135,5 @@ keep it legible.
 
 ## Community
 
-Questions, show-and-tell, pair-debugging: [Discord](https://discord.gg/7Ntxzm3eJ). By
+Questions, show-and-tell, pair-debugging: [Discord](https://discord.gg/ebbdvSCXqu). By
 contributing you agree your work is licensed under the repo's MIT license.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Built by [seanchen.io](https://seanchen.io).
 
 **▶ [Watch the 20-min code walkthrough](https://www.youtube.com/watch?v=rvRyBhILrls&list=PLE9hy4A7ZTmpGq7GHf5tgGFWh2277AeDR&index=42)** — the loop, the memory pillars, the evals, the Telegram gateway and the "Waku Waku" wake word, live.
 
-[YouTube](https://www.youtube.com/@SeanAIStories) · [X](https://x.com/ShenSeanChen) · [LinkedIn](https://linkedin.com/in/shen-sean-chen) · [Instagram](https://www.instagram.com/sean_ai_stories) · [TikTok](https://www.tiktok.com/@sean_ai_stories) · [Discord](https://discord.gg/tvECErKcFr) ·
+[YouTube](https://www.youtube.com/@SeanAIStories) · [X](https://x.com/ShenSeanChen) · [LinkedIn](https://linkedin.com/in/shen-sean-chen) · [Instagram](https://www.instagram.com/sean_ai_stories) · [TikTok](https://www.tiktok.com/@sean_ai_stories) · [Discord](https://discord.gg/ebbdvSCXqu) ·
 [哔哩哔哩](https://space.bilibili.com/479332937) · [小红书](https://www.xiaohongshu.com/user/profile/5cf02cfb0000000005014371) · [抖音](https://www.douyin.com/user/MS4wLjABAAAAWCkd62_e8q4n-S34LIL04HsYN3m03l8MFdVYZToojP8)
 
 ### ☕️ [Buy me a coffee](https://buy.stripe.com/5kA176bA895ggog4gh) — it keeps this repo (and the videos) coming
@@ -439,7 +439,7 @@ The point of a teaching repo is a readable core; these come alive one at a time,
 
 ## Community
 
-Star the repo, join the [Discord](https://discord.gg/7Ntxzm3eJ), and grab a
+Star the repo, join the [Discord](https://discord.gg/ebbdvSCXqu), and grab a
 [good first issue](https://github.com/ShenSeanChen/waku-agent/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 — that link is the live list, so it's always current. Gateways, memory backends and
 community skills are all shaped to be first PRs; the easiest needs no Python at all
@@ -451,7 +451,7 @@ never build the same thing.
 ## Also from me
 
 - **[launch-mvp-stripe-nextjs-supabase](https://github.com/ShenSeanChen/launch-mvp-stripe-nextjs-supabase)** — NextJS + Supabase + Stripe, everything you need to ship a SaaS.
-- **[AutoManus.io](https://automanus.io)** — my AI startup: a sales lead manager for made-to-order products. It embeds where conversations already happen (WhatsApp, email, web chat) to capture inbound, automate follow-ups and kill CRM busywork. Pre-seed backed by Character VC. ([AutoManus Discord](https://discord.gg/5HhcNjCR))
+- **[AutoManus.io](https://automanus.io)** — my AI startup: a sales lead manager for made-to-order products. It embeds where conversations already happen (WhatsApp, email, web chat) to capture inbound, automate follow-ups and kill CRM busywork. Pre-seed backed by Character VC. ([AutoManus Discord](https://discord.gg/SxXATg9rSK))
 
 MIT — see [LICENSE](LICENSE). Built by [@ShenSeanChen](https://github.com/ShenSeanChen)
 ([YouTube](https://www.youtube.com/@SeanAIStories) · [X](https://x.com/ShenSeanChen)).


### PR DESCRIPTION
The community invite had expired, so every route into Discord was a 404 —
including the contact link in the issue template, which is what renders on
every New Issue page. Both replacements are permanent invites and land in
#waku-agent rather than #self-intro.

The AutoManus invite in the projects list was dead too ("Unknown Invite"),
and was not part of the report.

Closes #106

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
