### PR TITLE
feat: add study planner community skill

### DIFF
--- a/skills/community/study-planner/SKILL.md
+++ b/skills/community/study-planner/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: study-planner
+description: Create a realistic study plan for exams, subjects, topics, or deadlines. Use for "make me a study plan", "plan my studying", "help me prepare for an exam", "create a revision schedule", "what should I study today", or "help me prepare for a test".
+---
+
+## How to plan
+
+1. Identify the user's goal, exam/deadline, subjects or topics, available study time, and current preparation level.
+2. If important information is missing, ask only the minimum questions needed to create a useful plan.
+3. Calculate how much time is available and divide the workload across that time.
+4. Prioritize topics based on difficulty, importance, and how well the user already knows them.
+5. Break each day into focused study sessions with short breaks.
+6. Include revision and practice sessions rather than only introducing new topics.
+7. Leave some buffer time for unfinished topics or unexpected schedule changes.
+
+## Study plan format
+
+- **Goal** — what the user is preparing for.
+- **Time available** — days remaining and realistic study time.
+- **Priority** — topics ranked by importance.
+- **Daily plan** — what to study in each session.
+- **Revision** — when and what to review.
+- **Practice** — questions, exercises, or mock tests to complete.
+
+For each study session, give a specific topic and a clear objective.
+
+Keep plans realistic, concise, and easy to follow. Do not assume the user can study all day.
+
+## Edge cases
+
+| Situation | Do |
+|---|---|
+| Exam date is unclear | Ask when the exam is |
+| Study time is unclear | Ask how much time they can realistically study |
+| Too many topics for the available time | Prioritize the highest-value topics and explain what is being deprioritized |
+| Very little time remains | Create a focused crash plan covering the most important material |
+| User has not started studying | Start with fundamentals and prioritize essential topics |
+| User is already well prepared | Focus more on revision, practice, and weak areas |
+| User falls behind | Rebalance the remaining schedule instead of simply adding more hours |


### PR DESCRIPTION
## What does this PR do?

Adds a `study-planner` community skill that helps users create realistic study plans for exams, subjects, topics, and deadlines.

The skill prioritizes topics, breaks studying into manageable sessions, and includes revision and practice time.

## Related Issue

N/A — community skill contribution.

## How was this tested?

- Ran `python scripts/validate_skills.py`
- Skill validation passed successfully.

## Type of Change

- [x] `content`: Content update