### PR TITLE
Mark deprecated OpenAI models as unavailable in the picker

### DIFF
--- a/evals/deterministic/test_providers.py
+++ b/evals/deterministic/test_providers.py
@@ -97,6 +97,40 @@ def test_bad_key_gives_a_fixable_error_not_a_codec_crash(monkeypatch):
     assert "claude-opus-4-8" in [m["id"] for m in result["models"]]
 
 
+def test_deprecated_models_are_marked(monkeypatch):
+    """Models in the deny-list appear in the catalog with deprecated=True so
+    the picker can show them greyed-out instead of silently hiding them."""
+    import io
+    import json
+    import urllib.request
+
+    from waku.ops import catalog
+
+    def fake_urlopen(req, timeout=10):
+        body = io.BytesIO(json.dumps({"data": [
+            {"id": "gpt-5.5"},
+            {"id": "gpt-5.3-chat-latest"},
+            {"id": "gpt-4.1-mini"},
+        ]}).encode())
+        body.__enter__ = lambda *a: body
+        body.__exit__ = lambda *a: None
+        return body
+
+    monkeypatch.setenv("WAKU_PROVIDER", "openai")
+    monkeypatch.setenv("OPENAI_API_KEY", "fake-key")
+    monkeypatch.delenv("WAKU_BASE_URL", raising=False)
+    monkeypatch.delenv("WAKU_MODEL", raising=False)
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    catalog._models_cache.clear()
+
+    result = catalog.list_models()
+    by_id = {m["id"]: m for m in result["models"]}
+    assert by_id["gpt-5.3-chat-latest"]["deprecated"] is True
+    assert by_id["gpt-5.5"]["deprecated"] is False
+    assert by_id["gpt-4.1-mini"]["deprecated"] is False
+    catalog._models_cache.clear()
+
+
 def test_catalog_url_is_used_with_both_auth_styles(monkeypatch):
     """kimi chats on the anthropic wire but LISTS models on its OpenAI-compat
     endpoint — catalog_url must win, carrying both auth header styles, so the

--- a/waku/ops/catalog.py
+++ b/waku/ops/catalog.py
@@ -32,6 +32,15 @@ from waku.ops.pricing import remember_price
 
 _models_cache: dict[str, tuple[float, list]] = {}
 
+# Models that OpenAI still returns from GET /v1/models but 404 on actual use.
+# The whole -chat-latest line was deprecated; see issue #132 for the timeline.
+_DEPRECATED_IDS: frozenset[str] = frozenset({
+    "gpt-5.3-chat-latest",
+    "gpt-5.2-chat-latest",
+    "gpt-5.1-chat-latest",
+    "gpt-5-chat-latest",
+})
+
 
 def _known_default_ids(prov, out: dict, is_active: bool) -> list[dict]:
     """Best-effort model list when the live catalog is unreachable: the provider's
@@ -151,6 +160,7 @@ def list_models(provider: str | None = None, *, use_cache: bool = True) -> dict:
             # gate's tiny budget: the UI steers them away from the gate slot
             "reasoning": ("reasoning" in params) if params is not None else None,
             "context": m.get("context_length"),
+            "deprecated": mid in _DEPRECATED_IDS,
         }
         try:
             # OpenRouter prices are $/token strings; keep $/M for display + cost

