### PR TITLE
fix: let GPT-5.6 tool calls work on Chat Completions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -177,6 +177,8 @@ WAKU_PROVIDER=anthropic
 # Each provider has sensible defaults (see waku/loop/models.py PROVIDERS):
 #   anthropic:  claude-sonnet-5              + claude-haiku-4-5 (gate/summarizer)
 #   openai:     gpt-5.5                      + gpt-4.1-mini
+#               (gpt-5.6-* need reasoning_effort=none for Completions+tools;
+#                set WAKU_MODEL=gpt-5.6-sol and the adapter does that)
 #   gemini:     gemini-3.5-flash             + gemini-3.1-flash-lite
 #   deepseek:   deepseek-v4-pro              + deepseek-v4-pro
 #   minimax:    MiniMax-M3                   + MiniMax-M2

--- a/evals/deterministic/test_models.py
+++ b/evals/deterministic/test_models.py
@@ -39,6 +39,29 @@ def test_openai_default_is_tool_capable(tmp_path):
     assert PROVIDERS["openai"].default_pair() == ["gpt-5.5", "gpt-4.1-mini"]
 
 
+def test_gpt56_tool_calls_force_reasoning_effort_none():
+    """Opt-in GPT-5.6 on Completions: function tools 400 unless effort is none."""
+    from waku.loop.models import OpenAICompatClient
+
+    client = OpenAICompatClient.__new__(OpenAICompatClient)
+    tools = [{"name": "save_note", "description": "remember a fact",
+              "input_schema": {"type": "object"}}]
+    with_tools = client._to_openai(
+        model="gpt-5.6-sol", messages=[{"role": "user", "content": "hi"}],
+        max_tokens=10, tools=tools)
+    assert with_tools["reasoning_effort"] == "none"
+
+    gate = client._to_openai(
+        model="gpt-5.6-luna", messages=[{"role": "user", "content": "hi"}],
+        max_tokens=10)
+    assert "reasoning_effort" not in gate
+
+    old = client._to_openai(
+        model="gpt-5.5", messages=[{"role": "user", "content": "hi"}],
+        max_tokens=10, tools=tools)
+    assert "reasoning_effort" not in old
+
+
 def test_no_default_model_is_a_moving_alias():
     """The whole gpt-5.x-chat-latest line went 404 at once (issue #132), and
     waku shipped a default pointing into it. An alias is what made that a silent

--- a/waku/loop/models.py
+++ b/waku/loop/models.py
@@ -83,16 +83,14 @@ PROVIDERS: dict[str, Provider] = {
                           "claude-sonnet-5", "claude-haiku-4-5-20251001",
                           catalog_url="https://api.anthropic.com/v1/models",
                           flagship="claude-opus-4-8", fast="claude-sonnet-5"),
-    # The gpt-5.6 REASONING models (luna/sol/terra) can't use function tools on
-    # /v1/chat/completions (they need /v1/responses), so every Waku turn 400s on
-    # them. That constraint still holds — what changed is where the escape hatch
-    # is: the whole `-chat-latest` line (5.3, 5.2, 5.1 and the bare gpt-5 alias)
-    # is now 404 deprecated, so "fall back to the previous -chat-latest" is not
-    # an option any more. gpt-5.5 is the newest plain model that returns a
-    # tool_call on /v1/chat/completions; gpt-4.1-mini is a cheap tool-capable
-    # gate. A `-latest` alias is deliberately NOT used — it silently changes
-    # under a pinned benchmark, and test_openai_default_is_tool_capable rejects
-    # one. base_url is None (SDK default) so point the picker at the catalog.
+    # GPT-5.6 sol/terra/luna default to reasoning.effort=medium, which 400s on
+    # function tools on /v1/chat/completions. Do not make them the default —
+    # gpt-5.5 is the newest plain model that returns a tool_call with no extra
+    # flags. Opt-in (WAKU_MODEL=gpt-5.6-*) is handled in OpenAICompatClient:
+    # tool turns send reasoning_effort=none, the Completions escape hatch.
+    # Responses would keep reasoning; this loop does not speak it. The old
+    # `-chat-latest` line is 404, so we do not pin a moving alias — see
+    # test_openai_default_is_tool_capable. gpt-4.1-mini is the cheap gate.
     "openai":    Provider("openai", "OPENAI_API_KEY", None,
                           "gpt-5.5", "gpt-4.1-mini",
                           catalog_url="https://api.openai.com/v1/models"),
@@ -349,6 +347,14 @@ class OpenAICompatClient:
                               "parameters": t["input_schema"]}}
                 for t in tools
             ]
+            # GPT-5.6 (sol/terra/luna) defaults to reasoning.effort=medium.
+            # Chat Completions rejects function tools unless effort is none
+            # (otherwise: use /v1/responses). Waku's loop is chat.completions,
+            # so pin none whenever tools are on the request. Gate/summarizer
+            # calls have tools=None and keep the model's default reasoning.
+            # Default stays gpt-5.5 (#136); this only unlocks WAKU_MODEL=gpt-5.6-*.
+            if (model or "").lower().startswith("gpt-5.6"):
+                kwargs["reasoning_effort"] = "none"
         return kwargs
 
     def _call(self, kwargs: dict, **extra):


### PR DESCRIPTION
## Summary
- Follow-on to #136: keep `gpt-5.5` as the OpenAI default (Completions + tools already work).
- GPT-5.6 sol/terra/luna default to `reasoning.effort=medium`, which **400s** on function tools on `/v1/chat/completions`. OpenAI's documented Completions escape hatch is `reasoning_effort=none` (otherwise: Responses API).
- The OpenAI adapter now sends `none` when the model id starts with `gpt-5.6` **and** tools are on the request. Gate/summarizer calls omit tools, so Luna can still reason.
- Lets `WAKU_MODEL=gpt-5.6-sol` work without rewriting the loop onto Responses.

## Test plan
- [x] `pytest -q evals/deterministic/test_models.py::test_gpt56_tool_calls_force_reasoning_effort_none` (offline)
- [x] Default path unchanged: `WAKU_PROVIDER=openai` with blank `WAKU_MODEL` still uses `gpt-5.5` and books an event
- [x] Opt-in: `WAKU_MODEL=gpt-5.6-sol` + `WAKU_SMALL_MODEL=gpt-5.6-luna`, then `Remember that Alex prefers morning meetings` → `save_note` succeeds (no 400)
- [x] Gate still prints `gate · skip/retrieve` on a 5.6-luna call (no tools, no forced `none`)


Made with [Cursor](https://cursor.com)