### PR TITLE
feat: connect remote MCP servers over Streamable HTTP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,34 @@ for its own sake is not.
 
 - **Be concise.** Sean wants short replies: lead with the answer, cut preamble and
   recap. A few lines beats a wall of text. Expand only when he asks for detail.
+- **Start every session by draining the community queue.** This is a public repo
+  with contributors waiting; an unanswered PR teaches someone that doing what we
+  asked gets silence. So on the first substantive turn of a new session, before
+  anything else, run:
+
+  ```
+  gh pr list --state open  ·  gh issue list --state open
+  ```
+
+  Report it as a **short table** — number, title, author, size, CI state, age —
+  plus anything already visibly wrong (an unrelated lockfile, a "Closes #N" that
+  points at the wrong issue, a `BEHIND` branch). Then propose an order,
+  **smallest first**, and stop.
+
+  Then walk the queue **one item at a time**, using the `review-pr` skill's four
+  fixed sections, in this order and no other:
+
+  1. **What this is** — plain language, no diff dump
+  2. **Why this is important** — the concrete failure, not the abstract benefit
+  3. **How do I test this** — copy-paste commands, and say what I already ran
+  4. **Merge / modify / close — and why** — one recommendation, then stop
+
+  **After each item, stop and wait for Sean's call on that one item.** Never
+  batch, never carry one yes forward to the next. Approving a plan is not
+  approval to merge anything. Test in throwaway worktrees via the `pr-worktree`
+  skill — never `gh pr checkout`. Frontend and TUI diffs are **Sean's to test**:
+  stand them up on port 7778 so the live 7777 is untouched, hand him the URL,
+  and never merge on my own screenshots.
 - **Never wipe runtime data without asking first, every time.** `scripts/demo_seed.py`
   and anything else that clears `.waku` (memory, calendar, chat log, traces, or the
   `usage.jsonl` spend ledger) must be proposed and explicitly approved by the user

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -113,3 +113,31 @@ make dashboard                               # demo_word_count / demo_reverse_te
 
 Same pattern scales to any server, yours or a vendor's — no changes to Waku's code.
 
+### Remote servers (Streamable HTTP)
+
+A server that is already running somewhere else is named by `url` instead of
+`command`. This is the MCP spec's transport for remote servers; the older
+HTTP+SSE transport is deprecated and is not supported.
+
+```json
+{"servers": [{"name": "waku_memory",
+              "url": "https://your-host/mcp",
+              "auth_env": "WAKU_MEMORY_API_KEY"}]}
+```
+
+`auth_env` names an **environment variable**; its value is sent as
+`Authorization: Bearer <value>`. The credential never goes in `mcp.json` —
+that file gets pasted into bug reports, and a bearer token in one is a leaked
+credential. If the variable is not exported, Waku says so by name rather than
+connecting anonymously and letting the server's 401 look like an outage.
+
+Try it against the demo server, no remote host required:
+
+```bash
+python examples/mcp_demo_server.py --http --port 8931
+# .waku/mcp.json → {"servers": [{"name": "demo", "url": "http://127.0.0.1:8931/mcp"}]}
+```
+
+Requires `mcp>=2.1` (`pip install -e '.[mcp]'`). The 1.x SDK spelled this
+transport differently and the remote branch does not work on it.
+

