### PR TITLE
ui: add a System / Light / Dark theme toggle to the dashboard

### DIFF
--- a/evals/deterministic/test_theme_toggle.py
+++ b/evals/deterministic/test_theme_toggle.py
@@ -1,0 +1,68 @@
+"""DETERMINISTIC EVAL — the dashboard theme switch has exactly one switch.
+
+The dashboard used to follow the OS only, through `prefers-color-scheme`
+queries. The System / Light / Dark button works by resolving the choice in
+`js/theme.js` and stamping `data-theme="light|dark"` on `<html>`, so the CSS
+reads ONE attribute.
+
+That only holds while nobody adds a media query back. A stray
+`@media (prefers-color-scheme:dark)` would win over the picked theme for
+whatever it styles, and the symptom is a half-dark page nobody can explain from
+reading either file alone — so pin the invariant here instead.
+
+The other two checks cover the ways the button dies silently: the script has to
+load in <head> (or the page flashes the wrong palette on every reload) and the
+button has to be wired to a real handler."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+STATIC = Path(__file__).resolve().parents[2] / "waku" / "ops" / "static"
+INDEX = (STATIC / "index.html").read_text()
+CSS = (STATIC / "style.css").read_text()
+THEME_JS = (STATIC / "js" / "theme.js").read_text()
+
+# CSS comments explain the rule; only real at-rules break it.
+CSS_RULES = re.sub(r"/\*.*?\*/", "", CSS, flags=re.DOTALL)
+
+
+def test_no_prefers_color_scheme_queries_remain():
+    """One switch, not two. Style the dark case with `[data-theme="dark"]`."""
+    strays = re.findall(r"@media[^{]*prefers-color-scheme[^{]*", CSS_RULES)
+    assert not strays, (
+        "style.css must key off data-theme alone — these would override a "
+        f"manual Light/Dark pick: {strays}"
+    )
+
+
+def test_dark_palette_is_reachable():
+    """The attribute the JS writes and the selector the CSS reads must match."""
+    assert ':root[data-theme="dark"]{' in CSS_RULES
+    assert 'setAttribute(\'data-theme\'' in THEME_JS or 'setAttribute("data-theme"' in THEME_JS
+
+
+def test_native_controls_follow_the_picked_theme():
+    """`color-scheme:light dark` would leave scrollbars and form controls on the
+    OS setting, which is the one thing the button exists to override."""
+    assert "color-scheme:light;" in CSS_RULES
+    assert "color-scheme:dark;" in CSS_RULES
+    assert "color-scheme:light dark" not in CSS_RULES
+
+
+def test_theme_script_loads_in_head():
+    """Anywhere else and the page paints the default palette first, then
+    repaints — a white flash on every reload for a Dark user."""
+    head = INDEX.split("</head>")[0]
+    assert '<script src="/static/js/theme.js"></script>' in head
+
+
+def test_button_is_wired():
+    assert 'id="theme-toggle"' in INDEX and 'onclick="cycleTheme()"' in INDEX
+    assert "function cycleTheme()" in THEME_JS
+
+
+def test_all_three_choices_are_offered():
+    """System stays first: it is the default, and the cycle has to return to it."""
+    assert "const THEME_ORDER = ['system', 'light', 'dark'];" in THEME_JS

--- a/waku/ops/static/README.md
+++ b/waku/ops/static/README.md
@@ -6,7 +6,8 @@ files to change the UI; edit `dashboard.py` to change the server/API.
 
 - `index.html` — the shell (sidebar nav, `<main>`, chat dock) + the ordered
   `<script>` tags.
-- `style.css` — one flat file, `:root` design tokens at the top, light + dark.
+- `style.css` — one flat file, `:root` design tokens at the top, light + dark
+  (dark keys off `:root[data-theme="dark"]`).
 - `js/` — the app, split by concern (below).
 
 ## The files (`js/`), in load order
@@ -17,6 +18,7 @@ runs the bootstrap and must load last**.
 
 | file | what lives here |
 |------|-----------------|
+| `theme.js`   | System / Light / Dark picker — **the one file loaded in `<head>`**, see below |
 | `util.js`    | `esc`, markdown renderer, core globals (`D`, `editing`), `postJSON`, `reveal` |
 | `memory.js`  | inline Memory / SOUL / skill editing actions |
 | `models.js`  | `applyModel` (the one `/api/settings` writer), model picker / catalog / pins |
@@ -34,6 +36,12 @@ Data flows one way: `refresh()` (main.js) fetches `/api/data` into the global
 
 ## Rules that bite (read before editing)
 
+- **`theme.js` loads in `<head>`, everything else at the end of `<body>`.**
+  It writes `data-theme="light|dark"` on `<html>` before the first paint; move it
+  down with the others and a Dark user gets a white flash on every reload.
+  It also resolves the System choice itself, which is why `style.css` has **no
+  `prefers-color-scheme` queries** — the palette reads one attribute, not two
+  sources that have to agree. `test_theme_toggle.py` pins that.
 - **Inline handlers need global names.** Buttons use `onclick="fn()"` in the
   HTML strings the JS generates. `fn` must stay a top-level name in some `js/`
   file. Rename/move a handler and forget its call sites → the button silently

--- a/waku/ops/static/index.html
+++ b/waku/ops/static/index.html
@@ -1,7 +1,12 @@
 <!doctype html><html><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Waku わく</title>
-<link rel="stylesheet" href="/static/style.css"></head><body>
+<link rel="stylesheet" href="/static/style.css">
+<!-- The one script that loads in <head>: it stamps the resolved theme on
+     <html> before the first paint, so picking Dark on a light desktop does
+     not flash white on every reload. Everything else loads at the end of
+     the body. -->
+<script src="/static/js/theme.js"></script></head><body>
 <nav id="nav">
   <div class="brand">Waku わく<small id="model" style="cursor:pointer" title="click to change the model" onclick="location.hash='#models'"></small>
     <button id="nav-toggle" title="Hide sidebar">&#10094;</button></div>
@@ -33,6 +38,7 @@
 <div class="resizer" id="nav-resizer" title="Drag to resize sidebar"></div>
 <main>
   <header class="pagehead">
+    <button id="theme-toggle" onclick="cycleTheme()">System</button>
     <h1 id="title">Overview</h1>
     <div class="sub" id="sub"></div>
   </header>

--- a/waku/ops/static/js/theme.js
+++ b/waku/ops/static/js/theme.js
@@ -1,0 +1,60 @@
+/* Theme picker — System / Light / Dark.
+ *
+ * Loaded from <head>, before the body, unlike every other file in js/. That is
+ * deliberate: it stamps the resolved theme onto <html> before the first paint,
+ * so a dark-mode user never sees a flash of the light palette.
+ *
+ * Two values, and keeping them apart is the whole design:
+ *   - the CHOICE  ("system" | "light" | "dark") is what the user clicked, and
+ *     the only thing localStorage holds;
+ *   - the RESOLVED theme ("light" | "dark") is what lands in data-theme.
+ * Resolving "system" here, in JS, is why style.css has no prefers-color-scheme
+ * queries left: the palette has exactly ONE switch to read instead of two that
+ * would have to agree with each other. */
+
+const THEME_KEY = 'waku-theme';
+const THEME_ORDER = ['system', 'light', 'dark'];
+const THEME_LABEL = {system: 'System', light: 'Light', dark: 'Dark'};
+const THEME_DARK_QUERY = window.matchMedia('(prefers-color-scheme:dark)');
+
+/* localStorage throws in private mode and when site data is blocked; a theme
+   button is not worth taking the page down for, so fall back to System. */
+function themeChoice() {
+  try {
+    const stored = localStorage.getItem(THEME_KEY);
+    return THEME_ORDER.includes(stored) ? stored : 'system';
+  } catch (err) {
+    return 'system';
+  }
+}
+
+function nextTheme(choice) {
+  return THEME_ORDER[(THEME_ORDER.indexOf(choice) + 1) % THEME_ORDER.length];
+}
+
+function applyTheme() {
+  const choice = themeChoice();
+  const dark = choice === 'dark' || (choice === 'system' && THEME_DARK_QUERY.matches);
+  document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
+  // Runs once from <head> with no body yet, then again on DOMContentLoaded.
+  const btn = document.getElementById('theme-toggle');
+  if (btn) {
+    btn.textContent = THEME_LABEL[choice];
+    btn.title = 'Theme: ' + THEME_LABEL[choice] + ' — click for ' + THEME_LABEL[nextTheme(choice)];
+  }
+}
+
+function cycleTheme() {
+  try {
+    localStorage.setItem(THEME_KEY, nextTheme(themeChoice()));
+  } catch (err) {
+    /* no persistence available — the click still applies for this page */
+  }
+  applyTheme();
+}
+
+applyTheme();
+// System has to keep following the OS while the page is open, not only at boot.
+THEME_DARK_QUERY.addEventListener('change', applyTheme);
+// The button lives in the body, which does not exist yet on the first call.
+document.addEventListener('DOMContentLoaded', applyTheme);

--- a/waku/ops/static/style.css
+++ b/waku/ops/static/style.css
@@ -1,19 +1,26 @@
+/* THE THEME SWITCH. `js/theme.js` resolves the user's choice (System /
+   Light / Dark) before the first paint and writes data-theme="light|dark" on
+   <html>, so every rule below keys off that one attribute. There are
+   deliberately NO prefers-color-scheme queries in this file: the OS preference
+   is read in one place, and a manual pick has nothing to fight with. */
 :root{
-    /* let native UI (scrollbars, form controls) follow the active scheme,
-       otherwise they stay light even in dark mode */
-    color-scheme:light dark;
+    /* explicit, not `light dark`: native UI (scrollbars, form controls) must
+       follow the PICKED theme, not the OS one, or Dark-on-a-light-desktop
+       ships light scrollbars */
+    color-scheme:light;
     --bg:#fafaf9;--panel:#ffffff;--line:#e7e6e4;--line2:#d9d8d5;
     --ink:#21201d;--ink2:#6f6e69;--ink3:#a3a29d;
     --accent:#5e6ad2;--accent-soft:#eef0fb;
     --good:#1f7a4d;--good-soft:#e8f4ee;--bad:#c0392b;--bad-soft:#faeceb;
     --mono:ui-monospace,'SF Mono',Menlo,monospace;
   }
-  @media (prefers-color-scheme:dark){:root{
+  :root[data-theme="dark"]{
+    color-scheme:dark;
     --bg:#101012;--panel:#18181b;--line:#26262a;--line2:#333338;
     --ink:#ececea;--ink2:#96959f;--ink3:#5f5e66;
     --accent:#7c8aec;--accent-soft:#20223a;
     --good:#4cc38a;--good-soft:#12291d;--bad:#e5655a;--bad-soft:#331714;
-  }}
+  }
   *{box-sizing:border-box;margin:0}
   /* thin theme-colored scrollbars (like the chat dock's), instead of the
      chunky native ones */
@@ -36,6 +43,13 @@
   body.resizing{cursor:col-resize;user-select:none}
   #nav-toggle{float:right;background:none;border:none;color:var(--ink3);cursor:pointer;font-size:12px;padding:2px 4px;line-height:1}
   #nav-toggle:hover{color:var(--ink)}
+  /* Floated rather than flexed: .pagehead is a plain block that several views
+     write into, and float keeps the button out of their way. */
+  #theme-toggle{float:right;margin-top:2px;background:var(--panel);border:1px solid var(--line2);
+    border-radius:6px;color:var(--ink2);cursor:pointer;font:inherit;font-size:11.5px;
+    padding:4px 10px;min-width:64px}
+  #theme-toggle:hover{color:var(--ink);border-color:var(--ink3)}
+  #theme-toggle:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
   #nav-reopen{display:none;position:fixed;top:12px;left:12px;z-index:25;background:var(--panel);
     border:1px solid var(--line2);border-radius:8px;color:var(--ink2);width:34px;height:30px;cursor:pointer;font-size:14px}
   body.nav-hidden #nav,body.nav-hidden #nav-resizer{display:none}
@@ -124,10 +138,10 @@
   /* fenced code blocks */
   .mdcode{border:1px solid var(--line);border-radius:var(--radius);overflow:hidden;margin:10px 0;
           background:rgba(0,0,0,0.035)}
-  @media(prefers-color-scheme:dark){.mdcode{background:rgba(0,0,0,0.40)}}
+  :root[data-theme="dark"] .mdcode{background:rgba(0,0,0,0.40)}
   .mdcode-head{display:flex;align-items:center;justify-content:space-between;padding:5px 12px;
                border-bottom:1px solid var(--line);background:rgba(0,0,0,0.025)}
-  @media(prefers-color-scheme:dark){.mdcode-head{background:rgba(255,255,255,0.04)}}
+  :root[data-theme="dark"] .mdcode-head{background:rgba(255,255,255,0.04)}
   .mdcode-lang{font-family:var(--mono);font-size:10.5px;text-transform:uppercase;
                letter-spacing:.08em;color:var(--ink3);font-weight:600}
   .mdcode-copy{background:none;border:1px solid var(--line2);border-radius:6px;color:var(--ink3);
@@ -240,9 +254,11 @@
   .srcpill.mcp{background:var(--good-soft);color:var(--good)}
   .srcpill.apple{background:#0000;border:1px solid var(--line2);color:var(--ink2)}
   /* read-only SQL console (the Supabase-editor idea, scoped down) */
-  .sqlbox{width:100%;min-height:70px;background:#0b0b0d;color:#d6d7de;border:1px solid var(--line2);
+  /* Stays a dark console in both themes (it is a terminal, not a panel), but
+     lifts one shade on a light page so it does not read as a hole. */
+  .sqlbox{width:100%;min-height:70px;background:#1c1c20;color:#e6e6ea;border:1px solid var(--line2);
           border-radius:8px;padding:11px 13px;font:12.5px/1.5 var(--mono);resize:vertical;outline:none}
-  @media (prefers-color-scheme:light){.sqlbox{background:#1c1c20;color:#e6e6ea}}
+  :root[data-theme="dark"] .sqlbox{background:#0b0b0d;color:#d6d7de}
   .sqlbox:focus{border-color:var(--accent)}
   .qexample{font-family:var(--mono);font-size:11.5px;color:var(--accent);cursor:pointer;border-bottom:1px dashed var(--accent)}
   /* session picker in the chat surfaces */
@@ -585,10 +601,8 @@ details.subterm > summary.subterm-h::-webkit-details-marker{ display:none; }
 .connmodal-message{flex:1;min-width:160px;color:var(--ink3);font-size:11.5px}
 .conn-force{margin-left:6px}
 .connmodal :focus-visible{outline:2px solid var(--accent);outline-offset:2px}
-@media (prefers-color-scheme:dark){
-  .conncard:hover{box-shadow:0 5px 18px rgba(0,0,0,.25)}
-  .connstatus.needs-setup{color:#d9a441}
-}
+:root[data-theme="dark"] .conncard:hover{box-shadow:0 5px 18px rgba(0,0,0,.25)}
+:root[data-theme="dark"] .connstatus.needs-setup{color:#d9a441}
 @media (max-width:720px){
   .conngrid{grid-template-columns:1fr}
   .connmodal-back{padding:10px}


### PR DESCRIPTION
Closes #138.
 what this is

A small button in the page header that cycles **System → Light → Dark** and
remembers the choice in `localStorage`. System stays the default, so nothing
changes for anyone who never clicks it.

How it works

`js/theme.js` holds the *choice* (`system` / `light` / `dark`) and writes the
*resolved* theme to `data-theme="light|dark"` on `<html>`. Keeping those two
apart is the whole design.

Three details worth calling out, since each was a decision rather than a default:

- **It loads in `<head>`**, unlike every other script in `js/`. The attribute has
  to be on `<html>` before the first paint, or a Dark user gets a white flash on
  every reload.
- **`style.css` now has no `prefers-color-scheme` queries at all.** Since
  `theme.js` resolves System itself, the palette reads one switch instead of two
  sources that have to agree — and a media query left behind would silently
  outrank a manual pick, which reads as a half-dark page you cannot explain from
  either file alone. All five old blocks (palette, `.mdcode`, `.mdcode-head`,
  `.sqlbox`, the Connections tweaks) moved to `:root[data-theme="dark"]`.
- **`color-scheme` is explicit per theme**, no longer `light dark`. Otherwise
  native scrollbars and form controls keep following the OS — the one thing the
  button exists to override.

`localStorage` access is wrapped: it throws in private mode and with site data
blocked, and a theme button is not worth taking the dashboard down for. System
also keeps tracking the OS while the page is open, via a `matchMedia` listener.

All test passed , checked in local server buttons's working fine