### PR TITLE
ci: the tag is the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+# Publishing was a step someone had to remember, and twice nobody did: v0.1.3
+# and v0.1.4 were tagged and built and never uploaded, so `pip install
+# waku-agent` served 0.1.1 while main moved 67 commits ahead. A rule did not
+# fix that, because a rule is a reminder and a reminder is what failed.
+#
+# So the tag IS the release. Push v0.1.6 and this publishes it.
+#
+# No token is stored anywhere: PyPI Trusted Publishing lets GitHub prove which
+# workflow in which repo is asking, over OIDC. That is what `id-token: write`
+# below is for, and it is why there is no secret to leak or rotate.
+name: release
+
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # OIDC — how PyPI knows this workflow is really us
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # A tag is a human typing a number twice. If the two disagree, the tag
+      # says one thing and the artifact says another, and PyPI believes the
+      # artifact — so stop here rather than publish a version nobody tagged.
+      - name: The tag must be the version in waku/__init__.py
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          pkg=$(python -c "import re,pathlib; print(re.search(r'__version__ = \"(.*?)\"', pathlib.Path('waku/__init__.py').read_text()).group(1))")
+          echo "tag=$tag  package=$pkg"
+          if [ "$tag" != "$pkg" ]; then
+            echo "::error::tag $GITHUB_REF_NAME does not match __version__ $pkg — nothing published."
+            exit 1
+          fi
+
+      # The gate that guards main guards a release too. Publishing is the one
+      # action here that cannot be undone: PyPI does not allow re-uploading a
+      # version, even after a delete.
+      - name: Install
+        run: pip install -e '.[dev]'
+      - name: Deterministic evals
+        run: python -m pytest -q evals/deterministic
+
+      - name: Build
+        run: pipx run build
+      - name: Check the artifacts
+        run: pipx run twine check dist/*
+
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,9 +90,11 @@ for its own sake is not.
     `pip install waku-agent` from PyPI, assert `waku.__version__` matches and a
     file that did not exist in the previous release is present.
 
-  A rule is still only a reminder, and a reminder is what failed twice. The
-  structural fix is a `release.yml` that publishes on tag push via PyPI Trusted
-  Publishing (no stored token) — propose it, don't assume it.
+  Since 2026-08-29 `.github/workflows/release.yml` does this on its own: push a
+  `v*` tag and it runs the gate, builds, and publishes over PyPI Trusted
+  Publishing (no stored token). It **refuses** if the tag and `__version__`
+  disagree. So the release step is `git tag vX.Y.Z && git push origin vX.Y.Z` —
+  nothing to remember, and nothing for me to hold.
 - **`main` is protected — `git push origin main` is REJECTED, for everyone.** Since
   2026-07-26 a commit only lands once `skills-and-evals` is green, and `enforce_admins`
   is on, so the rule binds Sean and Claude identically. Ship via


### PR DESCRIPTION
## What

`.github/workflows/release.yml` — push a `v*` tag, and it runs the gate, builds,
and publishes to PyPI.

## Why

`v0.1.3` and `v0.1.4` were tagged, built, and **never uploaded**. For four weeks
`pip install waku-agent` served Aug 1 code while `main` moved 67 commits ahead.

I wrote a rule about this first. But the rule is a reminder, and a reminder is
exactly what failed — twice. This removes the step instead of restating it.

## No token anywhere

PyPI **Trusted Publishing**: GitHub proves over OIDC which workflow in which
repo is asking, so there is no API token stored in secrets — nothing to leak,
nothing to rotate. That is what `permissions: id-token: write` is for.

## The guard that matters

A tag is a human typing the version a second time. If the tag and
`waku/__init__.py` disagree, the tag says one thing and the artifact says
another — **and PyPI believes the artifact.** So the job refuses:

```
v0.1.5 vs __version__=0.1.5  -> publishes
v0.2.0 vs __version__=0.1.5  -> REFUSED
v0.1.4 vs __version__=0.1.5  -> REFUSED
```

That matters more than usual here: **PyPI does not allow re-uploading a version,
even after deleting it.** A wrong publish is permanent. The deterministic evals
run before the upload for the same reason.

## Before the first tag — one thing only Sean can do

Add a trusted publisher in the PyPI project settings for `waku-agent`:

| Field | Value |
|---|---|
| Owner | `ShenSeanChen` |
| Repository | `waku-agent` |
| Workflow | `release.yml` |
| Environment | `pypi` |

Until that exists the job will fail at the publish step — it cannot publish the
wrong thing, only fail to publish.

`pytest -q evals/deterministic` → 643 passed, 60 skipped.