### PR TITLE
feat: sign in to a remote MCP server instead of holding a key

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -131,6 +131,29 @@ that file gets pasted into bug reports, and a bearer token in one is a leaked
 credential. If the variable is not exported, Waku says so by name rather than
 connecting anonymously and letting the server's 401 look like an outage.
 
+### Signing in instead of holding a key
+
+A server that speaks MCP's authorization spec needs no key at all. Say so, and
+Waku opens your browser on first use:
+
+```json
+{"servers": [{"name": "waku_memory",
+              "url": "https://your-host/mcp",
+              "oauth": true}]}
+```
+
+Nothing is issued out of band and nothing is pasted anywhere. Waku registers
+itself with the server, catches the redirect on `127.0.0.1:41765`, and keeps
+the result in `.waku/mcp-auth/<server>.json`, written `0600` — one file per
+server, so a corrupt one costs a single connection rather than all of them.
+Delete that file to sign out.
+
+`oauth` and `auth_env` are two answers to one question, so naming both is
+refused rather than resolved by precedence.
+
+Headless or over SSH there is no browser to open: the authorization URL is
+printed, and you can finish the sign-in from any machine that has one.
+
 Try it against the demo server, no remote host required:
 
 ```bash

--- a/evals/deterministic/test_mcp_transport.py
+++ b/evals/deterministic/test_mcp_transport.py
@@ -189,3 +189,86 @@ def test_streamable_http_round_trips_with_an_auth_header():
     finally:
         server.terminate()
         server.wait(timeout=10)
+
+
+# --- oauth: the credential nobody has to issue ------------------------------
+
+
+def test_naming_both_credentials_is_refused_not_resolved(capsys):
+    """`auth_env` and `oauth` are two answers to one question.
+
+    Same shape as the transport refusal above, and the same reason: with no
+    stated precedence, picking one silently authenticates as something other
+    than the author wrote.
+    """
+    bridge = _bridge(
+        {
+            "name": "x",
+            "url": "http://127.0.0.1:1/mcp",
+            "auth_env": "WAKU_TEST_KEY",
+            "oauth": True,
+        }
+    )
+    assert bridge.start() == []
+    assert "pick one" in capsys.readouterr().out
+    bridge.close()
+
+
+def test_oauth_tokens_are_stored_per_server_and_not_world_readable():
+    """The token file is a bearer credential: anything holding it can act as
+    the user until it expires. It is written 0600, under WAKU_HOME, one file
+    per server — a corrupt one should cost a single connection, not all of
+    them."""
+    import asyncio
+    import stat
+
+    from mcp.shared.auth import OAuthToken
+
+    from waku.tools.mcp_oauth import FileTokenStorage
+
+    home = Path(tempfile.mkdtemp())
+    a = FileTokenStorage(home, "server_a")
+    b = FileTokenStorage(home, "server_b")
+
+    asyncio.run(a.set_tokens(OAuthToken(access_token="tok-a", token_type="Bearer")))
+    asyncio.run(b.set_tokens(OAuthToken(access_token="tok-b", token_type="Bearer")))
+
+    assert asyncio.run(a.get_tokens()).access_token == "tok-a"
+    assert asyncio.run(b.get_tokens()).access_token == "tok-b"
+
+    written = sorted(p.name for p in (home / "mcp-auth").glob("*.json"))
+    assert written == ["server_a.json", "server_b.json"]
+
+    mode = (home / "mcp-auth" / "server_a.json").stat().st_mode
+    assert not mode & (stat.S_IRGRP | stat.S_IROTH), "token file is readable beyond its owner"
+
+
+def test_a_corrupt_token_file_costs_a_sign_in_not_a_crash():
+    """Hand-edited or half-written JSON is treated as absent.
+
+    The alternative is a harness that will not start until someone deletes a
+    file whose path they have never seen.
+    """
+    import asyncio
+
+    from waku.tools.mcp_oauth import FileTokenStorage
+
+    home = Path(tempfile.mkdtemp())
+    storage = FileTokenStorage(home, "server_a")
+    path = home / "mcp-auth" / "server_a.json"
+    path.parent.mkdir(parents=True)
+    path.write_text("{not json", encoding="utf-8")
+
+    assert asyncio.run(storage.get_tokens()) is None
+    assert asyncio.run(storage.get_client_info()) is None
+
+
+def test_a_server_name_cannot_escape_the_auth_directory():
+    """Server names come from mcp.json and become filenames. A name with a
+    slash or a parent reference must not write outside WAKU_HOME."""
+    from waku.tools.mcp_oauth import FileTokenStorage
+
+    home = Path(tempfile.mkdtemp())
+    storage = FileTokenStorage(home, "../../etc/passwd")
+    assert (home / "mcp-auth") in storage._path.parents
+    assert "/" not in storage._path.name

--- a/evals/deterministic/test_mcp_transport.py
+++ b/evals/deterministic/test_mcp_transport.py
@@ -272,3 +272,29 @@ def test_a_server_name_cannot_escape_the_auth_directory():
     storage = FileTokenStorage(home, "../../etc/passwd")
     assert (home / "mcp-auth") in storage._path.parents
     assert "/" not in storage._path.name
+
+
+def test_an_oauth_failure_does_not_send_you_to_auth_env():
+    """An `oauth` server has no `auth_env`. Naming one in its failure sends the
+    reader to a setting their config does not contain — and the connection
+    error itself carries no status, so this hint is all they get."""
+    from waku.tools.mcp_client import _auth_hint
+
+    hint = _auth_hint(
+        {"name": "x", "url": "https://h/mcp", "oauth": True}, Path("/home/.waku/mcp-auth")
+    )
+    assert "auth_env" not in hint
+    assert "sign-in did not complete" in hint
+    assert "/home/.waku/mcp-auth" in hint, "say where to delete, not just that one can"
+
+
+def test_an_api_key_failure_names_the_variable_that_holds_the_key():
+    """The other half of the same choice: with `auth_env` set, the variable it
+    names is the one thing worth checking, so the hint says which."""
+    from waku.tools.mcp_client import _auth_hint
+
+    hint = _auth_hint(
+        {"name": "x", "url": "https://h/mcp", "auth_env": "WAKU_MEMORY_API_KEY"}, Path("/unused")
+    )
+    assert "WAKU_MEMORY_API_KEY" in hint
+    assert "sign-in" not in hint

--- a/waku/tools/mcp_client.py
+++ b/waku/tools/mcp_client.py
@@ -16,10 +16,20 @@ Config: WAKU_HOME/mcp.json — two transports, picked by which key is present.
   {"servers": [{"name": "waku_memory", "url": "https://host/mcp",
                 "auth_env": "WAKU_MEMORY_API_KEY"}]}
 
+A remote server is authorised one of two ways, and naming both is refused:
+
+  "auth_env": "VAR"   a long-lived key, held in an environment variable
+  "oauth": true       the browser flow — no key to issue, none to hand over
+
 `auth_env` names an environment variable, and never holds the credential
 itself: mcp.json is a config file people paste into bug reports, and a
 bearer token in one is a leaked credential. The variable's value is sent as
 `Authorization: Bearer <value>`.
+
+`oauth` signs in through the server's own page on first use and keeps the
+result under WAKU_HOME/mcp-auth/. Nothing has to be issued out of band, which
+is what makes a remote server installable by someone who does not know us.
+See mcp_oauth.py.
 
 Streamable HTTP is the MCP spec's transport for remote servers. The older
 HTTP+SSE transport is deprecated and is deliberately not supported here.
@@ -114,7 +124,15 @@ class MCPBridge:
         from mcp.client.streamable_http import create_mcp_http_client, streamable_http_client
 
         headers = {}
+        auth = None
         auth_env = spec.get("auth_env")
+        use_oauth = bool(spec.get("oauth"))
+
+        if auth_env and use_oauth:
+            # Same reasoning as command-vs-url above: two credentials named,
+            # no stated precedence, so refusing beats picking one silently.
+            raise ValueError("server names both 'auth_env' and 'oauth' — pick one")
+
         if auth_env:
             token = os.environ.get(auth_env)
             if not token:
@@ -124,13 +142,22 @@ class MCPBridge:
                 # not export the key".
                 raise ValueError(f"{auth_env} is not set (named by 'auth_env' in mcp.json)")
             headers["Authorization"] = f"Bearer {token}"
+        elif use_oauth:
+            from waku.tools.mcp_oauth import build_provider
+
+            # An httpx auth flow, not a header: the SDK drives the 401, the
+            # discovery and the refresh itself, so this is handed to the
+            # client once and never thought about again.
+            auth = build_provider(url, spec["name"], self.config_path.parent)
 
         # create_mcp_http_client applies the SDK's own timeouts and
-        # follow_redirects; passing headers is the only supported way to
-        # authenticate this transport. Because we build the client rather
+        # follow_redirects; a header or an auth flow are the two supported ways
+        # to authenticate this transport. Because we build the client rather
         # than letting the transport build one, we own its lifecycle — hence
         # entering it on the stack ourselves.
-        client = await self._stack.enter_async_context(create_mcp_http_client(headers=headers))
+        client = await self._stack.enter_async_context(
+            create_mcp_http_client(headers=headers, auth=auth)
+        )
         return await self._stack.enter_async_context(
             streamable_http_client(url, http_client=client)
         )

--- a/waku/tools/mcp_client.py
+++ b/waku/tools/mcp_client.py
@@ -71,6 +71,27 @@ def _model_safe_name(server: str, tool: str) -> str:
     return safe[-64:].lstrip("_")
 
 
+def _auth_hint(spec: dict, auth_dir: Path) -> str:
+    """What to tell someone whose remote server would not connect.
+
+    The SDK reports a rejected HTTP request as a generic "Server returned an
+    error response" with no status on the exception, so a 401 and a 500 are
+    indistinguishable by the time we see it. Name what the caller can actually
+    check rather than inventing a cause — and name the right thing: an `oauth`
+    server has no `auth_env`, so pointing its user at one sends them to a
+    setting their config does not contain.
+    """
+    if spec.get("oauth"):
+        return (
+            f"  {spec['url']} — sign-in did not complete. Run waku again to use a token "
+            f"that was saved, or delete {auth_dir} to start over"
+        )
+    return (
+        f"  {spec['url']} — if the server requires auth, check that "
+        f"{spec.get('auth_env') or 'auth_env'} holds a current credential"
+    )
+
+
 class MCPBridge:
     def __init__(self, config_path: Path, timeout: float = 30.0):
         self.config_path = config_path
@@ -162,47 +183,74 @@ class MCPBridge:
             streamable_http_client(url, http_client=client)
         )
 
-    async def _connect_all(self, servers) -> dict:
+    def _token_exists(self, spec: dict) -> bool:
+        """Whether a sign-in has already produced a token for this server.
+
+        Read from disk rather than remembered, because the token is written by
+        the SDK's auth flow on a different task than this one.
+        """
+        if not spec.get("oauth"):
+            return False
+        from waku.tools.mcp_oauth import FileTokenStorage
+
+        return FileTokenStorage(self.config_path.parent, spec["name"])._path.exists()
+
+    async def _connect_one(self, spec: dict) -> list[dict]:
+        """Open one server's session and return its tool metadata."""
         from mcp import ClientSession
 
+        name = spec["name"]
+        read, write = await self._open_streams(spec)
+        session = await self._stack.enter_async_context(ClientSession(read, write))
+        await session.initialize()
+        self._sessions[name] = session
+        tools = (await session.list_tools()).tools
+        # `input_schema` in the SDK's 2.x line; it was `inputSchema` in 1.x.
+        # getattr covers both so a user on either pin gets a working connector
+        # rather than an AttributeError reported as "failed to connect".
+        return [
+            {
+                "name": t.name,
+                "description": t.description,
+                "inputSchema": getattr(t, "input_schema", None) or getattr(t, "inputSchema", None),
+            }
+            for t in tools
+        ]
+
+    async def _connect_all(self, servers) -> dict:
         self._stack = AsyncExitStack()
         listed: dict = {}
         for spec in servers:
             name = spec["name"]
+            had_token = self._token_exists(spec)
             try:
-                read, write = await self._open_streams(spec)
-                session = await self._stack.enter_async_context(ClientSession(read, write))
-                await session.initialize()
-                self._sessions[name] = session
-                tools = (await session.list_tools()).tools
-                # `input_schema` in the SDK's 2.x line; it was `inputSchema`
-                # in 1.x. getattr covers both so a user on either pin gets a
-                # working connector rather than an AttributeError reported as
-                # "failed to connect".
-                listed[name] = [
-                    {
-                        "name": t.name,
-                        "description": t.description,
-                        "inputSchema": getattr(t, "input_schema", None)
-                        or getattr(t, "inputSchema", None),
-                    }
-                    for t in tools
-                ]
-            except Exception as exc:  # one bad server shouldn't stop the rest
-                print(f"MCP server '{name}' failed to connect: {exc}")
+                listed[name] = await self._connect_one(spec)
+            except Exception as first_exc:  # one bad server shouldn't stop the rest
+                # Bound to a name of our own: Python unbinds an `except … as`
+                # variable at the end of the block, so the retry below cannot
+                # reassign it.
+                error = first_exc
+                # A first sign-in spends human time in the browser — longer
+                # than the connection that triggered it is willing to wait. By
+                # the time the token is written the attempt has already failed,
+                # so the very run that signs you in is the one that appears not
+                # to work. Retry once, and only when a token exists now that
+                # did not before: that condition is true exactly after a
+                # sign-in, and false for every other failure.
+                if not had_token and self._token_exists(spec):
+                    print(f"  signed in — reconnecting to '{name}'")
+                    try:
+                        listed[name] = await self._connect_one(spec)
+                        continue
+                    except Exception as retry_exc:
+                        error = retry_exc
+
+                print(f"MCP server '{name}' failed to connect: {error}")
                 # ValueError is this module's own config refusal above; it
                 # already says exactly what is wrong, and adding an auth hint
                 # to it would point at the wrong thing.
-                if spec.get("url") and not isinstance(exc, ValueError):
-                    # The SDK reports a rejected HTTP request as a generic
-                    # "Server returned an error response" with no status on
-                    # the exception, so a 401 and a 500 are indistinguishable
-                    # here. Name what the caller can actually check instead of
-                    # inventing a cause.
-                    print(
-                        f"  {spec['url']} — if the server requires auth, check that "
-                        f"{spec.get('auth_env') or 'auth_env'} holds a current credential"
-                    )
+                if spec.get("url") and not isinstance(error, ValueError):
+                    print(_auth_hint(spec, self.config_path.parent / "mcp-auth"))
         return listed
 
     def call(self, server: str, tool: str, args: dict) -> str:

--- a/waku/tools/mcp_oauth.py
+++ b/waku/tools/mcp_oauth.py
@@ -1,0 +1,215 @@
+"""OAuth for remote MCP servers — the browser flow, and where the tokens live.
+
+A remote server can be authorised two ways. `auth_env` names an environment
+variable holding a long-lived key: simple, but somebody has to issue the key
+and hand it over, which does not survive contact with a stranger. This module
+is the other way — the one MCP's own authorization spec describes. The user
+runs waku, a browser opens, they sign in on the server's own page, and no
+secret ever passes through a human's clipboard or a config file.
+
+Nothing here is waku-specific. It is the standard flow: discover the
+authorization server from the resource's metadata, register this client
+dynamically, open the browser, catch the redirect on loopback, exchange the
+code. The SDK does all of it; this file supplies the three things the SDK
+cannot know — where to keep the tokens, how to open a browser, and how to
+catch the callback.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import socket
+import webbrowser
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from threading import Thread
+from typing import ClassVar
+from urllib.parse import parse_qs, urlparse
+
+from mcp.client.auth import OAuthClientProvider, TokenStorage
+from mcp.shared.auth import (
+    AuthorizationCodeResult,
+    OAuthClientInformationFull,
+    OAuthClientMetadata,
+    OAuthToken,
+)
+
+# Where a server's tokens and its dynamic registration are kept. One file per
+# server rather than one shared file: two servers' registrations have nothing
+# to do with each other, and a corrupt file should cost one connection rather
+# than all of them.
+AUTH_DIR = "mcp-auth"
+
+# The loopback port the authorization server redirects back to. Fixed rather
+# than ephemeral because the redirect URI is registered with the authorization
+# server at DCR time and has to still be true on the next run — a random port
+# would force a re-registration every time, and some servers pin the URI.
+CALLBACK_PORT = 41765
+CALLBACK_PATH = "/callback"
+
+
+def _sanitise(name: str) -> str:
+    """A server name is user-supplied and becomes a filename."""
+    return "".join(c if c.isalnum() or c in "-_" else "_" for c in name)[:64]
+
+
+class FileTokenStorage(TokenStorage):
+    """Tokens and client registration on disk, one JSON file per server.
+
+    Written 0600 and never logged. This file is a bearer credential: anything
+    holding it can act as the user against that server until it expires.
+    """
+
+    def __init__(self, home: Path, server_name: str) -> None:
+        self._path = Path(home) / AUTH_DIR / f"{_sanitise(server_name)}.json"
+
+    def _read(self) -> dict:
+        try:
+            return json.loads(self._path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, json.JSONDecodeError):
+            # A truncated or hand-edited file is treated as absent rather than
+            # fatal: the cost is one more sign-in, and the alternative is a
+            # harness that will not start until someone deletes a file whose
+            # name they do not know.
+            return {}
+
+    def _write(self, data: dict) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        # Write-then-rename so an interrupted write cannot leave a half file
+        # where a valid one was, and chmod before the rename so the secret is
+        # never briefly world-readable.
+        tmp = self._path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        os.chmod(tmp, 0o600)
+        tmp.replace(self._path)
+
+    async def get_tokens(self):
+        raw = self._read().get("tokens")
+        return OAuthToken.model_validate(raw) if raw else None
+
+    async def set_tokens(self, tokens) -> None:
+        data = self._read()
+        data["tokens"] = tokens.model_dump(mode="json", exclude_none=True)
+        self._write(data)
+
+    async def get_client_info(self):
+        raw = self._read().get("client_info")
+        return OAuthClientInformationFull.model_validate(raw) if raw else None
+
+    async def set_client_info(self, client_info) -> None:
+        data = self._read()
+        data["client_info"] = client_info.model_dump(mode="json", exclude_none=True)
+        self._write(data)
+
+
+class _CallbackHandler(BaseHTTPRequestHandler):
+    """Catches the one redirect, shows a page, and hands the code back.
+
+    `result` is deliberately class-level: BaseHTTPRequestHandler is
+    instantiated by the server per request, so an instance attribute would be
+    thrown away with the instance that set it. Only ever one sign-in is in
+    flight, and `callback_handler` clears it before starting the server.
+    """
+
+    result: ClassVar[dict] = {}
+
+    def do_GET(self) -> None:  # noqa: N802 — BaseHTTPRequestHandler's spelling
+        parsed = urlparse(self.path)
+        if parsed.path != CALLBACK_PATH:
+            self.send_response(404)
+            self.end_headers()
+            return
+        params = parse_qs(parsed.query)
+        _CallbackHandler.result = {k: v[0] for k, v in params.items()}
+        body = (
+            b"<html><body style='font-family:system-ui;padding:3rem'>"
+            b"<h2>Signed in.</h2><p>You can close this tab and return to the terminal.</p>"
+            b"</body></html>"
+        )
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *_args) -> None:
+        """Silence: this server lives for one request inside a chat session."""
+
+
+def _port_is_free(port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            s.bind(("127.0.0.1", port))
+            return True
+        except OSError:
+            return False
+
+
+def build_provider(server_url: str, server_name: str, home: Path) -> OAuthClientProvider:
+    """The provider the HTTP client authenticates with.
+
+    `OAuthClientProvider` is an httpx auth flow, so it attaches to the client
+    rather than to a request: the SDK retries the 401 itself, discovers the
+    authorization server from the resource metadata, and only then calls the
+    two handlers below.
+    """
+    redirect_uri = f"http://127.0.0.1:{CALLBACK_PORT}{CALLBACK_PATH}"
+
+    metadata = OAuthClientMetadata(
+        client_name="Waku",
+        redirect_uris=[redirect_uri],
+        grant_types=["authorization_code", "refresh_token"],
+        response_types=["code"],
+        token_endpoint_auth_method="none",
+    )
+
+    async def redirect_handler(authorization_url: str) -> None:
+        print("\n  Opening your browser to sign in…")
+        print(f"  If it does not open: {authorization_url}\n")
+        # `open_new_tab` rather than `open`: a headless or SSH session has no
+        # browser, and this returning False is the honest signal that the URL
+        # printed above is the only way through.
+        webbrowser.open_new_tab(authorization_url)
+
+    async def callback_handler() -> AuthorizationCodeResult:
+        if not _port_is_free(CALLBACK_PORT):
+            raise RuntimeError(
+                f"port {CALLBACK_PORT} is in use — the sign-in redirect has nowhere to land. "
+                "Close whatever holds it and try again."
+            )
+        _CallbackHandler.result = {}
+        server = HTTPServer(("127.0.0.1", CALLBACK_PORT), _CallbackHandler)
+        thread = Thread(target=server.handle_request, daemon=True)
+        thread.start()
+        # Poll rather than join: this runs on the bridge's event loop, and a
+        # blocking join would stop the loop the transport is about to need.
+        for _ in range(600):  # 5 minutes at 0.5s
+            if _CallbackHandler.result:
+                break
+            await asyncio.sleep(0.5)
+        server.server_close()
+
+        result = _CallbackHandler.result
+        if not result:
+            raise RuntimeError("timed out waiting for the browser sign-in to come back")
+        if "error" in result:
+            # The server said no. Surface its own words: "access_denied" and
+            # "invalid_client" send you to completely different places.
+            raise RuntimeError(
+                f"authorization failed: {result['error']}"
+                + (f" — {result['error_description']}" if "error_description" in result else "")
+            )
+        return AuthorizationCodeResult(
+            code=result["code"], state=result.get("state"), iss=result.get("iss")
+        )
+
+    return OAuthClientProvider(
+        server_url=server_url,
+        client_metadata=metadata,
+        storage=FileTokenStorage(home, server_name),
+        redirect_handler=redirect_handler,
+        callback_handler=callback_handler,
+    )


### PR DESCRIPTION
Follow-on to #151, which merged before this commit was pushed.

## What this is

`auth_env` works, but somebody has to issue the key and hand it over. That is
fine among people who know each other and is the whole obstacle for anyone
else — a stranger cannot install a remote server without first asking us for a
secret. This adds the other path MCP's authorization spec describes:

```json
{"servers": [{"name": "waku_memory", "url": "https://host/mcp", "oauth": true}]}
```

The user runs waku, a browser opens, they sign in on the server's own page.
Nothing is issued out of band.

## Why this is important

It is the difference between onboarding instructions that read

1. get a key from us
2. export it
3. write mcp.json
4. run waku

and instructions that read

1. write mcp.json
2. run waku

The SDK drives discovery, dynamic registration, the code exchange and refresh.
`OAuthClientProvider` is an httpx auth flow, so it attaches to the client once
rather than per request. `mcp_oauth.py` supplies only what the SDK cannot know:
where tokens live, how to open a browser, how to catch the redirect.

Three decisions worth a look rather than a skim:

- **Tokens at `WAKU_HOME/mcp-auth/<server>.json`, `0600`**, temp-file-then-rename
  so an interrupted write cannot replace a good file with half of one. One file
  per server — a corrupt one should cost one connection, not all of them.
- **A file that will not parse is treated as absent.** The cost is one more
  sign-in, against a harness that refuses to start until someone deletes a file
  whose path they have never seen.
- **The callback port is fixed, not ephemeral.** The redirect URI is registered
  at DCR time and has to still be true next run; a random port would force
  re-registration every time, and some servers pin the URI.

## How do I test this

Already run on this branch:

```bash
pytest evals/deterministic/test_mcp_transport.py -q   # 12 passed
pytest evals/deterministic -q                          # 627 passed, 60 skipped
ruff check waku/tools/                                 # clean
```

By hand, against a server that speaks the authorization spec:

```bash
# .waku/mcp.json → {"servers": [{"name": "waku_memory",
#                                "url": "https://<host>/mcp", "oauth": true}]}
make run
```

A browser opens on the first tool call. `.waku/mcp-auth/waku_memory.json`
appears afterwards; delete it to sign out.

**Not yet exercised end to end against a live server** — that needs a browser
and a human, so it is the one claim here I cannot make from CI.

## Notes for the reviewer

Four new deterministic tests: the double-credential refusal, per-server storage
with the file mode asserted, a corrupt file costing only a sign-in, and a server
name containing `../` staying inside `WAKU_HOME`.
