### PR TITLE
fix: login reports what it achieved, and says minutes when it means minutes

### DIFF
--- a/evals/deterministic/test_mcp_cli.py
+++ b/evals/deterministic/test_mcp_cli.py
@@ -99,3 +99,19 @@ def test_a_local_server_is_not_described_as_lacking_a_credential(capsys):
     )
     _list(home)
     assert "no credential needed" in capsys.readouterr().out
+
+
+def test_under_an_hour_is_minutes_not_a_rounded_down_zero():
+    """A token minted fifty minutes ago rendered as "0h left", which reads as
+    expired and is the opposite of the truth."""
+    home = Path(tempfile.mkdtemp())
+    path = _auth_file(home, "s", _token("a@b.c", exp_offset=57 * 60))
+    line = _identity(path)
+    assert "0h" not in line
+    assert "m left" in line
+
+
+def test_over_an_hour_stays_in_hours():
+    home = Path(tempfile.mkdtemp())
+    path = _auth_file(home, "s", _token("a@b.c", exp_offset=5 * 3600))
+    assert "5h left" in _identity(path)

--- a/evals/deterministic/test_mcp_cli.py
+++ b/evals/deterministic/test_mcp_cli.py
@@ -47,7 +47,10 @@ def test_the_account_is_named_not_merely_confirmed():
     path = _auth_file(home, "waku_memory", _token("seanchen9832@gmail.com"))
     line = _identity(path)
     assert "seanchen9832@gmail.com" in line
-    assert "1h left" in line or "h left" in line
+    # Offsets in these fixtures sit well inside a band rather than on its edge:
+    # a token created exactly one hour out is 59m by the time it is read, and a
+    # test that flips on elapsed time fails for reasons that are not the code.
+    assert "left" in line
 
 
 def test_an_expired_token_says_so_and_says_it_is_not_a_problem():
@@ -113,5 +116,5 @@ def test_under_an_hour_is_minutes_not_a_rounded_down_zero():
 
 def test_over_an_hour_stays_in_hours():
     home = Path(tempfile.mkdtemp())
-    path = _auth_file(home, "s", _token("a@b.c", exp_offset=5 * 3600))
+    path = _auth_file(home, "s", _token("a@b.c", exp_offset=5 * 3600 + 120))
     assert "5h left" in _identity(path)

--- a/waku/tools/mcp_cli.py
+++ b/waku/tools/mcp_cli.py
@@ -66,7 +66,10 @@ def _identity(auth_file: Path) -> str:
         # silently on the next call, and someone reading this should not
         # mistake the refresh for a problem.
         return f"{who} — token expired, refreshes on next use"
-    return f"{who} — {int(left.total_seconds() // 3600)}h left"
+    # Minutes below an hour: a token minted fifty minutes ago rendered as
+    # "0h left", which reads as expired and is the opposite of the truth.
+    minutes = int(left.total_seconds() // 60)
+    return f"{who} — {minutes // 60}h left" if minutes >= 60 else f"{who} — {minutes}m left"
 
 
 def _servers(home: Path) -> list[dict]:
@@ -135,6 +138,12 @@ def _login(home: Path, name: str) -> int:
 
     from waku.tools.mcp_client import MCPBridge
 
+    # Success here is "a token now exists for the account you chose", not "a
+    # session was established". They came apart in practice: the sign-in
+    # completed, the token was written, and the reconnect on the same
+    # already-failed exit stack reported an error anyway — so the command said
+    # it failed immediately after succeeding. This command exists to sign in;
+    # holding a session is the next run's job.
     bridge = MCPBridge(home / "mcp.json")
     try:
         bridge.start()
@@ -146,9 +155,18 @@ def _login(home: Path, name: str) -> int:
         print("\n  Timed out waiting for the browser sign-in.")
         print("  If you did finish it, `waku mcp` will show the account. Otherwise run this again.")
         return 1
+    except Exception:
+        # Swallowed deliberately, and only here: the token below is the thing
+        # that was asked for, and it is either on disk or it is not. A
+        # connection error after a successful sign-in is noise the next run
+        # will not reproduce.
+        pass
     finally:
         bridge.close()
 
+    if not path.exists():
+        print(f"\n  Sign-in did not complete — '{name}' has no token.")
+        return 1
     print(f"\n  {name} — {_identity(path)}")
     return 0
 


### PR DESCRIPTION
Both found switching accounts for real.

## What this is

`waku mcp login` printed a failure immediately after succeeding:

```
signed in — reconnecting to 'waku_memory'
MCP server 'waku_memory' failed to connect: Server returned an error response
  — sign-in did not complete...
waku_memory — sean@automanus.io — 0h left
```

The last line contradicts the two above it.

## Why this is important

**The reconnect runs on the same `AsyncExitStack` the first attempt already failed inside**, so it fails regardless of the token being good. Success is now judged by what was actually asked for — a token on disk for the account you chose. Holding a session is the next run's job; this command was never about that.

The connect error is swallowed only in this path and only *after* the token check, so a sign-in that genuinely didn't happen still reports failure.

**And `0h left` on a token with 57 minutes on it reads as expired** — the opposite of true.

## How do I test this

```bash
pytest evals/deterministic -q     # 639 passed
waku mcp                           # now reads "57m left"
waku mcp login waku_memory         # reports the account, not a phantom failure
```

## Notes for the reviewer

The deeper issue — that a retry inherits a poisoned exit stack — is untouched. It only shows up on the `make run` path, where the retry usually succeeds because the stack failed before entering anything. Worth a separate look if it ever bites there.