### PR TITLE
fix: write dashboard SOUL.md as UTF-8

### DIFF
--- a/evals/deterministic/test_skill_encoding.py
+++ b/evals/deterministic/test_skill_encoding.py
@@ -97,3 +97,14 @@ def test_dashboard_edited_skill_is_written_as_utf8(
 
     assert result == {"ok": True}
     assert_utf8_skill(path, "dashboard-report")
+
+
+def test_dashboard_soul_is_written_as_utf8(tmp_path, monkeypatch, require_explicit_text_encoding):
+    home = tmp_path / "home"
+    monkeypatch.setenv("WAKU_HOME", str(home))
+    soul = "用户偏好中文回复 🚀"
+
+    result = memory_action({"action": "save_soul", "content": soul})
+
+    assert result == {"ok": True}
+    assert (home / "SOUL.md").read_bytes().decode("utf-8").replace("\r\n", "\n") == soul + "\n"

--- a/waku/ops/dashboard.py
+++ b/waku/ops/dashboard.py
@@ -809,7 +809,7 @@ def memory_action(payload: dict) -> dict:
         text = (payload.get("content") or "").strip()
         if not text:
             return {"error": "SOUL cannot be empty"}
-        (settings.home / "SOUL.md").write_text(text + "\n")
+        (settings.home / "SOUL.md").write_text(text + "\n", encoding="utf-8")
         return {"ok": True}
     if action == "save_skill":
         # Edit any loaded SKILL.md by hand (same file the agent's create_skill


### PR DESCRIPTION
Closes #173

Follow-up to [Issue #23](https://github.com/ShenSeanChen/waku-agent/issues/23), [PR #25](https://github.com/ShenSeanChen/waku-agent/pull/25), and [PR #28](https://github.com/ShenSeanChen/waku-agent/pull/28).

### Summary

The dashboard `save_soul` action now writes `SOUL.md` with `encoding="utf-8"`.

This brings the path in line with the existing `save_skill` implementation and with the UTF-8 reads used by the session runtime.

### Test coverage

The regression test saves Chinese text and an emoji, then reads the file bytes as UTF-8. It also rejects implicit text encodings, so the test does not depend on the host operating system.

```text
uv run --frozen python -m pytest -q evals/deterministic/test_skill_encoding.py
5 passed

uv run --frozen python -m ruff check waku evals scripts
All checks passed
```

The full deterministic suite was also run locally on Windows. It reported `631 passed, 3 failed, 63 skipped`; all three failures are in the existing coding evals in `evals/deterministic/test_coding_eval.py`. This PR does not modify those tests or their implementation. `make` is not installed in the local Windows environment, so the Makefile targets could not be invoked directly.

### Scope

The change is limited to one dashboard write path and its regression test. It adds no dependency and does not change network or secret handling.