--- a/evals/deterministic/test_mcp_transport.py
+++ b/evals/deterministic/test_mcp_transport.py
@@ -1,0 +1,191 @@
+"""DETERMINISTIC EVAL — the MCP connector's two transports, proven offline.
+
+The connector was stdio-only until 2026-08-26: `_connect_all` built
+`StdioServerParameters` unconditionally, so a remote MCP server could not be
+reached at all. This file pins the branch that fixed it.
+
+Nothing here touches the network. The stdio case spawns the demo server that
+ships in `examples/`; the HTTP case spawns that same server in
+`streamable-http` mode on a loopback port. Both are real MCP sessions over a
+real transport — not mocks — which is the point: the two bugs this connector
+has actually had (an SDK rename, and a transport that was never implemented)
+would both sail past a mocked session.
+
+What is deliberately NOT asserted: that a particular remote service accepts
+our credential. That needs a live server and a real key, and belongs in a
+hand-run check, not in CI.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+from waku.tools.mcp_client import MCPBridge, _model_safe_name
+
+pytest.importorskip("mcp", reason="the MCP connector is an optional extra")
+
+REPO = Path(__file__).resolve().parents[2]
+DEMO = REPO / "examples" / "mcp_demo_server.py"
+
+
+def _bridge(spec: dict) -> MCPBridge:
+    path = Path(tempfile.mkdtemp()) / "mcp.json"
+    path.write_text(json.dumps({"servers": [spec]}), encoding="utf-8")
+    return MCPBridge(path, timeout=30.0)
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+# --- tool names the model provider will actually accept ---------------------
+
+
+def test_dotted_tool_names_survive_the_provider_contract():
+    """MCP allows a dot in a tool name; Anthropic and OpenAI do not.
+
+    waku-memory publishes `memory.remember` and five siblings, so this is not
+    a hypothetical shape — connecting to it emitted
+    `waku_memory_memory.remember`, which the provider rejects before the model
+    sees the turn. The bug looks like the model being broken, not the name.
+    """
+    assert _model_safe_name("waku_memory", "memory.remember") == "waku_memory_memory_remember"
+    assert re.fullmatch(r"[a-zA-Z0-9_-]{1,64}", _model_safe_name("srv", "a.b/c d"))
+
+
+def test_long_names_are_truncated_to_the_limit_and_stay_legal():
+    """64 characters is the provider's ceiling. Truncating must not leave a
+    leading underscore, which reads as a private name to a model."""
+    name = _model_safe_name("s" * 40, "t" * 40)
+    assert len(name) <= 64
+    assert re.fullmatch(r"[a-zA-Z0-9_-]{1,64}", name)
+    assert not name.startswith("_")
+
+
+def test_sanitising_does_not_change_what_is_sent_to_the_server():
+    """The rename is presentation. Dispatch must still use the server's own
+    name, or every renamed tool becomes an unknown-tool error at call time."""
+    bridge = _bridge({"name": "demo", "command": sys.executable, "args": [str(DEMO)]})
+    tools = bridge.start()
+    try:
+        tool = next(t for t in tools if t.name == "demo_reverse_text")
+        # Round-tripping proves the far side accepted the name we sent.
+        assert tool.fn(text="waku").strip() == "ukaw"
+    finally:
+        bridge.close()
+
+
+# --- config shape: two transports, chosen by which key is present -----------
+
+
+def test_naming_both_transports_is_refused_not_resolved(capsys):
+    """A server entry with `url` AND `command` is a mistake, not a precedence
+    question. Silently preferring one would run the transport the author did
+    not mean and give no sign of it."""
+    bridge = _bridge({"name": "x", "url": "http://127.0.0.1:1/mcp", "command": "echo"})
+    assert bridge.start() == []
+    assert "pick one transport" in capsys.readouterr().out
+    bridge.close()
+
+
+def test_missing_credential_names_the_variable(capsys):
+    """`auth_env` names a variable that is not exported.
+
+    The failure has to say so. Connecting anonymously instead would earn a 401
+    the SDK reports as a generic error, and the user would read a missing
+    export as a broken server.
+    """
+    os.environ.pop("WAKU_TEST_KEY_ABSENT", None)
+    bridge = _bridge(
+        {"name": "x", "url": "http://127.0.0.1:1/mcp", "auth_env": "WAKU_TEST_KEY_ABSENT"}
+    )
+    assert bridge.start() == []
+    assert "WAKU_TEST_KEY_ABSENT is not set" in capsys.readouterr().out
+    bridge.close()
+
+
+def test_config_error_does_not_get_an_auth_hint(capsys):
+    """The auth hint is for transport failures. Printing it under a config
+    refusal points the reader at the wrong thing entirely."""
+    bridge = _bridge({"name": "x", "url": "http://127.0.0.1:1/mcp", "command": "echo"})
+    bridge.start()
+    assert "holds a current credential" not in capsys.readouterr().out
+    bridge.close()
+
+
+# --- real sessions, both transports -----------------------------------------
+
+
+def test_stdio_still_round_trips():
+    """The path that already worked. Kept because the HTTP branch refactored
+    the function it lives in, and because an SDK rename broke tool listing
+    here once already (`inputSchema` -> `input_schema`)."""
+    bridge = _bridge({"name": "demo", "command": sys.executable, "args": [str(DEMO)]})
+    tools = bridge.start()
+    try:
+        assert "demo_reverse_text" in [t.name for t in tools]
+        # A tool with no input schema is unusable by the model even when it
+        # lists fine, which is exactly how the rename presented.
+        schema = next(t for t in tools if t.name == "demo_reverse_text").input_schema
+        assert schema.get("properties", {}).get("text")
+        assert bridge.call("demo", "reverse_text", {"text": "waku"}).strip() == "ukaw"
+    finally:
+        bridge.close()
+
+
+def test_streamable_http_round_trips_with_an_auth_header():
+    """The branch this file exists for.
+
+    The header is not verified by the demo server -- it accepts anything --
+    so this proves the transport carries a session and a tool call, not that
+    a credential was accepted. The credential path is proven by the server
+    that does check: a live 401 says `api key is unknown or revoked` rather
+    than `bearer token required`, which is only reachable if the header
+    arrived.
+    """
+    port = _free_port()
+    server = subprocess.Popen(
+        [sys.executable, str(DEMO), "--http", "--port", str(port)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    url = f"http://127.0.0.1:{port}/mcp"
+    try:
+        for _ in range(60):
+            if server.poll() is not None:
+                pytest.fail("demo server exited before it listened")
+            try:
+                urllib.request.urlopen(url, timeout=0.5)
+                break
+            except urllib.error.HTTPError:
+                break  # listening; a bare GET is a 400/406 by design
+            except OSError:
+                time.sleep(0.25)
+        else:
+            pytest.fail(f"demo server never listened on {port}")
+
+        os.environ["WAKU_TEST_KEY_PRESENT"] = "mem_sk_not_a_real_key"
+        bridge = _bridge({"name": "mem", "url": url, "auth_env": "WAKU_TEST_KEY_PRESENT"})
+        try:
+            assert "mem_reverse_text" in [t.name for t in bridge.start()]
+            assert bridge.call("mem", "reverse_text", {"text": "harness"}).strip() == "ssenrah"
+        finally:
+            bridge.close()
+            os.environ.pop("WAKU_TEST_KEY_PRESENT", None)
+    finally:
+        server.terminate()
+        server.wait(timeout=10)

--- a/examples/mcp_demo_server.py
+++ b/examples/mcp_demo_server.py
@@ -14,9 +14,13 @@ that's the whole point: connectors plug in without changing Waku's code.
 
 from __future__ import annotations
 
-from mcp.server.fastmcp import FastMCP
+# `MCPServer` is what the SDK's 2.x line calls the class 1.x shipped as
+# `mcp.server.fastmcp.FastMCP`. The old import path is gone, not deprecated,
+# so this file raised ModuleNotFoundError under the installed SDK until
+# 2026-08-26. The decorator API below is unchanged.
+from mcp.server.mcpserver import MCPServer
 
-mcp = FastMCP("demo")
+mcp = MCPServer("demo")
 
 
 @mcp.tool()
@@ -32,4 +36,23 @@ def reverse_text(text: str) -> str:
 
 
 if __name__ == "__main__":
-    mcp.run()  # stdio transport — how Waku's MCPBridge talks to it
+    # stdio by default — how Waku's MCPBridge talks to a local server.
+    # `--http` runs the same two tools over Streamable HTTP instead, which is
+    # how it talks to a remote one. Same tools, same code: only the transport
+    # differs, which is the thing worth seeing.
+    #
+    #   python examples/mcp_demo_server.py --http --port 8931
+    #   # then in .waku/mcp.json:
+    #   {"servers": [{"name": "demo", "url": "http://127.0.0.1:8931/mcp"}]}
+    import argparse
+
+    parser = argparse.ArgumentParser(description="waku-agent's demo MCP server")
+    parser.add_argument("--http", action="store_true", help="serve Streamable HTTP")
+    parser.add_argument("--port", type=int, default=8931)
+    parser.add_argument("--host", default="127.0.0.1")
+    args = parser.parse_args()
+
+    if args.http:
+        mcp.run(transport="streamable-http", host=args.host, port=args.port)
+    else:
+        mcp.run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,8 +103,12 @@ notion = [
     "notion-client>=2.5",
 ]
 # Optional: connect MCP servers (.waku/mcp.json)
+# >=2.1: the Streamable HTTP transport is `streamable_http_client` and takes a
+# pre-built httpx client. 1.x spelled it `streamablehttp_client`, took headers
+# directly, and yielded a third element — so mcp_client.py's remote branch does
+# not work on 1.x at all, and an unpinned floor would fail at import time.
 mcp = [
-    "mcp>=1.0",
+    "mcp>=2.1",
 ]
 dev = [
     "pytest>=8.0",

--- a/waku/tools/mcp_client.py
+++ b/waku/tools/mcp_client.py
@@ -5,10 +5,24 @@ asyncio event loop on a daemon thread, holds every server's session on that loop
 via a single AsyncExitStack (anyio requires the stack be entered/exited on the
 same task), and lets the sync loop call tools via run_coroutine_threadsafe.
 
-Config: WAKU_HOME/mcp.json
+Config: WAKU_HOME/mcp.json — two transports, picked by which key is present.
+
+  stdio: the client launches the server as a local subprocess.
   {"servers": [{"name": "fs", "command": "npx",
                 "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
                 "env": {}}]}
+
+  Streamable HTTP: the server is already running, somewhere else.
+  {"servers": [{"name": "waku_memory", "url": "https://host/mcp",
+                "auth_env": "WAKU_MEMORY_API_KEY"}]}
+
+`auth_env` names an environment variable, and never holds the credential
+itself: mcp.json is a config file people paste into bug reports, and a
+bearer token in one is a leaked credential. The variable's value is sent as
+`Authorization: Bearer <value>`.
+
+Streamable HTTP is the MCP spec's transport for remote servers. The older
+HTTP+SSE transport is deprecated and is deliberately not supported here.
 
 Each server's tools register as `<server>_<tool>` on the ToolRegistry. A server
 that fails to connect is skipped with a warning — Waku still starts.
@@ -18,11 +32,33 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
+import re
 import threading
 from contextlib import AsyncExitStack
 from pathlib import Path
 
 from waku.tools.registry import Tool
+
+
+def _model_safe_name(server: str, tool: str) -> str:
+    """`<server>_<tool>`, reduced to what a model provider will accept.
+
+    Tool names reach Anthropic and OpenAI under `^[a-zA-Z0-9_-]{1,64}$`. MCP
+    itself places no such limit, and dotted names are a common convention --
+    waku-memory publishes `memory.remember`, `memory.recall` and four more --
+    so a server whose names are perfectly legal MCP produced a request the
+    provider rejected, on the first turn, before the model saw anything.
+
+    Only the name the model reads is rewritten. The name sent back to the
+    server is the original, so this cannot break dispatch.
+    """
+    safe = re.sub(r"[^a-zA-Z0-9_-]", "_", f"{server}_{tool}")
+    if len(safe) <= 64:
+        return safe
+    # Keep the tail: the tool's own name is what disambiguates, and the
+    # server prefix is the part a reader can afford to lose.
+    return safe[-64:].lstrip("_")
 
 
 class MCPBridge:
@@ -44,33 +80,102 @@ class MCPBridge:
         for srv, metas in listed.items():
             for meta in metas:
                 tools.append(Tool(
-                    name=f"{srv}_{meta['name']}",
+                    name=_model_safe_name(srv, meta["name"]),
                     description=f"[MCP:{srv}] {meta.get('description','') or ''}",
                     input_schema=meta.get("inputSchema") or {"type": "object", "properties": {}},
+                    # `tname` is the server's OWN name, unsanitised — the
+                    # rename above is only how the model refers to the tool,
+                    # never what goes back over the wire.
                     fn=(lambda srv=srv, tname=meta["name"], **kw: self.call(srv, tname, kw)),
                 ))
         return tools
 
-    async def _connect_all(self, servers) -> dict:
-        from mcp import ClientSession, StdioServerParameters
+    async def _open_streams(self, spec: dict):
+        """Connect one server and return its (read, write) streams.
+
+        The transport is chosen by the config's shape rather than by a
+        `transport` field: a server entry either names a local command or a
+        remote url, and one that somehow names both is a mistake worth
+        refusing rather than resolving by precedence.
+        """
+        from mcp import StdioServerParameters
         from mcp.client.stdio import stdio_client
+
+        url = spec.get("url")
+        if url and spec.get("command"):
+            raise ValueError("server has both 'url' and 'command' — pick one transport")
+
+        if not url:
+            params = StdioServerParameters(
+                command=spec["command"], args=spec.get("args", []), env=spec.get("env") or None
+            )
+            return await self._stack.enter_async_context(stdio_client(params))
+
+        from mcp.client.streamable_http import create_mcp_http_client, streamable_http_client
+
+        headers = {}
+        auth_env = spec.get("auth_env")
+        if auth_env:
+            token = os.environ.get(auth_env)
+            if not token:
+                # Fail here rather than connecting anonymously: the server
+                # would answer 401 and the tools would simply be missing,
+                # which reads as "the server is down" instead of "you did
+                # not export the key".
+                raise ValueError(f"{auth_env} is not set (named by 'auth_env' in mcp.json)")
+            headers["Authorization"] = f"Bearer {token}"
+
+        # create_mcp_http_client applies the SDK's own timeouts and
+        # follow_redirects; passing headers is the only supported way to
+        # authenticate this transport. Because we build the client rather
+        # than letting the transport build one, we own its lifecycle — hence
+        # entering it on the stack ourselves.
+        client = await self._stack.enter_async_context(create_mcp_http_client(headers=headers))
+        return await self._stack.enter_async_context(
+            streamable_http_client(url, http_client=client)
+        )
+
+    async def _connect_all(self, servers) -> dict:
+        from mcp import ClientSession
 
         self._stack = AsyncExitStack()
         listed: dict = {}
         for spec in servers:
             name = spec["name"]
             try:
-                params = StdioServerParameters(
-                    command=spec["command"], args=spec.get("args", []), env=spec.get("env") or None
-                )
-                read, write = await self._stack.enter_async_context(stdio_client(params))
+                read, write = await self._open_streams(spec)
                 session = await self._stack.enter_async_context(ClientSession(read, write))
                 await session.initialize()
                 self._sessions[name] = session
                 tools = (await session.list_tools()).tools
-                listed[name] = [{"name": t.name, "description": t.description, "inputSchema": t.inputSchema} for t in tools]
+                # `input_schema` in the SDK's 2.x line; it was `inputSchema`
+                # in 1.x. getattr covers both so a user on either pin gets a
+                # working connector rather than an AttributeError reported as
+                # "failed to connect".
+                listed[name] = [
+                    {
+                        "name": t.name,
+                        "description": t.description,
+                        "inputSchema": getattr(t, "input_schema", None)
+                        or getattr(t, "inputSchema", None),
+                    }
+                    for t in tools
+                ]
             except Exception as exc:  # one bad server shouldn't stop the rest
                 print(f"MCP server '{name}' failed to connect: {exc}")
+                # ValueError is this module's own config refusal above; it
+                # already says exactly what is wrong, and adding an auth hint
+                # to it would point at the wrong thing.
+                if spec.get("url") and not isinstance(exc, ValueError):
+                    # The SDK reports a rejected HTTP request as a generic
+                    # "Server returned an error response" with no status on
+                    # the exception, so a 401 and a 500 are indistinguishable
+                    # here. Name what the caller can actually check instead of
+                    # inventing a cause.
+                    print(
+                        f"  {spec['url']} — if the server requires auth, check that "
+                        f"{spec.get('auth_env') or 'auth_env'} holds a current credential"
+                    )
         return listed
 
     def call(self, server: str, tool: str, args: dict) -> str:


### PR DESCRIPTION
## What this is

The MCP bridge could only spawn a local process. Every server had to be
something we could `exec`, so a server already running somewhere else — the
case MCP's remote transport exists for — had no way in.

This adds the `url` form to `.waku/mcp.json`:

```json
{"servers": [{"name": "waku_memory",
              "url": "https://your-host/mcp",
              "auth_env": "WAKU_MEMORY_API_KEY"}]}
```

Everything below the transport is unchanged — `ClientSession`, `list_tools`,
and the `<server>_<tool>` namespacing all work as before.

## Why this is important

Two design points are worth reviewing rather than skimming:

**Transport by config shape, not a `transport` field.** An entry names either
`command` or `url`. One naming both is refused, not resolved by precedence —
a silent winner there gives you a config that does something other than it
reads.

**`auth_env` names a variable, never the credential.** `mcp.json` is the file
people paste into bug reports. And an unset variable fails by name rather
than connecting anonymously: the server would answer 401, the tools would
simply be missing, and that reads as "the server is down" instead of "you did
not export the key".

## How do I test this

Local, no remote host needed:

```bash
pip install -e '.[mcp]'
python examples/mcp_demo_server.py --http --port 8931
# .waku/mcp.json → {"servers": [{"name": "demo", "url": "http://127.0.0.1:8931/mcp"}]}
make run
```

Already run on this branch:

```bash
pytest evals/deterministic/test_mcp_transport.py -q   # 8 passed
pytest evals/deterministic -q                          # 623 passed, 60 skipped
```

Also exercised end to end against a real deployed server: 7 tools listed, and
a memory written from a different MCP client was read back through this
bridge.

## Notes for the reviewer

- **`mcp>=1.0` → `mcp>=2.1`.** Not cosmetic: 1.x spelled the transport
  `streamablehttp_client`, took headers directly and yielded three elements,
  so the remote branch fails at *import* on 1.x — which would break the stdio
  path too. The floor is the fix.
- Second commit is unrelated (`CLAUDE.md`, the PR-review process) and kept
  separate so this one reviews on its own. Say the word and I'll drop it.
