### PR TITLE
fix: AppleScript cannot cold-start an app, so waku has to

### DIFF
--- a/evals/deterministic/test_apple_calendar.py
+++ b/evals/deterministic/test_apple_calendar.py
@@ -33,7 +33,9 @@ def test_probe_apple_calendar_is_read_only_and_requires_a_writable_calendar(monk
     script = captured["cmd"][2]
     assert captured["cmd"][:2] == ["osascript", "-e"]
     assert captured["kwargs"]["timeout"] == 15
-    assert "launch application \"Calendar\"" in script
+    # AppleScript cannot cold-start an app: this line used to be here and was
+    # itself what raised -600. waku starts Calendar with a shell `open` now.
+    assert "launch application" not in script
     assert "writable" in script
     assert "make new event" not in script
     assert "make new calendar" not in script

--- a/evals/deterministic/test_apple_tools.py
+++ b/evals/deterministic/test_apple_tools.py
@@ -59,7 +59,7 @@ def _code_lines(module) -> list[str]:
 def test_probe_apple_tools_checks_all_apps_without_touching_user_data(monkeypatch):
     calls = []
 
-    def osa(script, timeout):
+    def osa(script, timeout, **_):
         calls.append((script, timeout))
         return True, "1.0"
 
@@ -81,7 +81,7 @@ def test_probe_apple_tools_aggregates_failures_and_checks_every_app(monkeypatch)
     ])
     calls = []
 
-    def osa(script, timeout):
+    def osa(script, timeout, **_):
         calls.append((script, timeout))
         return next(responses)
 
@@ -107,7 +107,7 @@ def test_probe_apple_tools_aggregates_failures_and_checks_every_app(monkeypatch)
     ],
 )
 def test_probe_apple_tools_names_the_app_for_transport_failures(monkeypatch, detail):
-    def osa(script, timeout):
+    def osa(script, timeout, **_):
         if 'application "Mail"' in script:
             return False, detail
         return True, "1.0"
@@ -197,7 +197,7 @@ def test_create_note_success_and_failure_paths(monkeypatch):
     """create_note must report success/failure from _osa without real Notes.app."""
     calls: list[tuple[str, float | None]] = []
 
-    def fake_osa(script: str, timeout: float | None = None):
+    def fake_osa(script: str, timeout: float | None = None, **_):
         calls.append((script, timeout))
         return True, "ok"
 
@@ -206,7 +206,7 @@ def test_create_note_success_and_failure_paths(monkeypatch):
     assert "Notes" in calls[-1][0]
     assert calls[-1][1] is not None
     # force failure path
-    def bad_osa(script: str, timeout: float | None = None):
+    def bad_osa(script: str, timeout: float | None = None, **_):
         return False, "denied"
     monkeypatch.setattr(apple, "_osa", bad_osa)
     assert apple.create_note("x").startswith("Note failed:")
@@ -215,7 +215,7 @@ def test_create_note_success_and_failure_paths(monkeypatch):
 def test_create_reminder_includes_due_when_set(monkeypatch):
     captured: dict[str, str] = {}
 
-    def fake_osa(script: str, timeout: float | None = None):
+    def fake_osa(script: str, timeout: float | None = None, **_):
         captured["script"] = script
         return True, "ok"
 
@@ -227,7 +227,7 @@ def test_create_reminder_includes_due_when_set(monkeypatch):
 
 
 def test_read_apple_mail_uses_bounded_osa_and_formats_failure(monkeypatch):
-    def fake_osa(script: str, timeout: float | None = None):
+    def fake_osa(script: str, timeout: float | None = None, **_):
         assert timeout == 20
         assert "Mail" in script
         return False, "timeout"

