### PR TITLE
docs: how to share one memory across two agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,33 @@ Voice, Telegram, Apple Calendar and Mail, Google Calendar, MCP servers — each
 one is opt-in, behind its own extra, and none of them change the loop. Setup
 for all of them: **[docs/integrations.md](docs/integrations.md)**.
 
+## Share memory across agents — a remote MCP server
+
+Your memory is local by default and stays that way. If you want the *same*
+memory in more than one agent, point Waku at a remote MCP server and it becomes
+another set of tools — nothing about the loop changes.
+
+`.waku/mcp.json`:
+
+```json
+{"servers": [{"name": "waku_memory",
+              "url": "https://d1o2fv4416yi84.cloudfront.net/mcp",
+              "oauth": true}]}
+```
+
+```bash
+pip install -e '.[mcp]'
+make run
+```
+
+A browser opens the first time, you sign in on the server's own page, and the
+token is kept in `.waku/mcp-auth/` — nothing to request, nothing to paste. That
+example is [Waku Memory](https://waku.one), which is where this pays off: write
+something in one agent and a different one can read it back. Any server that
+speaks MCP works the same way, with `auth_env` instead if it wants an API key.
+
+Details, including the local-only demo server: **[docs/integrations.md](docs/integrations.md)**.
+
 ## It manages its own memory
 
 The agent has tools to keep itself useful — no black box:


### PR DESCRIPTION
## What this is

A README section for the remote-MCP support that landed in #151 and #152. Four
lines of config and two commands, under "Connect it to your life".

## Why this is important

The feature is documented in `docs/integrations.md`, which nobody reads before
the README. Right now someone arriving at this repo cannot discover from the
front page that it exists at all.

Two placement decisions worth a look:

- **Not in Quickstart.** This repo's pitch is that your memory is one SQLite
  file you own. A hosted server on the first screen reads as a walk-back of
  that, so the section sits further down and opens by saying the local memory
  stays local.
- **Framed as "any MCP server", with Waku Memory as the example.** The two
  projects share a name and nothing else; the harness gains a capability, not a
  dependency.

## How do I test this

Read it. Then, if you want to confirm the instructions are complete, follow
them exactly on a clean checkout — that path was walked today and the browser
sign-in connected on the first run.

## Notes for the reviewer

The URL is CloudFront's own name and will change when the service has a domain.
One line here and one in `docs/integrations.md` when it does — worth knowing
before this is filmed rather than after.
