### PR TITLE
fix: stop abandoning a sign-in that is still in progress

### DIFF
--- a/evals/deterministic/test_mcp_transport.py
+++ b/evals/deterministic/test_mcp_transport.py
@@ -298,3 +298,41 @@ def test_an_api_key_failure_names_the_variable_that_holds_the_key():
     )
     assert "WAKU_MEMORY_API_KEY" in hint
     assert "sign-in" not in hint
+
+
+def test_a_pending_sign_in_is_waited_for_longer_than_it_takes():
+    """`waku mcp login` gave up after 60s while the browser was still open and
+    the callback was still listening — two independently chosen timeouts, one
+    of them wrong. The connect deadline must exceed the sign-in one, or the
+    callback outlives the caller waiting on it."""
+    import json
+    import tempfile
+
+    from waku.tools.mcp_client import MCPBridge
+    from waku.tools.mcp_oauth import SIGN_IN_TIMEOUT
+
+    home = Path(tempfile.mkdtemp())
+    config = home / "mcp.json"
+    config.write_text(
+        json.dumps({"servers": [{"name": "x", "url": "https://h/mcp", "oauth": True}]}),
+        encoding="utf-8",
+    )
+    bridge = MCPBridge(config)
+    servers = json.loads(config.read_text())["servers"]
+    assert bridge._deadline(servers) > SIGN_IN_TIMEOUT, "would abandon a sign-in still in progress"
+
+
+def test_a_server_that_will_not_sign_in_does_not_get_the_long_wait():
+    """The long deadline is for human time in a browser. An api-key server has
+    none, and inheriting six minutes would turn a dead host into a six-minute
+    hang on every start."""
+    import json
+    import tempfile
+
+    from waku.tools.mcp_client import MCPBridge
+
+    home = Path(tempfile.mkdtemp())
+    config = home / "mcp.json"
+    config.write_text(json.dumps({"servers": []}), encoding="utf-8")
+    bridge = MCPBridge(config, timeout=30.0)
+    assert bridge._deadline([{"name": "y", "url": "https://h/mcp", "auth_env": "K"}]) == 60.0

--- a/waku/tools/mcp_cli.py
+++ b/waku/tools/mcp_cli.py
@@ -138,6 +138,14 @@ def _login(home: Path, name: str) -> int:
     bridge = MCPBridge(home / "mcp.json")
     try:
         bridge.start()
+    except TimeoutError:
+        # A traceback here is the wrong answer to "you took too long in the
+        # browser". The sign-in may still have completed — the callback writes
+        # the token whether or not anyone is still waiting — so say what to
+        # check rather than what broke.
+        print("\n  Timed out waiting for the browser sign-in.")
+        print("  If you did finish it, `waku mcp` will show the account. Otherwise run this again.")
+        return 1
     finally:
         bridge.close()
 

--- a/waku/tools/mcp_client.py
+++ b/waku/tools/mcp_client.py
@@ -101,12 +101,31 @@ class MCPBridge:
         self._stack: AsyncExitStack | None = None
         self._sessions: dict = {}
 
+    def _deadline(self, servers: list[dict]) -> float:
+        """How long to wait for every server to connect.
+
+        Normally twice the per-call timeout. But a server configured for oauth
+        with no token yet is about to open a browser and wait for a person to
+        read a consent screen, and that is minutes. Waiting the ordinary amount
+        means giving up while the browser is still open — which looks like a
+        broken server and leaves the sign-in half-finished.
+
+        The margin over SIGN_IN_TIMEOUT matters: expiring first would mean the
+        callback is still patiently listening on a connection nobody is holding
+        any more.
+        """
+        from waku.tools.mcp_oauth import SIGN_IN_TIMEOUT
+
+        if any(s.get("oauth") and not self._token_exists(s) for s in servers):
+            return SIGN_IN_TIMEOUT + 60.0
+        return self.timeout * 2
+
     def start(self) -> list[Tool]:
         """Connect every configured server and return their tools (as Tools)."""
         self._thread.start()
         servers = json.loads(self.config_path.read_text(encoding="utf-8")).get("servers", [])
         fut = asyncio.run_coroutine_threadsafe(self._connect_all(servers), self._loop)
-        listed = fut.result(self.timeout * 2)  # {server: [tool metas]}
+        listed = fut.result(self._deadline(servers))  # {server: [tool metas]}
         tools: list[Tool] = []
         for srv, metas in listed.items():
             for meta in metas:

--- a/waku/tools/mcp_oauth.py
+++ b/waku/tools/mcp_oauth.py
@@ -49,6 +49,14 @@ AUTH_DIR = "mcp-auth"
 CALLBACK_PORT = 41765
 CALLBACK_PATH = "/callback"
 
+# How long the callback server waits for the browser to come back. This is
+# human time — reading a consent screen, picking between two Google accounts —
+# so it is minutes, not seconds. Exported because the caller that waits on the
+# connection has to wait longer than this, and two independently-chosen
+# numbers is how the CLI came to give up at 60s while this sat patiently for
+# five minutes.
+SIGN_IN_TIMEOUT = 300.0
+
 
 def _sanitise(name: str) -> str:
     """A server name is user-supplied and becomes a filename."""
@@ -186,7 +194,7 @@ def build_provider(server_url: str, server_name: str, home: Path) -> OAuthClient
         thread.start()
         # Poll rather than join: this runs on the bridge's event loop, and a
         # blocking join would stop the loop the transport is about to need.
-        for _ in range(600):  # 5 minutes at 0.5s
+        for _ in range(int(SIGN_IN_TIMEOUT / 0.5)):
             if _CallbackHandler.result:
                 break
             await asyncio.sleep(0.5)


### PR DESCRIPTION
## What this is

`waku mcp login` raised `TimeoutError` with the browser still open:

```
File "waku/tools/mcp_client.py", line 109, in start
  listed = fut.result(self.timeout * 2)
TimeoutError
```

## Why this is important

Two timeouts, chosen independently, and one of them wrong. The OAuth callback waits **five minutes** — correctly, because reading a consent screen and choosing between two Google accounts is human time. The caller waiting on it gave up after **sixty seconds**.

`make run` had the same bug and hid it: the first sign-in only worked because it finished inside a minute.

The fix derives the deadline instead of assuming it. A server configured for `oauth` with no token yet is about to open a browser, so it gets `SIGN_IN_TIMEOUT` plus a margin; everything else keeps the ordinary wait, because inheriting six minutes would turn a dead host into a six-minute hang on every start.

`SIGN_IN_TIMEOUT` is now exported from `mcp_oauth` so the two numbers cannot drift apart again — which is the actual defect, not either value.

## How do I test this

```bash
pytest evals/deterministic -q      # 637 passed, 60 skipped
waku mcp login waku_memory          # take your time in the browser
```

Two tests pin the relationship: the connect deadline must exceed the sign-in timeout, and a server that will never sign in must not inherit the long wait.

## Notes for the reviewer

A timeout now prints what to check rather than a traceback. The callback writes the token whether or not anyone is still waiting, so the sign-in may well have succeeded — and `waku mcp` will say so.