### PR TITLE
fix: the openai default 404s — the whole -chat-latest line is deprecated

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -176,7 +176,7 @@ WAKU_PROVIDER=anthropic
 # ── Models (optional) ───────────────────────────────────────────────────────
 # Each provider has sensible defaults (see waku/loop/models.py PROVIDERS):
 #   anthropic:  claude-sonnet-5              + claude-haiku-4-5 (gate/summarizer)
-#   openai:     gpt-5.6                      + gpt-5.6-luna
+#   openai:     gpt-5.5                      + gpt-4.1-mini
 #   gemini:     gemini-3.5-flash             + gemini-3.1-flash-lite
 #   deepseek:   deepseek-v4-pro              + deepseek-v4-pro
 #   minimax:    MiniMax-M3                   + MiniMax-M2

--- a/evals/deterministic/test_models.py
+++ b/evals/deterministic/test_models.py
@@ -1,7 +1,13 @@
+import os
 from types import SimpleNamespace
 
+import pytest
+
+from evals.helpers import HAS_KEY
 from waku.config import Settings
 from waku.loop import models
+
+RUN_LIVE_EVALS = os.getenv("WAKU_RUN_LIVE_EVALS") == "1"
 
 
 def test_xai_grok_provider_uses_expected_key_endpoint_and_models(monkeypatch, tmp_path):
@@ -29,8 +35,57 @@ def test_openai_default_is_tool_capable(tmp_path):
     variants (luna/sol/terra) can't use function tools on /v1/chat/completions
     (they 400). The default must be a NON-reasoning, tool-capable chat model."""
     from waku.loop.models import PROVIDERS
-    assert PROVIDERS["openai"].model == "gpt-5.3-chat-latest"
-    assert PROVIDERS["openai"].default_pair() == ["gpt-5.3-chat-latest", "gpt-4.1-mini"]
+    assert PROVIDERS["openai"].model == "gpt-5.5"
+    assert PROVIDERS["openai"].default_pair() == ["gpt-5.5", "gpt-4.1-mini"]
+
+
+def test_no_default_model_is_a_moving_alias():
+    """The whole gpt-5.x-chat-latest line went 404 at once (issue #132), and
+    waku shipped a default pointing into it. An alias is what made that a silent
+    break rather than a caught one: the id in the repo never changed, so nothing
+    local could tell it had stopped resolving.
+
+    Pinning concrete ids does not stop a provider deprecating a model — nothing
+    offline can. It stops the OTHER half of the failure, where a benchmark drifts
+    under you because the name quietly started meaning something else. Catching
+    an actual deprecation needs the live probe below.
+    """
+    from waku.loop.models import PROVIDERS
+
+    offenders = [f"{name}: {m}"
+                 for name, prov in PROVIDERS.items()
+                 for m in prov.default_pair()
+                 if m.endswith("-latest")]
+    assert not offenders, (
+        "default models must be concrete ids, not moving aliases — "
+        f"{', '.join(offenders)}. See issue #132.")
+
+
+@pytest.mark.skipif(not (HAS_KEY and RUN_LIVE_EVALS),
+                    reason="set WAKU_RUN_LIVE_EVALS=1 and configure an API key to run live evals")
+def test_openai_defaults_still_resolve_live():
+    """The only check that can catch a deprecation, because only the provider
+    knows. Calls both defaults in the exact shape OpenAICompatClient._to_openai
+    sends — chat.completions WITH a function tool attached — because that is the
+    combination gpt-5.6-luna passes as a bare call and 400s on.
+
+    Off by default; `make gate` with WAKU_RUN_LIVE_EVALS=1 is where this bites.
+    """
+    import openai
+
+    from waku.loop.models import PROVIDERS
+
+    key = os.getenv("OPENAI_API_KEY")
+    if not key:
+        pytest.skip("no OPENAI_API_KEY")
+    client = openai.OpenAI(api_key=key, timeout=60)
+    tool = [{"type": "function",
+             "function": {"name": "ping", "description": "ping",
+                          "parameters": {"type": "object", "properties": {}}}}]
+    for model in PROVIDERS["openai"].default_pair():
+        client.chat.completions.create(
+            model=model, tools=tool, max_completion_tokens=32,
+            messages=[{"role": "user", "content": "call ping"}])
 
 
 def test_gemini_thought_signature_round_trips():

--- a/waku/loop/models.py
+++ b/waku/loop/models.py
@@ -85,12 +85,16 @@ PROVIDERS: dict[str, Provider] = {
                           flagship="claude-opus-4-8", fast="claude-sonnet-5"),
     # The gpt-5.6 REASONING models (luna/sol/terra) can't use function tools on
     # /v1/chat/completions (they need /v1/responses), so every Waku turn 400s on
-    # them. The non-reasoning "chat" line DOES call tools fine; gpt-5.3-chat-latest
-    # is the newest concrete one (preferred over the gpt-5-chat-latest alias so a
-    # benchmark is reproducible). gpt-4.1-mini is a cheap tool-capable gate.
-    # base_url is None (SDK default) so point the picker at OpenAI's catalog.
+    # them. That constraint still holds — what changed is where the escape hatch
+    # is: the whole `-chat-latest` line (5.3, 5.2, 5.1 and the bare gpt-5 alias)
+    # is now 404 deprecated, so "fall back to the previous -chat-latest" is not
+    # an option any more. gpt-5.5 is the newest plain model that returns a
+    # tool_call on /v1/chat/completions; gpt-4.1-mini is a cheap tool-capable
+    # gate. A `-latest` alias is deliberately NOT used — it silently changes
+    # under a pinned benchmark, and test_openai_default_is_tool_capable rejects
+    # one. base_url is None (SDK default) so point the picker at the catalog.
     "openai":    Provider("openai", "OPENAI_API_KEY", None,
-                          "gpt-5.3-chat-latest", "gpt-4.1-mini",
+                          "gpt-5.5", "gpt-4.1-mini",
                           catalog_url="https://api.openai.com/v1/models"),
     # one key, every lab's models, and a $0 tier: the default models below are
     # free ids (":free" suffix). Rate-limited (~50 req/day without credits).


### PR DESCRIPTION
WAKU_PROVIDER=openai died on every turn. gpt-5.3-chat-latest is gone, and
so are 5.2, 5.1 and the bare gpt-5-chat-latest alias, so falling back one
generation is not available. The failure reads as a waku bug: the gate
succeeds on the small model, then the main model 404s.

gpt-5.5 is the newest plain model that returns a tool_call from
chat.completions with a function tool attached — probed live against every
candidate, which is the shape OpenAICompatClient actually sends.

Two guards, because pinning a new id fixes today only. An offline check
rejects any default ending in -latest: the alias is what made this silent,
since the id in the repo never changed while it stopped resolving. A live
probe under WAKU_RUN_LIVE_EVALS calls both defaults with a tool attached —
the only check that can see a deprecation, because only the provider knows.

.env.example advertised gpt-5.6-luna, which is precisely the model that
400s on function tools.

Closes #132

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
