### PR TITLE
feat: add interview prep community skill

### DIFF
--- a/skills/community/interview-prep/SKILL.md
+++ b/skills/community/interview-prep/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: interview-prep
+description: Prepare me for a job interview, technical interview, or placement. Use for "prep me for an interview", "help me prepare for an interview", "what should I revise", "practice interview questions", or "mock interview me".
+---
+
+## How to prepare
+
+1. Ask for the company, role, interview date, and available preparation time if they are not provided.
+2. Identify the key technical and behavioral areas relevant to the role.
+3. Prioritize difficult and high-value topics based on the role and time available.
+4. Break preparation into manageable sessions.
+5. Include technical questions, behavioral questions, and practice where appropriate.
+6. If the user asks for a mock interview, ask one question at a time and wait for their answer before continuing.
+7. End with a concise last-minute checklist.
+
+## Interview prep format
+
+- **Role** — company and position.
+- **Time available** — days remaining and preparation hours.
+- **Priority areas** — what to prepare first.
+- **Preparation plan** — clear tasks for each session.
+- **Practice questions** — technical and behavioral questions.
+- **Final checklist** — what to review before the interview.
+
+Keep the preparation practical, focused, and realistic.
+
+## Edge cases
+
+| Situation | Do |
+|---|---|
+| Interview date is unclear | Ask when the interview is |
+| Role is unclear | Ask what position they are interviewing for |
+| Very little preparation time | Create a focused crash plan |
+| User has not started preparing | Start with fundamentals and prioritize the highest-value topics |
+| User asks for a mock interview | Ask one interview question at a time |
+| User is applying for multiple roles | Focus on the role specified by the user; ask if unclear |


### PR DESCRIPTION
**What this does, and why**

Adds an `interview-prep` community skill that helps users prepare for job interviews, technical interviews, and placement interviews. It creates a practical preparation plan based on the role, interview date, available preparation time, and preparation level.

**Which issue does it close?**

N/A  community skill contribution.

---

- [x] **Tested it, not just written it.** Say how below — the review will ask.
- [ ] **A deterministic eval** in `evals/deterministic/` covers the behavior.
      Not applicable for this community skill contribution.
- [ ] `make gate` and `make lint` pass locally.
      Not applicable — this is a Markdown-only community skill.
- [x] Any heavy or optional dependency is **behind an extra**, not in the
      default install.
- [x] No hidden network calls, no reading secrets or `.env`, nothing runs at
      install time.

**How you tested it** 

```text
python scripts/validate_skills.py

skill validation OK — 4 skill(s): interview-prep, meeting-prep, schedule-meeting, weekly-brief