### PR TITLE
release: 0.1.6

### DIFF
--- a/waku/__init__.py
+++ b/waku/__init__.py
@@ -8,4 +8,4 @@ Four pillars, one module each:
   ops      → waku/ops + evals/              (trace → eval → gate → release)
 """
 
-__version__ = "0.1.5"
+__version__ = "0.1.6"


### PR DESCRIPTION
Ships the Waku mark (favicon + sidebar), the Windows cp1252 fix, and the release workflow. All landed after 0.1.5 was uploaded, so `pip install waku-agent` currently serves a dashboard with no logo.

`pytest -q evals/deterministic` → 644 passed. `ruff` clean.