--- a/evals/deterministic/test_applescript_cold_start.py
+++ b/evals/deterministic/test_applescript_cold_start.py
@@ -1,0 +1,113 @@
+"""AppleScript cannot cold-start an app, so waku has to (issue: both calendars
+failed on 2026-08-29).
+
+`launch application "Calendar"` was in the codebase specifically to stop -600
+"Application isn't running". It was the line RAISING it: with Calendar closed,
+
+    osascript -e 'launch application "Calendar"'
+    -> execution error: Calendar got an error: Application isn't running. (-600)
+
+The character offset in the real failure ("15:44") pointed straight at that
+line. Mail, Reminders and Notes never attempted a launch at all, so each one
+failed the same way whenever its app happened to be closed.
+
+Only a shell-level `open` starts the app. These tests are offline — no
+osascript runs, no app is launched — they check that waku still asks.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from waku.tools import apple
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOLS = ROOT / "waku" / "tools"
+
+
+@pytest.fixture
+def spy(monkeypatch):
+    """Record what waku shells out, and pretend the app starts on demand."""
+    calls: list[list[str]] = []
+    started = {"yes": False}
+
+    class Result:
+        def __init__(self, rc): self.returncode = rc
+
+    def fake_run(argv, **kw):
+        calls.append(argv)
+        if argv[:2] == ["pgrep", "-x"]:
+            return Result(0 if started["yes"] else 1)
+        if argv[0] == "open":
+            started["yes"] = True          # the shell launch is what works
+            return Result(0)
+        return Result(0)
+
+    monkeypatch.setattr(apple.subprocess, "run", fake_run)
+    monkeypatch.setattr(apple.sys, "platform", "darwin")
+    return calls
+
+
+def test_a_closed_app_is_started_before_we_talk_to_it(spy):
+    apple.ensure_running("Calendar")
+    assert ["open", "-gj", "-a", "Calendar"] in spy, (
+        "a closed app must be started by the shell — AppleScript answers -600"
+    )
+
+
+def test_it_starts_hidden_and_without_stealing_focus(spy):
+    """-g keeps it behind the user's windows, -j starts it hidden. Reading a
+    calendar mid-sentence must not pull the user out of what they were doing."""
+    apple.ensure_running("Calendar")
+    launch = next(c for c in spy if c[0] == "open")
+    assert "-g" in launch[1] and "j" in launch[1], launch
+
+
+def test_an_already_running_app_is_left_alone(monkeypatch):
+    """No relaunch, and no 12-second wait, on the common path."""
+    calls: list[list[str]] = []
+
+    class Result:
+        returncode = 0
+
+    def fake_run(argv, **kw):
+        calls.append(argv)
+        return Result()
+
+    monkeypatch.setattr(apple.subprocess, "run", fake_run)
+    monkeypatch.setattr(apple.sys, "platform", "darwin")
+    apple.ensure_running("Calendar")
+    assert not [c for c in calls if c[0] == "open"], "should not relaunch a live app"
+
+
+def test_no_module_still_asks_applescript_to_launch():
+    """The idiom that does not work must not come back."""
+    for path in TOOLS.glob("*.py"):
+        # Only real string literals count — the explanation of why this idiom
+        # fails necessarily contains the idiom.
+        for node in ast.walk(ast.parse(path.read_text())):
+            if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+                continue
+            if node.value.strip().startswith(("AppleScript cannot", "Start `app`")):
+                continue  # the docstrings that explain this very rule
+            for bad in ('launch application "', ' to launch'):
+                if bad in node.value:
+                    pytest.fail(f"{path.name}:{node.lineno} AppleScript cannot launch an app")
+
+
+def test_every_osa_call_names_the_app_it_needs():
+    """_osa launches whatever `app=` names, so a call that omits it is a call
+    that will fail the moment that app is closed — exactly the Mail, Reminders
+    and Notes bug."""
+    tree = ast.parse((TOOLS / "apple.py").read_text())
+    missing = [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and getattr(node.func, "id", "") == "_osa"
+        and "app" not in {kw.arg for kw in node.keywords}
+    ]
+    assert not missing, f"_osa call(s) at line(s) {missing} do not name their app"

--- a/waku/tools/apple.py
+++ b/waku/tools/apple.py
@@ -47,9 +47,47 @@ _SLOW_APP_TIMEOUT = 25
 _cache: dict[str, tuple[float, str]] = {}
 
 
-def _osa(script: str, timeout: int = _TIMEOUT) -> tuple[bool, str]:
+
+def _is_running(app: str) -> bool:
+    try:
+        return subprocess.run(["pgrep", "-x", app], capture_output=True,
+                              check=False, timeout=5).returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return True  # cannot tell — assume it is up and let _osa report the truth
+
+
+def ensure_running(app: str, timeout: float = 12.0) -> None:
+    """Start `app` before talking to it, because AppleScript cannot.
+
+    Both of the obvious idioms answer -600 "Application isn't running" when the
+    app is not already running — the launch line is itself what raises, which is
+    why the error's character offset points straight at it. We shipped one of
+    them believing it fixed -600; it was the line producing it, so a closed
+    Calendar failed exactly as before. Mail, Reminders and Notes never tried.
+
+    Only a shell-level open can cold-start the app. `-g` keeps it behind the
+    user's windows and `-j` starts it hidden, so reading the calendar does not
+    steal focus mid-sentence.
+    """
+    if sys.platform != "darwin" or _is_running(app):
+        return
+    try:
+        subprocess.run(["open", "-gj", "-a", app], capture_output=True,
+                       check=False, timeout=15)
+    except (OSError, subprocess.SubprocessError):
+        return  # cannot launch it; _osa will say what actually went wrong
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if _is_running(app):
+            return
+        time.sleep(0.25)
+
+
+def _osa(script: str, timeout: int = _TIMEOUT, app: str | None = None) -> tuple[bool, str]:
     if sys.platform != "darwin":
         return False, "Apple tools are macOS-only."
+    if app:
+        ensure_running(app)
     try:
         r = subprocess.run(["osascript", "-e", script], capture_output=True, text=True, timeout=timeout, check=False)
     except subprocess.TimeoutExpired:
@@ -69,9 +107,13 @@ def probe_apple_tools() -> None:
     """Verify Automation access to every app without reading or writing user data."""
     failures = []
     for app in _PROBE_APPS:
+        # Without the launch a closed app answers -600 and the probe reports it
+        # as an Automation-permission failure — a different problem with a
+        # different fix, and a trip to System Settings for nothing.
         ok, detail = _osa(
             f'tell application "{app}" to return version',
             timeout=_PROBE_TIMEOUT,
+            app=app,
         )
         if not ok:
             failures.append(f"{app}: {detail}")
@@ -145,16 +187,12 @@ def read_apple_calendar(days_ahead: int = 7) -> str:
     end tell
   end try''' for c in cals)
 
-        # `launch` starts Calendar without stealing focus; without it a quit
-        # Calendar.app answers -600 "Application isn't running" instead of
-        # auto-starting, which read as a permissions problem for an hour.
         script = f'''
 set out to ""
-launch application "Calendar"
 tell application "Calendar"{blocks}
 end tell
 return out'''
-        ok, res = _osa(script, timeout=20 + 12 * len(cals))
+        ok, res = _osa(script, timeout=20 + 12 * len(cals), app="Calendar")
         if not ok:
             return f"Calendar unavailable: {res}"
 
@@ -191,7 +229,7 @@ tell application "Mail"
   end repeat
 end tell
 return out'''
-        ok, res = _osa(script, timeout=20)
+        ok, res = _osa(script, timeout=20, app="Mail")
         if ok:
             return res
         return (
@@ -208,14 +246,14 @@ def create_reminder(title: str, due: str = "") -> str:
     if due:
         props += f', due date:(date "{due}")'
     ok, res = _osa(f'tell application "Reminders" to make new reminder with properties {{{props}}}',
-                   timeout=_SLOW_APP_TIMEOUT)
+                   timeout=_SLOW_APP_TIMEOUT, app="Reminders")
     return f"Reminder created: {title}" if ok else f"Reminder failed: {res}"
 
 
 def create_note(title: str, body: str = "") -> str:
     safe = (title + "\n" + body).replace('"', "'")
     ok, res = _osa(f'tell application "Notes" to make new note at folder "Notes" with properties {{body:"{safe}"}}',
-                   timeout=_SLOW_APP_TIMEOUT)
+                   timeout=_SLOW_APP_TIMEOUT, app="Notes")
     return f"Note created: {title}" if ok else f"Note failed: {res}"
 
 

--- a/waku/tools/calendar.py
+++ b/waku/tools/calendar.py
@@ -23,6 +23,7 @@ from datetime import datetime
 from email.utils import parseaddr
 from pathlib import Path
 
+from waku.tools.apple import ensure_running
 from waku.tools.registry import Tool
 
 APPLE_CALENDAR_NAME = "Waku"
@@ -76,8 +77,8 @@ def probe_apple_calendar() -> None:
     """
     if sys.platform != "darwin":
         raise RuntimeError("Apple Calendar probe is macOS-only.")