--- a/waku/ops/static/js/models.js
+++ b/waku/ops/static/js/models.js
@@ -55,6 +55,11 @@ function modelRow(m, st){
   const price = m.free ? "free" : (m.price_out != null ? `$${m.price_in}/$${m.price_out} per M` : "");
   const tags = [price, m.context ? Math.round(m.context/1000) + "k ctx" : ""]
                .filter(Boolean).join(" · ");
+  if (m.deprecated) return `<div class="tool" style="display:flex;align-items:center;gap:8px;padding:6px 8px;opacity:0.45">
+    <code style="flex:1;word-break:break-all;text-decoration:line-through">${esc(m.id)}</code>
+    <span class="meta" style="margin:0;white-space:nowrap">${esc(tags)}</span>
+    <span class="srcpill" style="background:var(--bad-soft,#fee);color:var(--bad,#c00)" title="this model returns 404 — OpenAI deprecated it but still lists it in GET /v1/models">unavailable</span>
+  </div>`;
   return `<div class="tool" style="display:flex;align-items:center;gap:8px;padding:6px 8px">
     <a class="pinstar ${isPinned?"on":""}" title="${isPinned?"pinned to Your models — click to remove":"pin to Your models (shows in chat switcher)"}"
        onclick="pinModel('${esc(st.provider)}','${esc(m.id)}','${isPinned?"unpin":"pin"}')">${isPinned?"★":"☆"}</a>
@@ -74,11 +79,11 @@ function modelRow(m, st){
 // free first, then biggest context. Gate: cheap non-reasoning instruct-style.
 const GATE_HINT = /instruct|gemma|haiku|flash|mini|nano|lite|small/;
 function loopPicks(ms){
-  return ms.filter(m => m.tools)
+  return ms.filter(m => m.tools && !m.deprecated)
            .sort((a,b) => (b.free - a.free) || ((b.context||0) - (a.context||0))).slice(0, 4);
 }
 function gatePicks(ms){
-  return ms.filter(m => m.tools !== false && m.reasoning !== true
+  return ms.filter(m => m.tools !== false && m.reasoning !== true && !m.deprecated
                         && (m.free || (m.price_out != null && m.price_out <= 1.5)))
            .sort((a,b) => (GATE_HINT.test(b.id) - GATE_HINT.test(a.id))
                         || (b.free - a.free) || ((a.price_out||99) - (b.price_out||99))).slice(0, 4);
@@ -197,7 +202,7 @@ async function loadAddModels(provider){
   try { data = await (await fetch("/api/models?provider=" + encodeURIComponent(provider))).json(); }
   catch(e){ sel.innerHTML = `<option value="">couldn't load — pick another provider</option>`; return; }
   const ms = data.models || [];
-  sel.innerHTML = `<option value="">choose a model…</option>` + ms.map(m => {
+  sel.innerHTML = `<option value="">choose a model…</option>` + ms.filter(m => !m.deprecated).map(m => {
     const meta = [m.free ? "free" : (m.price_out != null ? `$${m.price_in}/$${m.price_out}` : ""),
                   m.context ? Math.round(m.context/1000) + "k" : ""].filter(Boolean).join(" · ");
     return `<option value="${esc(m.id)}">${esc(m.id)}${meta ? "  ("+esc(meta)+")" : ""}</option>`;
@@ -442,7 +447,9 @@ function renderModelPickerItems(id, query){
   const metaBox = document.getElementById(id + "-meta");
   if (!itemsBox) return;
   const filtered = _modalModels.filter(m => (m.id || "").toLowerCase().includes(query));
-  itemsBox.innerHTML = filtered.map((m, index) => `<div class="model-picker-item${index === 0 ? " active" : ""}" role="option" data-model="${escAttr(m.id)}">${esc(m.id)}</div>`).join("");
+  itemsBox.innerHTML = filtered.map((m, index) => m.deprecated
+    ? `<div class="model-picker-item" role="option" style="opacity:0.45;text-decoration:line-through;pointer-events:none" data-model="${escAttr(m.id)}">${esc(m.id)} (unavailable)</div>`
+    : `<div class="model-picker-item${index === 0 ? " active" : ""}" role="option" data-model="${escAttr(m.id)}">${esc(m.id)}</div>`).join("");
   if (metaBox){
     if (_modalModels.length === 0) metaBox.textContent = "No models loaded — you can still type any model id.";
     else if (filtered.length === 0) metaBox.textContent = `No models match "${query}".`;


### PR DESCRIPTION
## Summary

- Adds a deny-list of known-deprecated OpenAI model ids (`gpt-5.3-chat-latest`, `gpt-5.2-chat-latest`, `gpt-5.1-chat-latest`, `gpt-5-chat-latest`) in `catalog.py`
- Each catalog entry now carries a `deprecated` flag so the frontend can distinguish them
- The model picker shows deprecated models greyed-out with a strikethrough and an "unavailable" pill, instead of hiding them — so a user who had one pinned understands why it broke
- Deprecated models are excluded from suggested picks (loop/gate) and the add-model dropdown
- In the modal picker, deprecated models are non-selectable (greyed + pointer-events:none)

This follows the issue author's preferred option 3 ("mark rather than hide") combined with option 1 (deny-list).

## Test plan

- [x] New test `test_deprecated_models_are_marked` verifies the backend flag
- [x] All 45 existing provider tests pass
- [ ] Manual: set `WAKU_PROVIDER=openai`, open the dashboard model picker, confirm `gpt-5.3-chat-latest` etc. appear greyed with "unavailable"
- [ ] Manual: confirm deprecated models don't appear in suggested picks or the add-model dropdown

Closes #137