### PR TITLE
release: one source of truth for the version, bumped to 0.1.5

### DIFF
--- a/evals/deterministic/test_version.py
+++ b/evals/deterministic/test_version.py
@@ -1,0 +1,38 @@
+"""The package version must have exactly one source of truth.
+
+For four releases it had two: pyproject.toml said 0.1.4 while
+waku/__init__.py still said 0.1.0, because nothing forced them to agree and
+nothing read __version__ loudly enough to notice. A wrong __version__ is the
+kind of bug that only shows up in someone else's bug report.
+
+pyproject now declares the version dynamic and points hatchling at
+waku/__init__.py, so there is one number. These tests fail if anyone puts the
+second one back.
+"""
+
+import re
+import tomllib
+from pathlib import Path
+
+import waku
+
+ROOT = Path(__file__).resolve().parents[2]
+PYPROJECT = tomllib.loads((ROOT / "pyproject.toml").read_text())
+
+
+def test_pyproject_does_not_hardcode_a_second_version():
+    """A static [project] version is how the two numbers drifted apart."""
+    assert "version" not in PYPROJECT["project"], (
+        "pyproject.toml declares its own version again — it must stay dynamic "
+        "so waku/__init__.py is the only place the number lives"
+    )
+    assert "version" in PYPROJECT["project"].get("dynamic", [])
+
+
+def test_hatchling_reads_the_version_from_the_package():
+    assert PYPROJECT["tool"]["hatch"]["version"]["path"] == "waku/__init__.py"
+
+
+def test_version_is_a_release_number():
+    """Catches a placeholder or a leftover dev marker going out to PyPI."""
+    assert re.fullmatch(r"\d+\.\d+\.\d+", waku.__version__), waku.__version__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 [project]
 name = "waku-agent"
-version = "0.1.4"
+# Single source of truth is waku/__init__.py — pyproject and the package
+# disagreed for four releases (0.1.4 here, 0.1.0 there) because nothing
+# forced them to match. Now there is only one number to bump.
+dynamic = ["version"]
 description = "A minimal, transparent, local-first Waku: harness + loop + memory + eval, in code you can read in an afternoon."
 readme = "README.md"
 license = { text = "MIT" }
@@ -127,6 +130,9 @@ build-backend = "hatchling.build"
 # whiteboard PNG and the .excalidraw sources, plus the agent tooling (.claude,
 # .agents, .pi) that only matters inside this repo. All of it stays on GitHub,
 # where people actually read it; none of it belongs in a package download.
+[tool.hatch.version]
+path = "waku/__init__.py"
+
 [tool.hatch.build.targets.sdist]
 exclude = [
     "docs", "examples",

--- a/waku/__init__.py
+++ b/waku/__init__.py
@@ -8,4 +8,4 @@ Four pillars, one module each:
   ops      → waku/ops + evals/              (trace → eval → gate → release)
 """
 
-__version__ = "0.1.0"
+__version__ = "0.1.5"


### PR DESCRIPTION
## What

`pyproject.toml` said `0.1.4` while `waku/__init__.py` said `0.1.0`. They had
disagreed for four releases.

pyproject now declares `dynamic = ["version"]` and points hatchling at
`waku/__init__.py`, so the number lives in exactly one place. Bumped to `0.1.5`.

## Why it matters

PyPI's latest is still `0.1.1` — **50 commits behind `main`**. Anyone running
`pip install waku-agent` today gets Aug 7 code. This is the version bump that
release rides on, and it was worth fixing the drift first so the number that
ships is the number the package reports.

## Verified

| Check | Result |
|---|---|
| `pytest -q evals/deterministic` | 642 passed, 60 skipped |
| `ruff check waku evals scripts` | All checks passed |
| Mutation — put a static `version =` back | `test_version.py` goes **red** |
| `uv build` | wheel + sdist at 0.1.5 |
| Wheel `METADATA` | `Version: 0.1.5` (dynamic version resolves) |
| `twine check dist/*` | both PASSED |
| Clean-venv install of the wheel | `waku.__version__ == metadata version == 0.1.5` |