+    ensure_running("Calendar")
     script = '''
-launch application "Calendar"
 tell application "Calendar"
   repeat with cal in calendars
     try
@@ -130,6 +131,7 @@ def sync_to_apple_calendar(title: str, start: str, end: str, notes: str = "") ->
     # Prefer a dedicated "Waku" calendar, but macOS can't create calendars in
     # iCloud-only accounts via AppleScript — fall back to the first writable
     # calendar and report which one was actually used.
+    ensure_running("Calendar")
     script = (
         _applescript_date("startDate", start)
         + _applescript_date("endDate", end)


### PR DESCRIPTION
Found from a live failure: both calendar tools failed in one turn.

## The Apple half

`read_apple_calendar` returned `Calendar got an error: Application isn't running. (-600)`.

The error carried its own diagnosis. **`15:44` is a character offset into the
script**, and characters 15–44 are:

```
\nlaunch application "Calendar"
```

That line was in the code *specifically* to prevent -600. **It was the line
raising it.** Reproduced on a real Mac with Calendar closed:

```
$ osascript -e 'set out to ""' -e 'launch application "Calendar"'
14:43: execution error: Calendar got an error: Application isn't running. (-600)

$ osascript -e 'tell application "Calendar" to launch'
31:37: execution error: ... (-600)          # the other idiom, same result

$ open -gj -a Calendar && osascript -e 'tell application "Calendar" to return name of every calendar'
Jarvis, Waku, Eventbrite, Work, ...        # works
```

**AppleScript cannot start an app that is not running.** Only a shell `open` can.

## It was wider than Calendar

| Entry point | Before |
|---|---|
| `read_apple_calendar` | tried to launch, with the line that fails |
| `read_apple_mail` | never tried |
| `create_reminder` | never tried |
| `create_note` | never tried |
| `probe_apple_tools` | never tried — **reported a closed app as an Automation-permission failure** |
| `calendar.py` probe + sync | the same dead line, and one path with no launch at all |

That probe row is the expensive one: it sends you to System Settings for a
permission that was never the problem.

## The fix

`_osa` now takes the app it is addressing and starts it first, so no call site
can forget. `-g` keeps it behind the user's windows, `-j` starts it hidden — a
calendar read must not steal focus mid-sentence. `ensure_running` swallows every
subprocess failure and returns, so it can never become the thing that raises;
`_osa` stays the one place that explains what went wrong.

## A test was holding the bug in place

```python
assert "launch application \"Calendar\"" in script
```

That asserted the broken line was **present**, which is why reinstating the bug
kept CI green. Inverted.

## Verified

| Check | Result |
|---|---|
| `pytest -q evals/deterministic` | **651 passed**, 60 skipped |
| `ruff check` | All checks passed |
| **Live, Calendar quit first** | waku cold-started it; `read_apple_calendar` returned normally instead of -600 |
| **Live probe, Calendar quit first** | `probe: OK` (previously a permissions error) |
| Mutation — reinstate `launch application` | **red** |
| Mutation — drop `app=` from one `_osa` call | **red** |

New `test_applescript_cold_start.py` is fully offline: it launches no app and
runs no osascript, it only checks that waku still asks.

## Not fixed here

The same turn also failed on Google Calendar, for an unrelated and honest
reason: the `[gcal]` extra is genuinely not installed (`googleapiclient` MISSING).
The error message said exactly that and was correct. Left alone — installing it
needs OAuth setup, which is Sean's call.