### PR TITLE
dashboard: put the Waku mark in the sidebar

### DIFF
--- a/waku/ops/static/index.html
+++ b/waku/ops/static/index.html
@@ -4,7 +4,7 @@
 <link rel="icon" type="image/svg+xml" href="/static/waku-mark.svg">
 <link rel="stylesheet" href="/static/style.css"></head><body>
 <nav id="nav">
-  <div class="brand">Waku わく<small id="model" style="cursor:pointer" title="click to change the model" onclick="location.hash='#models'"></small>
+  <div class="brand"><i class="mark" aria-hidden="true"></i>Waku わく<small id="model" style="cursor:pointer" title="click to change the model" onclick="location.hash='#models'"></small>
     <button id="nav-toggle" title="Hide sidebar">&#10094;</button></div>
   <div class="grp">System</div>
   <a href="#overview" data-v="overview">Overview</a>

--- a/waku/ops/static/style.css
+++ b/waku/ops/static/style.css
@@ -34,14 +34,22 @@
   .resizer{flex-shrink:0;width:5px;height:100vh;cursor:col-resize;background:transparent}
   .resizer:hover,body.resizing .resizer{background:var(--accent-soft)}
   body.resizing{cursor:col-resize;user-select:none}
-  #nav-toggle{float:right;background:none;border:none;color:var(--ink3);cursor:pointer;font-size:12px;padding:2px 4px;line-height:1}
+  #nav-toggle{margin-left:auto;background:none;border:none;color:var(--ink3);cursor:pointer;font-size:12px;padding:2px 4px;line-height:1}
   #nav-toggle:hover{color:var(--ink)}
   #nav-reopen{display:none;position:fixed;top:12px;left:12px;z-index:25;background:var(--panel);
     border:1px solid var(--line2);border-radius:8px;color:var(--ink2);width:34px;height:30px;cursor:pointer;font-size:14px}
   body.nav-hidden #nav,body.nav-hidden #nav-resizer{display:none}
   body.nav-hidden #nav-reopen{display:block}
-  .brand{font-weight:650;font-size:15px;padding:0 10px 4px}
-  .brand small{display:block;color:var(--ink3);font-weight:400;font-size:11px;margin-top:2px}
+  .brand{font-weight:650;font-size:15px;padding:0 10px 4px;
+    display:flex;align-items:baseline;gap:7px;flex-wrap:wrap}
+  /* The mark is a mask, not an <img>: an <img> of waku-mark.svg would follow
+     the BROWSER's colour scheme (the favicon has no choice), but in here it
+     has to follow the PAGE. Masking paints it in var(--ink) like any text,
+     and the evenodd holes in the sunglasses stay transparent. */
+  .brand .mark{width:17px;height:17px;flex:none;align-self:center;background:var(--ink);
+    -webkit-mask:url(/static/waku-mark.svg) center/contain no-repeat;
+    mask:url(/static/waku-mark.svg) center/contain no-repeat}
+  .brand small{display:block;width:100%;order:1;color:var(--ink3);font-weight:400;font-size:11px;margin-top:2px}
   /* Links are indented past their group header, which is what makes the header
      read as a PARENT instead of a line of text dropped between rows. Header and
      links used to share the same 10px left edge, so the sidebar looked like one


### PR DESCRIPTION
Follow-on to #167, which gave the browser tab the mark. This puts it in the
sidebar next to `Waku わく`.

## Why a CSS mask and not an `<img>`

An `<img src="/static/waku-mark.svg">` renders the SVG as its own document, so
it obeys the **browser's** colour scheme. That is correct for the favicon —
a favicon has no other signal. In the sidebar it is wrong: the page has its own
theme, and after #144 lands it will have a manual toggle the browser knows
nothing about. A browser-dark / page-light pair would show a near-black bird on
a near-white sidebar.

Masking punches the shape out of `var(--ink)`, so the mark tracks the page like
any other text, and the `fill-rule="evenodd"` sunglasses stay transparent.

## The layout trap this had to fix

`.brand` becoming a flex container makes `float:right` a **no-op** on
`#nav-toggle` — the collapse button would have dropped onto its own row.
`margin-left:auto` is the flex equivalent, and `.brand small` (the model line)
is `order:1` so it keeps a row to itself.

## Verified in the browser, both themes

| | light | dark |
|---|---|---|
| page ink | `rgb(33, 32, 29)` | `rgb(236, 236, 234)` |
| mark paint | `rgb(33, 32, 29)` | `rgb(236, 236, 234)` |
| matches page ink | **yes** | **yes** |

Layout measured, not eyeballed: mark `17×17` at `y=23`, collapse button at
`x=171, y=25` (**same row, pushed right**), model line at `y=52` (**its own
row**).

`pytest -q evals/deterministic` → 643 passed, 60 skipped. `ruff` clean.

**Frontend — Sean's to confirm on http://localhost:7777 before this merges.**